### PR TITLE
feat: add plugin management via CLI, API, and web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,29 @@ def get_context() -> Optional[str]:
     return "your custom context here"
 ```
 
-Place your plugin in the `src/plugins/` directory and update the plugin manager to include it. Your plugin can:
+Place your plugin in the `src/plugins/` directory and expose a `get_plugin` function. It will be discovered automatically. Your plugin can:
 - Read from local data files
 - Connect to APIs (with proper authentication)
 - Use system information
 - Implement caching for performance
 - Maintain state between generations
+
+### Managing Plugins
+
+You can list, enable, or disable plugins from the CLI:
+
+```bash
+uv run imagegen plugins list
+uv run imagegen plugins disable time_of_day
+uv run imagegen plugins enable time_of_day
+```
+
+The API also exposes plugin management:
+
+- `GET /api/plugins` – list all plugins and their status
+- `POST /api/plugins/{name}` with `{ "enabled": true|false }` – update plugin state
+
+And the web UI includes a sidebar where you can toggle plugins on or off.
 
 ## 🎮 Command Reference
 

--- a/src/generators/prompt_generator.py
+++ b/src/generators/prompt_generator.py
@@ -3,16 +3,18 @@ Prompt generator using Ollama for local inference.
 Incorporates temporal context (time of day, day of week, and holidays)
 for more contextually aware prompts.
 """
-import json
-import os
-import logging
-from typing import Optional
-import time
 
-from ..utils.error_handler import handle_errors, PromptError
+import json
+import logging
+import os
+import time
+from typing import Optional
+
+from ..plugins import get_context_with_descriptions, get_temporal_descriptor
 from ..utils.config import Config
+from ..utils.error_handler import PromptError, handle_errors
 from ..utils.metrics import GenerationMetrics
-from ..plugins import get_temporal_descriptor, get_context_with_descriptions
+
 
 class PromptGenerator:
     def __init__(self, config: Config):
@@ -30,32 +32,32 @@ class PromptGenerator:
         ]
         self.conversation_history = []
         self.logger = logging.getLogger(__name__)
-        
+
     @handle_errors(error_type=PromptError, retries=2)
     async def generate_prompt(self) -> str:
         """Generate a 60 word image prompt using Ollama with conversation context."""
         try:
             import ollama
-            
+
             metrics = GenerationMetrics(model_name=self.model_name)
             start_time = time.time()
-            
+
             # Get context with plugin descriptions
-            context_data = get_context_with_descriptions()
-            temporal_context = get_temporal_descriptor()
-            
+            context_data = get_context_with_descriptions(self.config)
+            temporal_context = get_temporal_descriptor(self.config)
+
             # Log plugin contributions
             self.logger.info("Plugin contributions:")
             for result in context_data["results"]:
                 self.logger.info(f"  {result.name}: {result.value} - {result.description}")
-            
+
             # Extract Lora keyword if present
             lora_keyword = None
             for result in context_data["results"]:
                 if result.name == "lora" and result.value:
                     lora_keyword = result.value
                     break
-            
+
             # Build system context with plugin information
             system_context_parts = [
                 "You are a creative prompt generator for image generation.",
@@ -68,91 +70,88 @@ class PromptGenerator:
                 f"\nCurrent temporal context: {temporal_context}",
                 "Begin the prompt with this temporal context, then add a concise but vivid scene description.",
                 "Keep the final combined prompt (including context) within the 77 token limit.",
-                "You may choose which context elements to incorporate based on relevance."
+                "You may choose which context elements to incorporate based on relevance.",
             ]
-            
+
             # Only add Lora-specific instructions if a Lora keyword is available
             if lora_keyword:
-                system_context_parts.extend([
-                    "\nIMPORTANT: You MUST make the Lora keyword a central subject or character in the scene.",
-                    "The Lora keyword should be in single quotes and be an active participant in the scene.",
-                    "Example format: '[temporal/style context]: [scene with Lora as subject]'",
-                    "For example: 'scene with '<keyword>' as the main character doing something'"
-                ])
-            
+                system_context_parts.extend(
+                    [
+                        "\nIMPORTANT: You MUST make the Lora keyword a central subject or character in the scene.",
+                        "The Lora keyword should be in single quotes and be an active participant in the scene.",
+                        "Example format: '[temporal/style context]: [scene with Lora as subject]'",
+                        "For example: 'scene with '<keyword>' as the main character doing something'",
+                    ]
+                )
+
             system_context = "\n".join(system_context_parts)
-            
+
             if lora_keyword:
                 system_context += f"\nCurrent Lora keyword that MUST be used as a subject in single quotes: '{lora_keyword}'"
                 system_context += "\nMake sure the Lora keyword is a central character or subject in the scene, not just mentioned."
-            
+
             self.logger.info(f"Generated temporal context: {temporal_context}")
-            
+
             # Initialize conversation if empty
             if not self.conversation_history:
                 # Select appropriate example prompts based on whether a Lora keyword is available
                 example_prompts = self.regular_example_prompts.copy()
                 if lora_keyword:
                     example_prompts.extend(self.lora_example_prompts)
-                
+
                 # Create user message with examples
                 user_message_parts = [
                     "Here are some example prompts:",
                     *[f"Example {i+1}: {prompt}" for i, prompt in enumerate(example_prompts)],
-                    "\nGenerate a new prompt that is different from these examples but equally creative."
+                    "\nGenerate a new prompt that is different from these examples but equally creative.",
                 ]
-                
+
                 # Add Lora-specific instruction if a Lora keyword is available
                 if lora_keyword:
-                    user_message_parts.append("Make the Lora keyword the central subject or character in the scene.")
-                
-                self.conversation_history = [{
-                    "role": "system",
-                    "content": system_context
-                }, {
-                    "role": "user",
-                    "content": "\n".join(user_message_parts)
-                }]
-            
+                    user_message_parts.append(
+                        "Make the Lora keyword the central subject or character in the scene."
+                    )
+
+                self.conversation_history = [
+                    {"role": "system", "content": system_context},
+                    {"role": "user", "content": "\n".join(user_message_parts)},
+                ]
+
             # Generate prompt with logging
             self.logger.info("Generating prompt with Ollama...")
             response = ollama.chat(
                 model=self.model_name,
                 messages=self.conversation_history,
-                options={"temperature": self.config.model.ollama_temperature}
+                options={"temperature": self.config.model.ollama_temperature},
             )
-            
+
             # Process and log the generated prompt
             new_prompt = response.message.content.strip()
             self.logger.info(f"Raw generated prompt: {new_prompt}")
-            
+
             # Add new prompt to conversation history
-            self.conversation_history.append({
-                "role": "assistant",
-                "content": new_prompt
-            })
+            self.conversation_history.append({"role": "assistant", "content": new_prompt})
             # Create next user message
             next_message = "Generate another unique prompt, different from previous ones."
             if lora_keyword:
-                next_message += " Remember to make the Lora keyword the central subject in the scene."
-            
-            self.conversation_history.append({
-                "role": "user",
-                "content": next_message
-            })
-            
+                next_message += (
+                    " Remember to make the Lora keyword the central subject in the scene."
+                )
+
+            self.conversation_history.append({"role": "user", "content": next_message})
+
             # Update metrics
             metrics.generation_time = time.time() - start_time
             metrics.prompt = new_prompt
             metrics.prompt_tokens = len(new_prompt.split())
-            
+
             return new_prompt
-            
+
         except ImportError:
             raise PromptError("Please install ollama-python: pip install ollama")
         except Exception as e:
             raise PromptError(f"Error generating prompt: {str(e)}")
-    
+
     @handle_errors(error_type=PromptError, retries=1)
     async def get_prompt_with_feedback(self) -> str:
         """Interactive prompt generation with user feedback."""
@@ -162,9 +161,11 @@ class PromptGenerator:
             print("-" * 80)
             print(prompt)
             print("-" * 80)
-            
-            choice = input("\nOptions:\n1. Use this prompt\n2. Generate new prompt\n3. Edit this prompt\nChoice (1-3): ")
-            
+
+            choice = input(
+                "\nOptions:\n1. Use this prompt\n2. Generate new prompt\n3. Edit this prompt\nChoice (1-3): "
+            )
+
             if choice == "1":
                 return prompt
             elif choice == "2":
@@ -174,7 +175,7 @@ class PromptGenerator:
                 return edited.strip()
             else:
                 print("Invalid choice, please try again.")
-    
+
     def cleanup(self):
         """Clean up resources."""
         self.conversation_history = []

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,106 +1,71 @@
-"""
-Plugin system for adding contextual information to prompts.
-"""
+"""Plugin system for adding contextual information to prompts."""
+
+import importlib
 import logging
-from typing import List, Dict, Any
+import pkgutil
+from pathlib import Path
+from typing import Any, Dict
 
-from ..utils.plugin_manager import PluginManager, PluginResult
-from .time_of_day import get_time_of_day
-from .nearest_holiday import get_nearest_holiday
-from .holiday_fact import get_holiday_fact
-from .art_style import get_art_style
-from .lora import apply_lora
 from ..utils.config import Config
+from ..utils.plugin_manager import PluginManager
 
-# Initialize plugin manager
+# Global plugin manager instance used across the application
 plugin_manager = PluginManager()
-
-# Initialize plugins dict to store plugin functions
-plugin_functions = {}
-
-def register_base_plugins():
-    """Register the base plugins that don't require additional configuration."""
-    plugin_manager.register(
-        "time_of_day",
-        "Provides temporal context based on the current time of day",
-        get_time_of_day,
-        order=1
-    )
-
-    plugin_manager.register(
-        "nearest_holiday",
-        "Adds context about upcoming or current holidays",
-        get_nearest_holiday,
-        order=2
-    )
-
-    plugin_manager.register(
-        "holiday_fact",
-        "Enriches holiday context with interesting facts",
-        get_holiday_fact,
-        order=3
-    )
-
-    plugin_manager.register(
-        "art_style",
-        "Suggests an artistic style for the image",
-        get_art_style,
-        order=4
-    )
-
-def register_lora_plugin(config: Config):
-    """Register the Lora plugin with the given config."""
-    def lora_plugin():
-        return apply_lora(config)
-    
-    # Store the plugin function
-    plugin_functions['lora'] = lora_plugin
-    
-    # Register or re-register the plugin
-    plugin_manager.register(
-        "lora",
-        "Randomly selects and applies a Lora model",
-        lora_plugin,
-        order=5
-    )
-
-# Register base plugins immediately
-register_base_plugins()
-
 logger = logging.getLogger(__name__)
+_initialized = False
 
-def get_context_with_descriptions() -> Dict[str, Any]:
-    """
-    Execute plugins and return their results with descriptions.
-    
-    Returns:
-        Dict containing plugin results and their descriptions
-    """
+
+def initialize_plugins(config: Config) -> None:
+    """Discover and register plugins dynamically based on configuration."""
+    global _initialized
+    plugin_manager.plugins.clear()
+
+    package_dir = Path(__file__).resolve().parent
+    for module_info in pkgutil.iter_modules([str(package_dir)]):
+        if module_info.name.startswith("_"):
+            continue
+
+        module = importlib.import_module(f"{__name__}.{module_info.name}")
+
+        if hasattr(module, "get_plugin"):
+            name, description, func = module.get_plugin(config)
+            enabled = name in config.plugins.enabled_plugins
+            order = config.plugins.plugin_order.get(name, 999)
+            plugin_manager.register(name, description, func, enabled=enabled, order=order)
+            logger.debug(f"Discovered plugin: {name}")
+
+    _initialized = True
+
+
+def ensure_initialized(config: Config) -> None:
+    """Initialize plugins on first use."""
+    if not _initialized or not plugin_manager.plugins:
+        initialize_plugins(config)
+
+
+def get_context_with_descriptions(config: Config) -> Dict[str, Any]:
+    """Execute plugins and return their results with descriptions."""
+    ensure_initialized(config)
     results = plugin_manager.execute_plugins()
-    
-    # Log the contributions of each plugin
+
     for result in results:
         logger.info(f"Plugin contribution - {result.name}: {result.value} ({result.description})")
-    
+
     return {
         "results": results,
-        "descriptions": plugin_manager.get_plugin_descriptions()
+        "descriptions": plugin_manager.get_plugin_descriptions(),
     }
 
-def get_temporal_descriptor() -> str:
-    """
-    Creates a human-readable string combining all plugin contributions.
-    
-    Returns:
-        str: A descriptive string combining all enabled plugin outputs
-    """
+
+def get_temporal_descriptor(config: Config) -> str:
+    """Create a human-readable string combining plugin contributions."""
+    ensure_initialized(config)
     results = plugin_manager.execute_plugins()
-    
-    # Build the descriptor string
+
     parts = []
     holiday_fact = None
     art_style = None
-    
+
     for result in results:
         if result.name == "holiday_fact":
             holiday_fact = result.value
@@ -109,17 +74,14 @@ def get_temporal_descriptor() -> str:
         else:
             if result.value:
                 parts.append(str(result.value))
-    
-    # Join the main parts
+
     descriptor = ", ".join(filter(None, parts))
-    
-    # Add holiday fact if available
+
     if holiday_fact:
         descriptor = f"{descriptor} ({holiday_fact})"
-    
-    # Add art style if available
+
     if art_style:
         descriptor = f"{descriptor}, {art_style}"
-    
+
     logger.info(f"Generated temporal descriptor: {descriptor}")
     return descriptor

--- a/src/plugins/art_style.py
+++ b/src/plugins/art_style.py
@@ -6,13 +6,17 @@ from typing import NamedTuple, Optional
 
 logger = logging.getLogger(__name__)
 
+
 class ArtStyle(NamedTuple):
     """Container for art style information."""
+
     name: str
     description: str
 
+
 class ArtStylePlugin:
     """Plugin for managing and selecting art styles."""
+
     _instance = None
     _styles: list[ArtStyle] = []
     _last_style: Optional[ArtStyle] = None
@@ -28,7 +32,7 @@ class ArtStylePlugin:
         """Load art styles from JSON file."""
         try:
             styles_path = Path(__file__).parent.parent.parent / "data" / "art_styles.json"
-            with open(styles_path, 'r') as f:
+            with open(styles_path, "r") as f:
                 data = json.load(f)
                 self._styles = [
                     ArtStyle(name=style["name"], description=style["description"])
@@ -41,10 +45,10 @@ class ArtStylePlugin:
     def get_random_style(self, avoid_last: bool = True) -> Optional[ArtStyle]:
         """
         Get a random art style, optionally avoiding the last used style.
-        
+
         Args:
             avoid_last: If True, won't return the same style twice in a row
-            
+
         Returns:
             Optional[ArtStyle]: A randomly selected art style, or None if no styles are available
         """
@@ -70,17 +74,26 @@ class ArtStylePlugin:
         self._last_style = chosen_style
         return chosen_style
 
+
 def get_art_style() -> str:
     """
     Get a random art style as a formatted string.
-    
+
     Returns:
         str: A string combining the style name and description,
              or an empty string if no styles are available
     """
     plugin = ArtStylePlugin()
     style = plugin.get_random_style()
-    
+
     if style:
         return f"in the style of {style.name} ({style.description})"
     return ""
+
+
+def get_plugin(config=None):
+    return (
+        "art_style",
+        "Suggests an artistic style for the image",
+        get_art_style,
+    )

--- a/src/plugins/holiday_fact.py
+++ b/src/plugins/holiday_fact.py
@@ -3,14 +3,17 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, TypedDict
 
+
 class Holiday(TypedDict):
     month: int
     day: int
     name: str
     type: str
 
+
 class HolidayFact:
     """Plugin for getting information about today's holidays and observances."""
+
     _instance = None
     _holidays: List[Holiday] = []
 
@@ -25,7 +28,7 @@ class HolidayFact:
         """Load holidays from JSON file."""
         try:
             holidays_path = Path(__file__).parent.parent.parent / "data" / "holidays.json"
-            with open(holidays_path, 'r') as f:
+            with open(holidays_path, "r") as f:
                 self._holidays = json.load(f)
         except (FileNotFoundError, json.JSONDecodeError) as e:
             print(f"Error loading holidays: {str(e)}")
@@ -38,24 +41,26 @@ class HolidayFact:
 
         current_date = datetime.now()
         return [
-            holiday for holiday in self._holidays
+            holiday
+            for holiday in self._holidays
             if holiday["month"] == current_date.month and holiday["day"] == current_date.day
         ]
+
 
 def get_holiday_fact() -> Optional[str]:
     """
     Get an interesting fact about today's holidays or observances.
-    
+
     Returns:
         Optional[str]: A string mentioning today's special observances,
                       or None if there are no holidays today
     """
     plugin = HolidayFact()
     todays_holidays = plugin.get_todays_holidays()
-    
+
     if not todays_holidays:
         return None
-        
+
     if len(todays_holidays) == 1:
         holiday = todays_holidays[0]
         if holiday["type"] == "fun":
@@ -73,3 +78,11 @@ def get_holiday_fact() -> Optional[str]:
         else:
             names = ", ".join(holiday_names[:-1]) + f", and {holiday_names[-1]}"
             return f"Today is packed with celebrations: {names}!"
+
+
+def get_plugin(config=None):
+    return (
+        "holiday_fact",
+        "Enriches holiday context with interesting facts",
+        get_holiday_fact,
+    )

--- a/src/plugins/lora.py
+++ b/src/plugins/lora.py
@@ -1,27 +1,31 @@
 """
 Plugin for loading and managing Lora models.
 """
-from pathlib import Path
-from typing import List, Optional, NamedTuple
+
 import logging
 import random
+from pathlib import Path
+from typing import List, NamedTuple, Optional
 
 from ..utils.config import Config
 
 logger = logging.getLogger(__name__)
 
+
 class SelectedLora(NamedTuple):
     """Container for selected Lora information."""
+
     name: str
     path: Path
     keyword: str  # The keyword that must be used in the prompt
+
 
 def get_available_loras(lora_dir: Path) -> List[str]:
     """Get list of available Lora models in the specified directory."""
     if not lora_dir.exists():
         logger.warning(f"Lora directory not found: {lora_dir}")
         return []
-    
+
     # Look for subdirectories that contain .safetensors files
     lora_names = []
     for subdir in lora_dir.iterdir():
@@ -29,34 +33,39 @@ def get_available_loras(lora_dir: Path) -> List[str]:
             if list(subdir.glob("*.safetensors")):
                 lora_names.append(subdir.name)
                 logger.info(f"Found Lora directory: {subdir.name}")
-    
+
     logger.info(f"Found {len(lora_names)} Lora directories in {lora_dir}")
     return lora_names
+
 
 def get_lora_path(lora_name: str, config: Config) -> Optional[Path]:
     """Get the full path to a Lora model file."""
     lora_dir = config.model.lora.lora_dir / lora_name
-    
+
     if not lora_dir.exists():
         logger.warning(f"Lora directory not found: {lora_dir}")
         return None
-    
+
     # Get all .safetensors files in the directory
     lora_files = list(lora_dir.glob("*.safetensors"))
     if not lora_files:
         logger.warning(f"No .safetensors files found in {lora_dir}")
         return None
-    
+
     # Sort by version number and get the latest
-    latest_lora = sorted(lora_files, key=lambda x: int(x.stem.split('-')[-1]) if '-' in x.stem else 0)[-1]
+    latest_lora = sorted(
+        lora_files, key=lambda x: int(x.stem.split("-")[-1]) if "-" in x.stem else 0
+    )[-1]
     logger.info(f"Selected latest Lora version: {latest_lora}")
     return latest_lora
+
 
 def get_lora_keyword(lora_name: str) -> str:
     """Get the keyword that must be used in the prompt for this Lora."""
     # For v4skin, the keyword is "v4skin"
     # You can add more mappings here if needed
     return lora_name
+
 
 def select_random_lora(config: Config) -> Optional[SelectedLora]:
     """
@@ -67,29 +76,30 @@ def select_random_lora(config: Config) -> Optional[SelectedLora]:
     if random.random() > config.model.lora.application_probability:
         logger.info("Skipping Lora application based on probability")
         return None
-    
+
     # Get available and enabled Loras
     available_loras = get_available_loras(config.model.lora.lora_dir)
     logger.info(f"Enabled Loras: {config.model.lora.enabled_loras}")
     logger.info(f"Available Loras: {available_loras}")
-    
+
     enabled_loras = [lora for lora in config.model.lora.enabled_loras if lora in available_loras]
-    
+
     if not enabled_loras:
         logger.warning("No enabled Loras found in the available Loras list")
         return None
-    
+
     # Randomly select one Lora
     selected_name = random.choice(enabled_loras)
     selected_path = get_lora_path(selected_name, config)
-    
+
     if selected_path:
         keyword = get_lora_keyword(selected_name)
         logger.info(f"Selected Lora: {selected_name} at path: {selected_path}")
         logger.info(f"Required keyword for prompt: {keyword}")
         return SelectedLora(name=selected_name, path=selected_path, keyword=keyword)
-    
+
     return None
+
 
 def apply_lora(config: Config) -> Optional[str]:
     """
@@ -101,3 +111,11 @@ def apply_lora(config: Config) -> Optional[str]:
         # Return the keyword that must be used in the prompt
         return selected.keyword
     return None
+
+
+def get_plugin(config: Config):
+    return (
+        "lora",
+        "Randomly selects and applies a Lora model",
+        lambda: apply_lora(config),
+    )

--- a/src/plugins/nearest_holiday.py
+++ b/src/plugins/nearest_holiday.py
@@ -3,23 +3,25 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional, TypedDict
 
+
 class Holiday(TypedDict):
     month: int
     day: int
     name: str
 
+
 def get_nearest_holiday() -> Optional[str]:
     """
     Determines the nearest upcoming holiday that hasn't passed yet.
     If all holidays for the current year have passed, returns the earliest holiday of next year.
-    
+
     Returns:
-        Optional[str]: A string describing the nearest holiday (e.g., "approaching Christmas") 
+        Optional[str]: A string describing the nearest holiday (e.g., "approaching Christmas")
                       or None if no holidays are defined
     """
     try:
         holidays_path = Path(__file__).parent.parent.parent / "data" / "holidays.json"
-        with open(holidays_path, 'r') as f:
+        with open(holidays_path, "r") as f:
             holidays: list[Holiday] = json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
         return None
@@ -30,27 +32,35 @@ def get_nearest_holiday() -> Optional[str]:
     current_date = datetime.now()
     current_month = current_date.month
     current_day = current_date.day
-    
+
     # Convert holidays to (month, day, name) tuples for easier comparison
     holiday_tuples = [(h["month"], h["day"], h["name"]) for h in holidays]
-    
+
     # Sort holidays by month and day
     holiday_tuples.sort()
-    
+
     # Find the next upcoming holiday
     upcoming_holiday = None
-    
+
     # First, check remaining holidays this year
     for month, day, name in holiday_tuples:
         if (month > current_month) or (month == current_month and day >= current_day):
             upcoming_holiday = (month, day, name)
             break
-    
+
     # If no upcoming holidays this year, take the first holiday of next year
     if not upcoming_holiday and holiday_tuples:
         upcoming_holiday = holiday_tuples[0]
-    
+
     if upcoming_holiday:
         return f"approaching {upcoming_holiday[2]}"
-    
+
     return None
+
+
+def get_plugin(config=None):
+    return (
+        "nearest_holiday",
+        "Adds context about upcoming or current holidays",
+        get_nearest_holiday,
+    )

--- a/src/plugins/time_of_day.py
+++ b/src/plugins/time_of_day.py
@@ -3,15 +3,16 @@ from typing import Literal
 
 TimeOfDay = Literal["morning", "afternoon", "evening", "night"]
 
+
 def get_time_of_day() -> TimeOfDay:
     """
     Determines the time of day based on the current hour.
-    
+
     Returns:
         str: One of "morning", "afternoon", "evening", or "night"
     """
     hour = datetime.now().hour
-    
+
     if 5 <= hour < 12:
         return "morning"
     elif 12 <= hour < 17:
@@ -20,3 +21,11 @@ def get_time_of_day() -> TimeOfDay:
         return "evening"
     else:
         return "night"
+
+
+def get_plugin(config=None):
+    return (
+        "time_of_day",
+        "Provides temporal context based on the current time of day",
+        get_time_of_day,
+    )

--- a/tests/test_plugin_api.py
+++ b/tests/test_plugin_api.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+
+from src.api.server import app, config, plugin_manager
+from src.plugins import initialize_plugins
+
+client = TestClient(app)
+
+
+def setup_function(function):
+    initialize_plugins(config)
+
+
+def test_list_plugins_endpoint():
+    response = client.get("/api/plugins")
+    assert response.status_code == 200
+    data = response.json()
+    assert any(p["name"] == "time_of_day" for p in data)
+
+
+def test_set_plugin_state_endpoint():
+    response = client.post("/api/plugins/time_of_day", json={"enabled": False})
+    assert response.status_code == 200
+    assert not plugin_manager.plugins["time_of_day"].enabled
+    response = client.post("/api/plugins/time_of_day", json={"enabled": True})
+    assert plugin_manager.plugins["time_of_day"].enabled

--- a/tests/test_plugin_cli.py
+++ b/tests/test_plugin_cli.py
@@ -1,0 +1,24 @@
+from typer.testing import CliRunner
+
+from src.plugins import initialize_plugins, plugin_manager
+from src.utils.cli import app
+from src.utils.config import Config
+
+runner = CliRunner()
+
+
+def setup_function(function):
+    initialize_plugins(Config())
+
+
+def test_plugin_list_displays_plugins():
+    result = runner.invoke(app, ["plugins", "list"])
+    assert result.exit_code == 0
+    assert "time_of_day" in result.stdout
+
+
+def test_enable_disable_plugin_changes_state():
+    runner.invoke(app, ["plugins", "disable", "time_of_day"])
+    assert not plugin_manager.plugins["time_of_day"].enabled
+    runner.invoke(app, ["plugins", "enable", "time_of_day"])
+    assert plugin_manager.plugins["time_of_day"].enabled

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -89,9 +89,9 @@ export default function Home() {
     }
   };
 
-  const handlePluginToggle = async (pluginName: string) => {
+  const handlePluginToggle = async (plugin: PluginInfo) => {
     try {
-      await api.togglePlugin(pluginName);
+      await api.togglePlugin(plugin.name, !plugin.enabled);
       const updatedPlugins = await api.getPlugins();
       setPlugins(updatedPlugins);
     } catch (error) {
@@ -246,17 +246,24 @@ export default function Home() {
                       </h3>
                       <div className="space-y-1">
                         {plugins.map((plugin) => (
-                          <label 
-                            key={plugin.name} 
-                            className="flex items-center gap-2 text-xs cursor-pointer hover:text-foreground transition-colors"
+                          <label
+                            key={plugin.name}
+                            className="flex items-start gap-2 text-xs cursor-pointer hover:text-foreground transition-colors"
                           >
-                            <input 
-                              type="checkbox" 
+                            <input
+                              type="checkbox"
                               checked={plugin.enabled}
-                              onChange={() => handlePluginToggle(plugin.name)}
-                              className="rounded accent-primary"
+                              onChange={() => handlePluginToggle(plugin)}
+                              className="rounded mt-0.5 accent-primary"
                             />
-                            <span>{plugin.name}</span>
+                            <span className="flex-1">
+                              <span className="block capitalize">{plugin.name.replace(/_/g, ' ')}</span>
+                              {plugin.description && (
+                                <span className="block text-[10px] text-muted-foreground">
+                                  {plugin.description}
+                                </span>
+                              )}
+                            </span>
                           </label>
                         ))}
                       </div>

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -55,9 +55,13 @@ export class ImageGenAPI {
     return response.json();
   }
 
-  async togglePlugin(pluginName: string): Promise<{ plugin: string; enabled: boolean }> {
-    const response = await fetch(`${this.baseUrl}/api/plugins/${pluginName}/toggle`, {
+  async togglePlugin(pluginName: string, enabled: boolean): Promise<PluginInfo> {
+    const response = await fetch(`${this.baseUrl}/api/plugins/${pluginName}`, {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ enabled }),
     });
     if (!response.ok) throw new Error('Failed to toggle plugin');
     return response.json();


### PR DESCRIPTION
## Summary
- add `plugins` CLI group to list, enable, and disable prompt plugins
- expose API endpoints to query and toggle plugin state
- surface plugin management in the web UI sidebar
- document automatic plugin discovery and management commands in README

## Testing
- `npm run lint`
- `uv run pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68a51bc39420832cb7635db20022d454