### PR TITLE
fix: lazy-load optional image backends

### DIFF
--- a/src/generators/factory.py
+++ b/src/generators/factory.py
@@ -7,11 +7,8 @@ from pathlib import Path
 from typing import Tuple
 
 from ..utils.config import Config
-from .image_generator import ImageGenerator
 from .mock_image_generator import MockImageGenerator
 from .stable_diffusion_image_generator import StableDiffusionImageGenerator
-from .turbo_image_generator import TurboImageGenerator
-from .zimage_generator import ZImageGenerator
 
 
 def _hf_cache_root() -> Path:
@@ -97,9 +94,15 @@ def create_image_generator(config: Config) -> Tuple[object, str]:
             backend_label(config, backend),
         )
     if backend == "turbo":
+        from .turbo_image_generator import TurboImageGenerator
+
         return TurboImageGenerator(config), backend_label(config, backend)
     if backend == "zimage":
+        from .zimage_generator import ZImageGenerator
+
         return ZImageGenerator(config), backend_label(config, backend)
     if backend == "flux":
+        from .image_generator import ImageGenerator
+
         return ImageGenerator(config), backend_label(config, backend)
     raise ValueError(f"Unsupported image backend: {backend}")

--- a/tests/test_factory_imports.py
+++ b/tests/test_factory_imports.py
@@ -1,0 +1,71 @@
+"""Regression tests for backend factory import behavior."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def make_config(image_backend: str = "small"):
+    config = MagicMock()
+    config.model.image_backend = image_backend
+    config.model.flux_model = "black-forest-labs/FLUX.1-schnell"
+    config.model.small_sd_model = "segmind/tiny-sd"
+    config.model.smoke_test_model = "hf-internal-testing/tiny-stable-diffusion-torch"
+    config.model.turbo_model = "stabilityai/sd-turbo"
+    config.model.zimage_model_path = Path("/tmp/fake_zimage_model")
+    config.model.zimage_attention = "_sdpa"
+    config.model.zimage_compile = False
+    config.image.height = 1024
+    config.image.width = 1024
+    config.image.num_inference_steps = 4
+    config.image.guidance_scale = 0.0
+    config.system.output_dir = Path("/tmp/test_output")
+    config.system.cpu_only = True
+    return config
+
+
+def test_factory_import_does_not_require_turbo_backend(monkeypatch):
+    """Importing the factory for a non-turbo backend should not import turbo code."""
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.endswith("turbo_image_generator"):
+            raise ImportError("turbo backend intentionally unavailable in this test")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    sys.modules.pop("src.generators.factory", None)
+    sys.modules.pop("src.generators.turbo_image_generator", None)
+
+    factory = importlib.import_module("src.generators.factory")
+    generator, backend_name = factory.create_image_generator(make_config("small"))
+
+    assert generator.backend_name == "small"
+    assert backend_name == "small-sd"
+
+
+def test_factory_only_imports_turbo_when_requested(monkeypatch):
+    """The turbo backend should still surface import errors when explicitly requested."""
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.endswith("turbo_image_generator"):
+            raise ImportError("turbo backend intentionally unavailable in this test")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    sys.modules.pop("src.generators.factory", None)
+    sys.modules.pop("src.generators.turbo_image_generator", None)
+
+    factory = importlib.import_module("src.generators.factory")
+
+    try:
+        factory.create_image_generator(make_config("turbo"))
+    except ImportError as exc:
+        assert "turbo backend intentionally unavailable" in str(exc)
+    else:
+        raise AssertionError("Expected turbo backend import to fail when explicitly requested")


### PR DESCRIPTION
## Summary
- avoid importing optional turbo, zimage, and flux backends during factory module import
- let the API start even when an unused optional backend has an incompatible dependency chain
- add regression tests proving non-turbo startup no longer requires turbo imports

## Verification
- uv run pytest tests/test_factory_imports.py tests/test_zimage_plugin_integration.py -q
- docker build backend image from this branch
- docker run built backend image with env vars and `import src.api.server` succeeded

## Why
Merged main currently crashes on Docker startup before serving the gallery fix because `src.generators.factory` eagerly imports `turbo_image_generator`, which pulls in `diffusers.AutoPipelineForText2Image` and trips a diffusers/transformers incompatibility even when turbo is not the selected backend.
