### PR TITLE
fix: invalidate stale empty gallery cache

### DIFF
--- a/web-ui/components/Gallery.tsx
+++ b/web-ui/components/Gallery.tsx
@@ -98,7 +98,7 @@ export default function Gallery() {
       // Try to get from cache first
       const cachedData = await galleryCache.get<GalleryResponse>(cacheKey);
 
-      if (cachedData) {
+      if (cachedData && cachedData.total > 0) {
         console.log('Loading gallery from cache');
         setImages(cachedData.images);
         setTotal(cachedData.total);
@@ -138,7 +138,7 @@ export default function Gallery() {
         const cacheKey = `gallery_${viewMode}_${page}_${viewMode === "all" ? imagesPerPage : 200}`;
         const cachedData = await galleryCache.get<GalleryResponse>(cacheKey);
 
-        if (cachedData) {
+        if (cachedData && cachedData.total > 0) {
           console.log('API failed, using cached data');
           setImages(cachedData.images);
           setTotal(cachedData.total);

--- a/web-ui/lib/cache.ts
+++ b/web-ui/lib/cache.ts
@@ -9,7 +9,7 @@ interface CachedData<T = unknown> {
 class GalleryCache {
   private dbName = 'GalleryCache';
   private storeName = 'galleryData';
-  private version = 1;
+  private version = 2;
   private ttl = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
   private db: IDBDatabase | null = null;
 
@@ -32,11 +32,12 @@ class GalleryCache {
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result;
 
-        // Create object store if it doesn't exist
-        if (!db.objectStoreNames.contains(this.storeName)) {
-          const store = db.createObjectStore(this.storeName, { keyPath: 'key' });
-          store.createIndex('timestamp', 'timestamp', { unique: false });
+        if (db.objectStoreNames.contains(this.storeName)) {
+          db.deleteObjectStore(this.storeName);
         }
+
+        const store = db.createObjectStore(this.storeName, { keyPath: 'key' });
+        store.createIndex('timestamp', 'timestamp', { unique: false });
       };
     });
   }


### PR DESCRIPTION
## Summary
- stop trusting cached gallery responses when they contain zero images
- prevent API-failure fallback from reusing stale empty gallery cache entries
- bump the gallery IndexedDB schema and recreate the object store so previously cached empty states are flushed on next load

## Verification
- cd web-ui && npm ci
- cd web-ui && npm run build

## Why
A transient empty gallery response was cached in IndexedDB for 24 hours. After the backend/data mount was fixed, the UI could still show ‘No images generated yet’ because it returned early from the stale empty cache without refetching the API.