### PR TITLE
fix: stop homepage gallery polling loop

### DIFF
--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -118,6 +118,7 @@ export default function Home() {
   const promptSeedRef = useRef(promptSeed);
   const cadenceMinutesRef = useRef(cadenceMinutes);
   const isGeneratingRef = useRef(isGenerating);
+  const statusRef = useRef<SystemStatus | null>(status);
   const runGenerationRef = useRef<(source: "manual" | "loop") => Promise<void>>(
     async () => {}
   );
@@ -146,6 +147,7 @@ export default function Home() {
     try {
       const response = await api.getGallery(6, 0);
       const latestImage = response.images[0];
+      const latestStatus = statusRef.current;
       startTransition(() => {
         setRecentImages(response.images);
         if (latestImage) {
@@ -156,8 +158,8 @@ export default function Home() {
               prompt: latestImage.prompt,
               image_path: latestImage.path,
               metadata: {
-                backend: status?.backend ?? "unknown",
-                plugins_used: status?.active_plugins ?? [],
+                backend: latestStatus?.backend ?? "unknown",
+                plugins_used: latestStatus?.active_plugins ?? [],
               },
               created_at: latestImage.created_at,
             } satisfies GenerateResponse)
@@ -167,7 +169,7 @@ export default function Home() {
     } catch (error) {
       console.error("Failed to load recent images:", error);
     }
-  }, [status?.active_plugins, status?.backend]);
+  }, []);
 
   runGenerationRef.current = async (source: "manual" | "loop") => {
     if (isGeneratingRef.current) return;
@@ -211,7 +213,7 @@ export default function Home() {
     setPromptSeed(readString(STORAGE_KEYS.promptSeed, ""));
     setCadenceMinutes(readNumber(STORAGE_KEYS.cadenceMinutes, 60));
     setLoopEnabled(readBoolean(STORAGE_KEYS.sessionLoop, false));
-  }, [loadRecentImages]);
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -229,6 +231,10 @@ export default function Home() {
     if (typeof window === "undefined") return;
     window.localStorage.setItem(STORAGE_KEYS.sessionLoop, String(loopEnabled));
   }, [loopEnabled]);
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
 
   useEffect(() => {
     isGeneratingRef.current = isGenerating;


### PR DESCRIPTION
## Summary
- stop the homepage recent-images callback from depending on status object identity
- keep latest status in a ref so the initial image card can still use backend/plugin metadata
- prevent the mount effect from reconnecting the websocket and refetching the gallery/status on every status update

## Verification
- cd web-ui && npm ci && npm run build

## Why
The homepage was repeatedly calling status and gallery APIs and reconnecting the websocket because  changed whenever  changed identity. That created the repeated console spam and gallery timeouts shown in the browser console screenshot.