### PR TITLE
[codex] Add Z-Image LoRA and Ollama UI support

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -8,6 +8,7 @@
 # Model Configuration
 # auto: use FLUX if cached, otherwise fall back to the small public model
 # flux: force FLUX
+# ollama: use an image-capable Ollama model over the configured Ollama host
 # small: force the small public fallback model
 # turbo: force the fast turbo model
 # smoke: force the internal smoke-test model
@@ -39,11 +40,17 @@ TURBO_MODEL=stabilityai/sd-turbo
 #          black-forest-labs/FLUX.1-dev (Non-commercial only)
 FLUX_MODEL=black-forest-labs/FLUX.1-schnell
 
+# Z-Image configuration
+# Used by the Docker-local checkpoint copy and the new backend/LoRA controls in Settings.
+ZIMAGE_MODEL_PATH=/app/ckpts/Z-Image-Turbo
+
 # Ollama Configuration
 # If running Ollama locally, use host.docker.internal on Windows/Mac
 # or the actual host IP on Linux
 OLLAMA_HOST=http://host.docker.internal:11434
 OLLAMA_MODEL=llama3.2:3b
+# Optional: only used when IMAGE_BACKEND=ollama
+OLLAMA_IMAGE_MODEL=
 
 # ========================================
 # FRONTEND CONFIGURATION
@@ -113,3 +120,16 @@ NUM_INFERENCE_STEPS=4
 # Port Configuration
 BACKEND_PORT=25800
 FRONTEND_PORT=7860
+
+# ========================================
+# OPTIONAL LORA / Z-IMAGE REVIEW DEFAULTS
+# ========================================
+
+# Local LoRAs are mounted from ./loras into /app/loras in the backend container.
+LORA_DIR=/app/loras
+ENABLED_LORAS=
+LORA_APPLICATION_PROBABILITY=0.7
+
+# Plugins can still be changed live in Settings, but these env vars set the boot defaults.
+ENABLED_PLUGINS=time_of_day,art_style
+PLUGIN_ORDER=time_of_day:1,art_style:2

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 # Image backend selection
 # auto: use FLUX if cached, otherwise small public fallback
 # flux: FLUX text-to-image
+# ollama: Ollama image generation via the local Ollama host
 # zimage: local Z-Image-Turbo checkout + weights
 # small: small public Stable Diffusion fallback
 # turbo: SD Turbo backend
@@ -22,6 +23,8 @@ HF_TOKEN=
 
 # Prompt generation
 OLLAMA_MODEL=llama3.2:3b
+# Optional: used only when IMAGE_BACKEND=ollama
+OLLAMA_IMAGE_MODEL=
 OLLAMA_TEMPERATURE=0.7
 MAX_SEQUENCE_LENGTH=512
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,11 @@ thoughts/
 settings.local.json
 .claude/settings.local.json
 
-output
+# Generated images, model checkpoints, and local test artifacts
+output/
+output_quarantine/
+ckpts/
+loras/
 
 # Test artifacts
 test_output.png

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ uv sync
 cp .env.example .env
 # Edit .env for your machine:
 # - OLLAMA_MODEL must point at a local Ollama model
+# - OLLAMA_IMAGE_MODEL is optional and only used for IMAGE_BACKEND=ollama
 # - HF_TOKEN is optional for small/turbo/smoke public models
 # - IMAGE_BACKEND=auto uses FLUX if cached, otherwise the small public fallback
 
@@ -56,6 +57,19 @@ That exposes:
 - UI: `http://localhost:7860`
 - API: `http://localhost:25800`
 - API docs: `http://localhost:25800/api/docs`
+
+For Z-Image review in Docker:
+
+- put LoRAs under `./loras/<name>/*.safetensors`
+- use **Settings → Models** to download `Z-Image-Turbo`
+- use **Settings → Models** to switch the active backend to `Z-Image`
+- use **Settings → Plugins** to enable `lora` and then select active LoRAs in the Models panel
+
+For Ollama-backed image generation:
+
+- install at least one Ollama image model such as `x/z-image-turbo` or `x/flux2-klein`
+- use **Settings → Ollama** to pick the Ollama prompt model and Ollama image model separately
+- use **Settings → Models** to switch the active backend to `Ollama Image`
 
 ## 🔑 Why Choose This?
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
       - ${AI_CACHE_DIR:-./.cache}/torch:/app/.cache/torch
       - ./output:/app/output
       - ./logs:/app/logs
+      - ./ckpts:/app/ckpts
       - ./loras:/app/loras
+      - ./ref-repos:/app/ref-repos
     environment:
       - HOST=0.0.0.0
       - PORT=8000
@@ -30,6 +32,7 @@ services:
       - SMOKE_TEST_MODEL=${SMOKE_TEST_MODEL:-hf-internal-testing/tiny-stable-diffusion-torch}
       - SMALL_SD_MODEL=${SMALL_SD_MODEL:-segmind/tiny-sd}
       - TURBO_MODEL=${TURBO_MODEL:-stabilityai/sd-turbo}
+      - ZIMAGE_MODEL_PATH=${ZIMAGE_MODEL_PATH:-/app/ckpts/Z-Image-Turbo}
       - FLUX_MODEL=${FLUX_MODEL:-black-forest-labs/FLUX.1-schnell}
       - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
       - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3.2:3b}

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -12,11 +12,14 @@ This repo now uses a single simple Docker flow aimed at end users: start the sta
 2. Set the values you care about in `.env.docker`:
    - `HF_TOKEN` for real model downloads
    - `IMAGE_BACKEND=auto` for the default behavior: use FLUX when cached, otherwise fall back to the small public model
+   - `IMAGE_BACKEND=ollama` if you want DreamGen to call Ollama's image-generation endpoint
+   - `IMAGE_BACKEND=zimage` if you want to review the Z-Image path specifically
    - `IMAGE_BACKEND=small` for the usable first-run fallback
    - `IMAGE_BACKEND=turbo` for the fast few-step turbo backend
    - `IMAGE_BACKEND=smoke` only for diagnostics and smoke tests
    - `IMAGE_BACKEND=mock` if you want placeholder images instead of real generation
    - `OLLAMA_HOST` if Ollama is not running on the same machine
+   - `OLLAMA_IMAGE_MODEL` if you want to pin a specific Ollama image model for `IMAGE_BACKEND=ollama`
 
 3. Start the app:
    ```bash
@@ -33,6 +36,8 @@ This repo now uses a single simple Docker flow aimed at end users: start the sta
 - Backend listens on `25800`
 - Frontend listens on `7860`
 - Model/cache files are stored under `./.cache`
+- Z-Image checkpoints are mounted at `./ckpts`
+- Local LoRAs are mounted at `./loras`
 - Generated images are stored under `./output`
 - Logs are stored under `./logs`
 
@@ -58,6 +63,25 @@ docker compose --env-file .env.docker up -d
 - The frontend talks directly to the published backend port, which keeps browser routing, image URLs, and WebSocket updates simple.
 - `AI_CACHE_DIR` defaults to `./.cache`, so users do not need to create a machine-specific cache folder first.
 - Ollama is expected to run outside Docker by default. `host.docker.internal` is mapped for Docker Desktop and Linux host-gateway setups.
+- DreamGen now resolves the prompt model and Ollama image model independently, so a stale `OLLAMA_MODEL` no longer breaks the Playground prompt button if another completion-capable model is installed.
 - The small and turbo fallback models are public and do not normally require a Hugging Face token.
 - The smoke backend is only for diagnostics; it is not expected to produce good-looking images.
 - If you do not have a compatible GPU and only want placeholder images, set `IMAGE_BACKEND=mock`.
+
+## Reviewing Z-Image In Docker
+
+The current Docker stack supports two Z-Image review modes:
+
+1. **Recommended: Z-Image + LoRA via DiffSynth**
+   - Start the stack.
+   - In **Settings → Models**, click **Download Local Copy** for `Z-Image-Turbo`.
+   - Add one or more LoRAs under `./loras/<name>/*.safetensors`.
+   - In **Settings → Plugins**, enable the `lora` plugin.
+   - In **Settings → Models**, switch the active backend to `Z-Image` and enable the LoRAs you want to test.
+
+2. **Native Z-Image without LoRA**
+   - This still expects a local checkout at `./ref-repos/Z-Image`, which is mounted into the backend container.
+   - If no LoRA is active and that checkout is missing, native Z-Image generation will fail.
+
+Important:
+- The backend and LoRA selections made in the web UI are runtime settings. They are useful for review, but a container restart returns to the `.env.docker` defaults.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "torch==2.6.0+cu124",
     "torchvision==0.21.0+cu124",
     "torchaudio==2.6.0+cu124",
-    "transformers>=4.30.0,<4.55.0",
+    "transformers>=4.55.0,<4.58.0",
     "diffusers>=0.29.0,<0.35.0",
     "Pillow>=10.0.0",
     "typer>=0.9.0",
@@ -47,6 +47,7 @@ dependencies = [
     "aiofiles>=23.0.0",
     "huggingface_hub[inference]>=0.20.0", # For InferenceClient image editing
     "loguru>=0.7.0", # For Z-Image generator logging
+    "diffsynth>=2.0.9", # For Z-Image LoRA inference support via DiffSynth-Studio
 ]
 
 [project.optional-dependencies]

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -27,7 +27,14 @@ from src.generators.factory import (
 )
 from src.generators.prompt_generator import PromptGenerator
 from src.plugins import plugin_manager, register_lora_plugin
+from src.plugins.lora import get_available_loras
 from src.utils.config import Config
+from src.utils.ollama import (
+    get_ollama_version,
+    list_ollama_models,
+    ollama_host,
+    resolve_ollama_model,
+)
 from src.utils.storage import (
     StorageManager,
     metadata_path_for,
@@ -39,6 +46,9 @@ from src.utils.storage import (
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+ALLOWED_IMAGE_BACKENDS = {"auto", "flux", "ollama", "zimage", "small", "turbo", "smoke", "mock"}
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -98,6 +108,52 @@ def configure_plugins() -> None:
 
 
 configure_plugins()
+
+
+def zimage_native_source_path() -> Path:
+    """Return the expected local Z-Image source checkout path."""
+    return PROJECT_ROOT / "ref-repos" / "Z-Image" / "src"
+
+
+def inspect_local_zimage_model(model_path: Path) -> tuple[str, int]:
+    """Return readiness status and size for a repo-local Z-Image checkpoint directory."""
+    if not model_path.exists():
+        return ("not_downloaded", 0)
+
+    size = sum(path.stat().st_size for path in model_path.rglob("*") if path.is_file())
+    transformer_files = list((model_path / "transformer").glob("*.safetensors"))
+    text_encoder_files = list((model_path / "text_encoder").glob("*.safetensors"))
+    required_files = [
+        model_path / "model_index.json",
+        model_path / "tokenizer" / "tokenizer.json",
+        model_path / "vae" / "diffusion_pytorch_model.safetensors",
+    ]
+
+    if transformer_files and text_encoder_files and all(path.exists() for path in required_files):
+        return ("ready", size)
+
+    return ("partial", size)
+
+
+def generation_config_payload() -> Dict[str, Any]:
+    """Serialize mutable generation/runtime settings for the frontend."""
+    return {
+        "width": config.image.width,
+        "height": config.image.height,
+        "num_inference_steps": config.image.num_inference_steps,
+        "guidance_scale": config.image.guidance_scale,
+        "true_cfg_scale": config.image.true_cfg_scale,
+        "ollama_temperature": config.model.ollama_temperature,
+        "image_backend": config.model.image_backend,
+        "ollama_image_model": config.model.ollama_image_model,
+        "enabled_loras": config.model.lora.enabled_loras,
+        "available_loras": get_available_loras(config.model.lora.lora_dir),
+        "lora_application_probability": config.model.lora.application_probability,
+        "lora_dir": str(config.model.lora.lora_dir),
+        "zimage_model_path": str(config.model.zimage_model_path),
+        "zimage_native_available": zimage_native_source_path().exists(),
+    }
+
 
 # Output directory setup
 OUTPUT_DIR = config.system.output_dir
@@ -215,6 +271,9 @@ class GenerateRequest(BaseModel):
     prompt: Optional[str] = Field(None, description="Optional custom prompt")
     enable_plugins: bool = Field(True, description="Enable plugin enhancements")
     seed: Optional[int] = Field(None, description="Random seed for reproducibility")
+    client_request_id: Optional[str] = Field(
+        None, description="Client-provided request ID used to correlate progress events"
+    )
 
 
 class GenerateResponse(BaseModel):
@@ -239,6 +298,9 @@ class PromptRequest(BaseModel):
 
     meta_prompt: Optional[str] = Field(
         None, description="Optional system prompt used to steer prompt generation"
+    )
+    client_request_id: Optional[str] = Field(
+        None, description="Client-provided request ID used to correlate progress events"
     )
 
 
@@ -311,6 +373,31 @@ class ConnectionManager:
 
 
 manager = ConnectionManager()
+
+
+async def broadcast_task_progress(
+    *,
+    task: str,
+    task_id: str,
+    client_request_id: Optional[str],
+    progress: int,
+    label: str,
+    detail: str,
+) -> None:
+    """Broadcast a normalized task progress event for frontend progress UIs."""
+    await manager.broadcast(
+        json.dumps(
+            {
+                "type": "task_progress",
+                "task": task,
+                "id": task_id,
+                "client_request_id": client_request_id,
+                "progress": progress,
+                "label": label,
+                "detail": detail,
+            }
+        )
+    )
 
 
 async def prefetch_default_fallback_model() -> None:
@@ -421,7 +508,7 @@ async def get_model_status():
             "id": "local:zimage",
             "name": "Z-Image-Turbo",
             "type": "text-to-image",
-            "downloadable": False,
+            "downloadable": True,
             "path": str(config.model.zimage_model_path),
         },
         {
@@ -471,6 +558,23 @@ async def get_model_status():
     for model_config in model_configs:
         model_id = model_config["id"]
         downloadable = model_config.get("downloadable", True)
+
+        if model_id == "local:zimage":
+            model_path = Path(model_config["path"])
+            status, size = inspect_local_zimage_model(model_path)
+            models.append(
+                {
+                    "id": model_id,
+                    "name": model_config["name"],
+                    "type": model_config["type"],
+                    "status": status,
+                    "size": size,
+                    "incomplete_files": 0,
+                    "path": str(model_path),
+                    "downloadable": True,
+                }
+            )
+            continue
 
         if not downloadable:
             model_path = Path(model_config["path"])
@@ -544,6 +648,8 @@ async def download_model(model_id: str):
     from urllib.parse import unquote
 
     model_id = unquote(model_id)
+    resolved_model_id = "Tongyi-MAI/Z-Image-Turbo" if model_id == "local:zimage" else model_id
+    local_dir = str(config.model.zimage_model_path) if model_id == "local:zimage" else None
 
     try:
         from huggingface_hub import snapshot_download
@@ -551,7 +657,7 @@ async def download_model(model_id: str):
         # Start download in background
         async def download_in_background():
             try:
-                logger.info(f"Starting download for model: {model_id}")
+                logger.info(f"Starting download for model: {resolved_model_id}")
                 await manager.broadcast(
                     json.dumps(
                         {
@@ -564,11 +670,18 @@ async def download_model(model_id: str):
 
                 # Use snapshot_download to get the entire model
                 loop = asyncio.get_event_loop()
-                await loop.run_in_executor(
-                    None, lambda: snapshot_download(repo_id=model_id, resume_download=True)
-                )
+                if local_dir is not None:
+                    await loop.run_in_executor(
+                        None,
+                        lambda: snapshot_download(repo_id=resolved_model_id, local_dir=local_dir),
+                    )
+                else:
+                    await loop.run_in_executor(
+                        None,
+                        lambda: snapshot_download(repo_id=resolved_model_id),
+                    )
 
-                logger.info(f"Download completed for model: {model_id}")
+                logger.info(f"Download completed for model: {resolved_model_id}")
                 await manager.broadcast(
                     json.dumps(
                         {
@@ -595,7 +708,7 @@ async def download_model(model_id: str):
         # Start the download task
         asyncio.create_task(download_in_background())
 
-        return {"message": f"Download started for {model_id}", "model_id": model_id}
+        return {"message": f"Download started for {resolved_model_id}", "model_id": model_id}
 
     except Exception as e:
         logger.error(f"Failed to start download: {str(e)}")
@@ -691,30 +804,36 @@ async def set_plugin_order(request: PluginOrderRequest):
 async def get_ollama_models():
     """Get list of available Ollama models"""
     try:
-        import ollama
-
-        # Get list of models from Ollama
-        models_response = ollama.list()
-
-        # Extract model information
-        models = []
-        for model in models_response.get("models", []):
-            models.append(
-                {
-                    "name": model.get("name") or model.get("model", ""),
-                    "size": model.get("size", 0),
-                    "modified": model.get("modified_at", ""),
-                    "digest": model.get("digest", ""),
-                }
-            )
-
-        # Get current model from config
-        current_model = config.model.ollama_model
+        models = list_ollama_models()
+        current_prompt = resolve_ollama_model(models, config.model.ollama_model, "completion")
+        current_image = resolve_ollama_model(models, config.model.ollama_image_model, "image")
+        try:
+            version = get_ollama_version()
+        except Exception:
+            version = ""
 
         return {
-            "models": models,
-            "current": current_model,
-            "host": os.getenv("OLLAMA_HOST", "http://localhost:11434"),
+            "models": [
+                {
+                    "name": model.name,
+                    "size": model.size,
+                    "modified": model.modified,
+                    "digest": model.digest,
+                    "format": model.format,
+                    "family": model.family,
+                    "capabilities": model.capabilities,
+                    "can_prompt": model.can_prompt,
+                    "can_vision": model.can_vision,
+                    "can_image": model.can_image,
+                }
+                for model in models
+            ],
+            "current": current_prompt,
+            "configured_prompt": config.model.ollama_model,
+            "current_image": current_image,
+            "configured_image": config.model.ollama_image_model,
+            "host": ollama_host(),
+            "version": version,
         }
     except Exception as e:
         logger.error(f"Failed to get Ollama models: {str(e)}")
@@ -746,14 +865,7 @@ async def set_ollama_model(data: dict):
 @app.get("/api/config/generation")
 async def get_generation_config():
     """Get current generation configuration parameters"""
-    return {
-        "width": config.image.width,
-        "height": config.image.height,
-        "num_inference_steps": config.image.num_inference_steps,
-        "guidance_scale": config.image.guidance_scale,
-        "true_cfg_scale": config.image.true_cfg_scale,
-        "ollama_temperature": config.model.ollama_temperature,
-    }
+    return generation_config_payload()
 
 
 @app.post("/api/config/generation")
@@ -772,9 +884,34 @@ async def set_generation_config(data: dict):
             config.image.true_cfg_scale = float(data["true_cfg_scale"])
         if "ollama_temperature" in data:
             config.model.ollama_temperature = float(data["ollama_temperature"])
+        if "image_backend" in data:
+            backend = str(data["image_backend"]).lower()
+            if backend not in ALLOWED_IMAGE_BACKENDS:
+                raise ValueError(
+                    f"Invalid image backend: {backend} "
+                    f"(must be one of {', '.join(sorted(ALLOWED_IMAGE_BACKENDS))})"
+                )
+            config.model.image_backend = backend
+        if "ollama_image_model" in data:
+            config.model.ollama_image_model = str(data["ollama_image_model"]).strip()
+        if "enabled_loras" in data:
+            enabled_loras = data["enabled_loras"]
+            if not isinstance(enabled_loras, list):
+                raise ValueError("enabled_loras must be a list of names")
+            config.model.lora.enabled_loras = [
+                str(lora_name).strip() for lora_name in enabled_loras if str(lora_name).strip()
+            ]
+        if "lora_application_probability" in data:
+            probability = float(data["lora_application_probability"])
+            if not 0.0 <= probability <= 1.0:
+                raise ValueError("lora_application_probability must be between 0.0 and 1.0")
+            config.model.lora.application_probability = probability
 
         logger.info(f"Generation config updated: {data}")
-        return {"message": "Configuration updated successfully", "config": data}
+        return {
+            "message": "Configuration updated successfully",
+            "config": generation_config_payload(),
+        }
     except Exception as e:
         logger.error(f"Failed to update generation config: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Failed to update configuration: {str(e)}")
@@ -783,9 +920,34 @@ async def set_generation_config(data: dict):
 @app.post("/api/prompt", response_model=PromptResponse)
 async def generate_prompt(request: PromptRequest):
     """Generate a prompt without creating an image."""
+    prompt_id = str(uuid.uuid4())
     try:
+        await broadcast_task_progress(
+            task="prompt_generation",
+            task_id=prompt_id,
+            client_request_id=request.client_request_id,
+            progress=15,
+            label="Preparing prompt generation",
+            detail="Collecting your meta prompt and warming up the prompt model.",
+        )
         prompt_gen = PromptGenerator(config)
+        await broadcast_task_progress(
+            task="prompt_generation",
+            task_id=prompt_id,
+            client_request_id=request.client_request_id,
+            progress=60,
+            label="Generating prompt",
+            detail="Asking Ollama to turn the meta prompt into a final image prompt.",
+        )
         prompt = await prompt_gen.generate_prompt(meta_prompt=request.meta_prompt)
+        await broadcast_task_progress(
+            task="prompt_generation",
+            task_id=prompt_id,
+            client_request_id=request.client_request_id,
+            progress=100,
+            label="Prompt ready",
+            detail="The generated prompt is ready to edit or use directly.",
+        )
         return PromptResponse(prompt=prompt)
     except Exception as e:
         logger.error(f"Prompt generation failed: {str(e)}")
@@ -804,40 +966,100 @@ async def generate_image(request: GenerateRequest):
                 {
                     "type": "generation_started",
                     "id": generation_id,
+                    "client_request_id": request.client_request_id,
                     "timestamp": datetime.now().isoformat(),
                 }
             )
+        )
+        await broadcast_task_progress(
+            task="image_generation",
+            task_id=generation_id,
+            client_request_id=request.client_request_id,
+            progress=8,
+            label="Preparing image request",
+            detail="Collecting the prompt, active plugins, and runtime settings.",
         )
 
         # Generate prompt if not provided
         if request.prompt:
             final_prompt = request.prompt
+            await broadcast_task_progress(
+                task="image_generation",
+                task_id=generation_id,
+                client_request_id=request.client_request_id,
+                progress=24,
+                label="Prompt ready",
+                detail="Using the prompt you provided directly.",
+            )
         else:
             prompt_gen = PromptGenerator(config)
+            await broadcast_task_progress(
+                task="image_generation",
+                task_id=generation_id,
+                client_request_id=request.client_request_id,
+                progress=24,
+                label="Generating prompt",
+                detail="Building a fresh prompt from Ollama and the active plugins.",
+            )
             final_prompt = await prompt_gen.generate_prompt()
 
             # Broadcast prompt generated event
             await manager.broadcast(
                 json.dumps(
-                    {"type": "prompt_generated", "id": generation_id, "prompt": final_prompt}
+                    {
+                        "type": "prompt_generated",
+                        "id": generation_id,
+                        "client_request_id": request.client_request_id,
+                        "prompt": final_prompt,
+                    }
                 )
+            )
+            await broadcast_task_progress(
+                task="image_generation",
+                task_id=generation_id,
+                client_request_id=request.client_request_id,
+                progress=40,
+                label="Prompt ready",
+                detail="The prompt is assembled. Preparing the image backend next.",
             )
 
         try:
             image_gen, backend_name = create_image_generator(config)
             logger.info("Using image backend: %s", backend_name)
+            await broadcast_task_progress(
+                task="image_generation",
+                task_id=generation_id,
+                client_request_id=request.client_request_id,
+                progress=55,
+                label="Backend ready",
+                detail="The selected image backend is loaded and ready to render.",
+            )
         except MemoryError as e:
             error_msg = "Insufficient memory to load the configured image backend."
             logger.error(f"Memory error loading Flux model: {str(e)}")
             await manager.broadcast(
-                json.dumps({"type": "generation_error", "id": generation_id, "error": error_msg})
+                json.dumps(
+                    {
+                        "type": "generation_error",
+                        "id": generation_id,
+                        "client_request_id": request.client_request_id,
+                        "error": error_msg,
+                    }
+                )
             )
             raise HTTPException(status_code=507, detail=error_msg)
         except Exception as e:
             error_msg = f"Failed to load image backend: {str(e)}"
             logger.error(error_msg)
             await manager.broadcast(
-                json.dumps({"type": "generation_error", "id": generation_id, "error": error_msg})
+                json.dumps(
+                    {
+                        "type": "generation_error",
+                        "id": generation_id,
+                        "client_request_id": request.client_request_id,
+                        "error": error_msg,
+                    }
+                )
             )
             raise HTTPException(status_code=500, detail=error_msg)
 
@@ -847,6 +1069,7 @@ async def generate_image(request: GenerateRequest):
             "smoke-test": "Loading smoke-test image model.",
             "small-sd": "Loading small Stable Diffusion fallback model.",
             "sd-turbo": "Loading turbo image model.",
+            "ollama": "Requesting an image from the configured Ollama host.",
         }.get(backend_name, "Loading Flux model (this may take several minutes on first run)...")
 
         await manager.broadcast(
@@ -854,9 +1077,18 @@ async def generate_image(request: GenerateRequest):
                 {
                     "type": "model_loading",
                     "id": generation_id,
+                    "client_request_id": request.client_request_id,
                     "message": loading_message,
                 }
             )
+        )
+        await broadcast_task_progress(
+            task="image_generation",
+            task_id=generation_id,
+            client_request_id=request.client_request_id,
+            progress=68,
+            label="Rendering image",
+            detail=loading_message,
         )
 
         # Generate and save the image through the active backend.
@@ -868,15 +1100,29 @@ async def generate_image(request: GenerateRequest):
             force_reinit=False,
             seed=request.seed,
         )
+        await broadcast_task_progress(
+            task="image_generation",
+            task_id=generation_id,
+            client_request_id=request.client_request_id,
+            progress=92,
+            label="Finalizing output",
+            detail="Saving metadata and writing the finished image to the gallery.",
+        )
+        generation_metadata = getattr(image_gen, "last_generation_metadata", {}) or {}
+        seed_supported = generation_metadata.get("seed_supported", True)
+        resolved_seed = generation_metadata.get("seed")
+        if resolved_seed is None and request.seed is not None and seed_supported:
+            resolved_seed = request.seed
         existing_metadata = read_image_metadata(image_path)
         write_image_metadata(
             image_path,
             {
                 **existing_metadata,
+                **generation_metadata,
                 "backend": backend_name,
                 "configured_backend": config.model.image_backend,
                 "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
-                "seed": request.seed,
+                "seed": resolved_seed,
             },
         )
 
@@ -889,10 +1135,19 @@ async def generate_image(request: GenerateRequest):
                 {
                     "type": "generation_completed",
                     "id": generation_id,
+                    "client_request_id": request.client_request_id,
                     "image_path": relative_path,
                     "prompt": final_prompt,
                 }
             )
+        )
+        await broadcast_task_progress(
+            task="image_generation",
+            task_id=generation_id,
+            client_request_id=request.client_request_id,
+            progress=100,
+            label="Image ready",
+            detail="The generated image is saved and ready to review.",
         )
 
         return GenerateResponse(
@@ -900,11 +1155,12 @@ async def generate_image(request: GenerateRequest):
             prompt=final_prompt,
             image_path=relative_path,
             metadata={
+                **generation_metadata,
                 "backend": backend_name,
                 "plugins_used": [
                     name for name, info in plugin_manager.plugins.items() if info.enabled
                 ],
-                "seed": request.seed,
+                "seed": resolved_seed,
             },
             created_at=datetime.now().isoformat(),
         )
@@ -914,7 +1170,14 @@ async def generate_image(request: GenerateRequest):
 
         # Broadcast error event
         await manager.broadcast(
-            json.dumps({"type": "generation_error", "id": generation_id, "error": str(e)})
+            json.dumps(
+                {
+                    "type": "generation_error",
+                    "id": generation_id,
+                    "client_request_id": request.client_request_id,
+                    "error": str(e),
+                }
+            )
         )
 
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/generators/factory.py
+++ b/src/generators/factory.py
@@ -54,6 +54,8 @@ def backend_label(config: Config, backend: str) -> str:
         return "small-sd"
     if backend == "turbo":
         return "sd-turbo"
+    if backend == "ollama":
+        return "ollama"
     if backend == "zimage":
         return "z-image"
 
@@ -97,6 +99,10 @@ def create_image_generator(config: Config) -> Tuple[object, str]:
         from .turbo_image_generator import TurboImageGenerator
 
         return TurboImageGenerator(config), backend_label(config, backend)
+    if backend == "ollama":
+        from .ollama_image_generator import OllamaImageGenerator
+
+        return OllamaImageGenerator(config), backend_label(config, backend)
     if backend == "zimage":
         from .zimage_generator import ZImageGenerator
 

--- a/src/generators/ollama_image_generator.py
+++ b/src/generators/ollama_image_generator.py
@@ -1,0 +1,101 @@
+"""Image generator backed by Ollama's experimental image API."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+from PIL import Image
+
+from ..utils.config import Config
+from ..utils.error_handler import ModelError
+from ..utils.ollama import (
+    OllamaRequestError,
+    generate_image_via_ollama,
+    list_ollama_models,
+    resolve_ollama_model,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaImageGenerator:
+    """Generate images through an external Ollama host."""
+
+    def __init__(self, config: Config):
+        self.config = config
+        self.model_name = config.model.ollama_image_model
+        self.width = config.image.width
+        self.height = config.image.height
+        self.last_generation_metadata: dict = {}
+
+    def initialize(self, force_reinit: bool = False) -> None:  # noqa: D401 - stub
+        """No-op initialize to mirror the local pipeline-backed generators."""
+        return None
+
+    async def generate(self, prompt: str, seed: Optional[int] = None) -> Image.Image:
+        from ..utils.storage import StorageManager
+
+        storage = StorageManager()
+        output_path = storage.get_output_path(prompt)
+        await self.generate_image(prompt, output_path, force_reinit=False, seed=seed)
+        return Image.open(output_path)
+
+    async def generate_image(
+        self,
+        prompt: str,
+        output_path: Path,
+        force_reinit: bool = False,
+        seed: Optional[int] = None,
+    ) -> Tuple[Path, float, str]:
+        del force_reinit  # No persistent pipeline to reinitialize.
+
+        start = time.time()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        models = await asyncio.to_thread(list_ollama_models)
+        model_name = resolve_ollama_model(models, self.config.model.ollama_image_model, "image")
+        if not model_name:
+            raise ModelError(
+                "No Ollama image model is available. Install an image-capable model such as "
+                "'x/z-image-turbo' or 'x/flux2-klein'."
+            )
+
+        try:
+            image = await asyncio.to_thread(
+                generate_image_via_ollama,
+                model_name=model_name,
+                prompt=prompt,
+                width=self.width,
+                height=self.height,
+            )
+        except OllamaRequestError as exc:
+            raise ModelError(str(exc)) from exc
+
+        image.save(output_path)
+        output_path.with_suffix(".txt").write_text(prompt, encoding="utf-8")
+
+        self.last_generation_metadata = {
+            "provider": "ollama",
+            "ollama_model": model_name,
+            "seed_supported": False,
+            "requested_seed": seed,
+        }
+
+        if (
+            self.config.model.ollama_image_model
+            and self.config.model.ollama_image_model != model_name
+        ):
+            logger.warning(
+                "Configured Ollama image model %s is unavailable or not image-capable; using %s instead",
+                self.config.model.ollama_image_model,
+                model_name,
+            )
+
+        return output_path, time.time() - start, model_name
+
+    def cleanup(self) -> None:
+        self.last_generation_metadata = {}

--- a/src/generators/prompt_generator.py
+++ b/src/generators/prompt_generator.py
@@ -12,6 +12,7 @@ from ..plugins import get_context_with_descriptions, get_temporal_descriptor
 from ..utils.config import Config
 from ..utils.error_handler import PromptError, handle_errors
 from ..utils.metrics import GenerationMetrics
+from ..utils.ollama import list_ollama_models, resolve_ollama_model
 
 
 class PromptGenerator:
@@ -39,6 +40,27 @@ class PromptGenerator:
 
             metrics = GenerationMetrics(model_name=self.model_name)
             start_time = time.time()
+
+            available_models = list_ollama_models()
+            resolved_model = resolve_ollama_model(
+                available_models,
+                self.config.model.ollama_model,
+                "completion",
+            )
+            if not resolved_model:
+                raise PromptError(
+                    "No Ollama prompt model is available. Install a completion-capable model "
+                    "such as 'qwen3.6', 'qwen3.5', or 'gemma4'."
+                )
+
+            if resolved_model != self.model_name:
+                self.logger.warning(
+                    "Configured Ollama prompt model %s is unavailable or not completion-capable; using %s instead",
+                    self.model_name,
+                    resolved_model,
+                )
+                self.model_name = resolved_model
+                metrics.model_name = resolved_model
 
             # Get context with plugin descriptions
             context_data = get_context_with_descriptions()

--- a/src/generators/zimage_generator.py
+++ b/src/generators/zimage_generator.py
@@ -11,6 +11,8 @@ from typing import Optional
 import torch
 from loguru import logger
 
+from ..plugins import plugin_manager, register_lora_plugin
+from ..plugins.lora import get_lora_path
 from .base_generator import GenerationResult, ImageGenerator
 
 
@@ -38,6 +40,12 @@ class ZImageGenerator(ImageGenerator):
         self.attention_backend = config.model.zimage_attention
         self.compile_model = config.model.zimage_compile
         self.components = None  # Will hold transformer, vae, text_encoder, tokenizer, scheduler
+        self.using_diffsynth = False
+        self.selected_lora_name: Optional[str] = None
+        self.last_generation_metadata: dict = {}
+
+        # Register LoRA plugin so Z-Image can consume the same selection flow as Flux.
+        register_lora_plugin(config)
 
     def _get_zimage_src_path(self) -> Path:
         """Get the path to Z-Image source code."""
@@ -51,8 +59,89 @@ class ZImageGenerator(ImageGenerator):
             "Clone Z-Image repo: git clone https://github.com/Tongyi-MAI/Z-Image ref-repos/Z-Image"
         )
 
-    def load_model(self):
-        """Load Z-Image model components into memory."""
+    def _get_selected_lora_path(self) -> Optional[Path]:
+        """Return the currently selected LoRA path, if any."""
+        try:
+            plugin_results = plugin_manager.execute_plugins()
+        except Exception as exc:
+            logger.warning(f"Failed to execute plugins for Z-Image LoRA selection: {exc}")
+            return None
+
+        for result in plugin_results:
+            if result.name == "lora" and result.value:
+                lora_path = get_lora_path(result.value, self.config)
+                if lora_path:
+                    self.selected_lora_name = result.value
+                    logger.info(f"Selected Z-Image LoRA '{result.value}' from {lora_path}")
+                return lora_path
+        self.selected_lora_name = None
+        return None
+
+    def _build_diffsynth_model_configs(self):
+        """Build local-path model configs for DiffSynth Z-Image loading."""
+        from diffsynth.pipelines.z_image import ModelConfig
+
+        transformer_paths = sorted(
+            str(path) for path in (self.model_path / "transformer").glob("*.safetensors")
+        )
+        text_encoder_paths = sorted(
+            str(path) for path in (self.model_path / "text_encoder").glob("*.safetensors")
+        )
+        vae_paths = [
+            str(self.model_path / "vae" / "diffusion_pytorch_model.safetensors"),
+        ]
+
+        required_paths = {
+            "transformer": transformer_paths,
+            "text_encoder": text_encoder_paths,
+            "vae": vae_paths,
+        }
+        missing = [
+            name
+            for name, paths in required_paths.items()
+            if not all(Path(p).exists() for p in paths)
+        ]
+        if missing:
+            missing_str = ", ".join(missing)
+            raise FileNotFoundError(
+                f"Missing required Z-Image checkpoint files for DiffSynth: {missing_str} under {self.model_path}"
+            )
+
+        return [
+            ModelConfig(path=transformer_paths),
+            ModelConfig(path=text_encoder_paths),
+            ModelConfig(path=vae_paths),
+        ]
+
+    def _load_diffsynth_pipe(self, lora_path: Path):
+        """Load Z-Image through DiffSynth-Studio so LoRAs can be applied."""
+        try:
+            from diffsynth.pipelines.z_image import ModelConfig, ZImagePipeline
+        except ImportError as exc:
+            raise ImportError(
+                "Z-Image LoRA support requires DiffSynth-Studio (`diffsynth`). "
+                "Install it first, then retry generation with Z-Image LoRAs enabled."
+            ) from exc
+
+        if not self.model_path.exists():
+            raise FileNotFoundError(
+                f"Z-Image model not found at {self.model_path}. "
+                "Download from HuggingFace: huggingface-cli download Tongyi-MAI/Z-Image-Turbo --local-dir <path>"
+            )
+
+        logger.info(f"Loading Z-Image via DiffSynth for LoRA support from: {self.model_path}")
+        self.pipe = ZImagePipeline.from_pretrained(
+            torch_dtype=torch.bfloat16,
+            device=self.device,
+            model_configs=self._build_diffsynth_model_configs(),
+            tokenizer_config=ModelConfig(path=str(self.model_path / "tokenizer")),
+        )
+        self.pipe.load_lora(self.pipe.dit, str(lora_path))
+        self.using_diffsynth = True
+        logger.info("Z-Image DiffSynth pipeline with LoRA loaded successfully")
+
+    def _load_native_components(self):
+        """Load native Z-Image components without LoRA support."""
         # Add Z-Image source to path
         zimage_src = self._get_zimage_src_path()
         if str(zimage_src) not in sys.path:
@@ -93,6 +182,17 @@ class ZImageGenerator(ImageGenerator):
 
         logger.info("Z-Image model loaded successfully")
 
+    def load_model(self):
+        """Load Z-Image model components into memory."""
+        lora_path = self._get_selected_lora_path()
+        self.cleanup()
+        if lora_path is not None:
+            self._load_diffsynth_pipe(lora_path)
+        else:
+            self._load_native_components()
+            self.using_diffsynth = False
+            self.selected_lora_name = None
+
     async def generate(
         self,
         prompt: str,
@@ -119,14 +219,18 @@ class ZImageGenerator(ImageGenerator):
         Returns:
             GenerationResult with generated image
         """
-        if self.components is None:
+        if (self.using_diffsynth and self.pipe is None) or (
+            not self.using_diffsynth and self.components is None
+        ):
             self.load_model()
 
-        # Import generate function
-        zimage_src = self._get_zimage_src_path()
-        if str(zimage_src) not in sys.path:
-            sys.path.insert(0, str(zimage_src))
-        from zimage import generate as zimage_generate
+        zimage_generate = None
+        if not self.using_diffsynth:
+            # Import generate function
+            zimage_src = self._get_zimage_src_path()
+            if str(zimage_src) not in sys.path:
+                sys.path.insert(0, str(zimage_src))
+            from zimage import generate as zimage_generate
 
         # Apply defaults from config
         height = height or self.config.image.height
@@ -134,37 +238,61 @@ class ZImageGenerator(ImageGenerator):
         num_inference_steps = num_inference_steps or 8  # Z-Image Turbo default
         seed = seed if seed is not None else torch.randint(0, 2**32, (1,)).item()
 
-        # Z-Image Turbo uses guidance_scale=0.0 (fixed)
-        guidance_scale = 0.0
-
-        # Negative prompts not used in Turbo variant
-        if negative_prompt:
-            logger.warning(
-                "Z-Image Turbo doesn't use negative prompts, ignoring negative_prompt parameter"
+        if self.using_diffsynth:
+            cfg_scale = (
+                guidance_scale if guidance_scale is not None else self.config.image.guidance_scale
+            )
+            logger.info(f"Generating image with Z-Image + LoRA via DiffSynth: {prompt[:100]}...")
+            logger.info(
+                f"Parameters: {width}x{height}, steps={num_inference_steps}, seed={seed}, cfg_scale={cfg_scale}"
             )
 
-        logger.info(f"Generating image with Z-Image: {prompt[:100]}...")
-        logger.info(f"Parameters: {width}x{height}, steps={num_inference_steps}, seed={seed}")
+            loop = asyncio.get_event_loop()
+            image = await loop.run_in_executor(
+                None,
+                lambda: self.pipe(
+                    prompt=prompt,
+                    negative_prompt=negative_prompt or "",
+                    height=height,
+                    width=width,
+                    num_inference_steps=num_inference_steps,
+                    cfg_scale=cfg_scale,
+                    seed=seed,
+                    rand_device=self.device,
+                ),
+            )
+        else:
+            # Z-Image Turbo uses guidance_scale=0.0 (fixed)
+            guidance_scale = 0.0
 
-        # Create generator for reproducibility
-        generator = torch.Generator(device=self.device).manual_seed(seed)
+            # Negative prompts not used in Turbo variant
+            if negative_prompt:
+                logger.warning(
+                    "Z-Image Turbo doesn't use negative prompts, ignoring negative_prompt parameter"
+                )
 
-        # Generate in separate thread to avoid blocking
-        loop = asyncio.get_event_loop()
-        images = await loop.run_in_executor(
-            None,
-            lambda: zimage_generate(
-                prompt=prompt,
-                **self.components,
-                height=height,
-                width=width,
-                num_inference_steps=num_inference_steps,
-                guidance_scale=guidance_scale,
-                generator=generator,
-            ),
-        )
+            logger.info(f"Generating image with Z-Image: {prompt[:100]}...")
+            logger.info(f"Parameters: {width}x{height}, steps={num_inference_steps}, seed={seed}")
 
-        image = images[0]
+            # Create generator for reproducibility
+            generator = torch.Generator(device=self.device).manual_seed(seed)
+
+            # Generate in separate thread to avoid blocking
+            loop = asyncio.get_event_loop()
+            images = await loop.run_in_executor(
+                None,
+                lambda: zimage_generate(
+                    prompt=prompt,
+                    **self.components,
+                    height=height,
+                    width=width,
+                    num_inference_steps=num_inference_steps,
+                    guidance_scale=guidance_scale,
+                    generator=generator,
+                ),
+            )
+
+            image = images[0]
 
         # Save image
         output_path = self._save_image(image, prompt, seed)
@@ -176,11 +304,15 @@ class ZImageGenerator(ImageGenerator):
             "height": height,
             "width": width,
             "steps": num_inference_steps,
-            "guidance_scale": guidance_scale,
+            "guidance_scale": guidance_scale if not self.using_diffsynth else cfg_scale,
             "attention_backend": self.attention_backend,
             "compiled": self.compile_model,
             "device": self.device,
+            "lora_backend": "diffsynth" if self.using_diffsynth else None,
+            "using_diffsynth": self.using_diffsynth,
+            "selected_lora": self.selected_lora_name if self.using_diffsynth else None,
         }
+        self.last_generation_metadata = metadata
 
         logger.info(f"Image saved to: {output_path}")
 
@@ -269,6 +401,9 @@ class ZImageGenerator(ImageGenerator):
                 del self.components[key]
             self.components = None
 
+        self.using_diffsynth = False
+        self.selected_lora_name = None
+        self.last_generation_metadata = {}
         super().cleanup()
 
         # Additional cleanup

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -55,12 +55,29 @@ def register_lora_plugin(config: Config):
     def lora_plugin():
         return apply_lora(config)
 
+    existing_plugin = plugin_manager.plugins.get("lora")
+
     # Store the plugin function
     plugin_functions["lora"] = lora_plugin
 
-    # Register or re-register the plugin
+    # Preserve any runtime toggles/order changes when generators refresh the plugin.
+    enabled = (
+        existing_plugin.enabled
+        if existing_plugin is not None
+        else "lora" in set(config.plugins.enabled_plugins)
+    )
+    order = (
+        existing_plugin.order
+        if existing_plugin is not None
+        else config.plugins.plugin_order.get("lora", 5)
+    )
+
     plugin_manager.register(
-        "lora", "Randomly selects and applies a Lora model", lora_plugin, order=5
+        "lora",
+        "Randomly selects and applies a Lora model",
+        lora_plugin,
+        enabled=enabled,
+        order=order,
     )
 
 

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -191,7 +191,7 @@ def generate(
     backend: Optional[str] = typer.Option(
         None,
         "--backend",
-        help="Override the image backend for this run (flux, zimage, small, turbo, smoke, mock)",
+        help="Override the image backend for this run (flux, ollama, zimage, small, turbo, smoke, mock)",
     ),
     mock: bool = typer.Option(
         False,
@@ -368,7 +368,7 @@ def loop(
     backend: Optional[str] = typer.Option(
         None,
         "--backend",
-        help="Override the image backend for this run (flux, zimage, small, turbo, smoke, mock)",
+        help="Override the image backend for this run (flux, ollama, zimage, small, turbo, smoke, mock)",
     ),
     mock: bool = typer.Option(
         False,

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -32,6 +32,7 @@ class ModelConfig:
     zimage_attention: str
     zimage_compile: bool
     ollama_model: str
+    ollama_image_model: str
     ollama_temperature: float
     flux_model: str
     max_sequence_length: int
@@ -129,7 +130,7 @@ class Config:
             image_backend = "mock"
         elif configured_backend:
             image_backend = configured_backend
-        elif legacy_image_model in {"flux", "zimage"}:
+        elif legacy_image_model in {"flux", "ollama", "zimage"}:
             image_backend = legacy_image_model
         else:
             image_backend = "auto"
@@ -159,6 +160,8 @@ class Config:
         if not ollama_model:
             raise ValueError("OLLAMA_MODEL environment variable is required")
 
+        ollama_image_model = os.getenv("OLLAMA_IMAGE_MODEL", "").strip()
+
         ollama_temp = os.getenv("OLLAMA_TEMPERATURE")
         if not ollama_temp:
             raise ValueError("OLLAMA_TEMPERATURE environment variable is required")
@@ -180,6 +183,7 @@ class Config:
             zimage_attention=zimage_attention,
             zimage_compile=zimage_compile,
             ollama_model=ollama_model,
+            ollama_image_model=ollama_image_model,
             ollama_temperature=float(ollama_temp),
             flux_model=flux_model,
             max_sequence_length=int(max_seq_len),
@@ -301,6 +305,7 @@ class Config:
         if self.model.image_backend not in {
             "auto",
             "flux",
+            "ollama",
             "zimage",
             "small",
             "turbo",
@@ -309,7 +314,7 @@ class Config:
         }:
             errors.append(
                 f"Invalid image backend: {self.model.image_backend} "
-                "(must be one of auto, flux, zimage, small, turbo, smoke, mock)"
+                "(must be one of auto, flux, ollama, zimage, small, turbo, smoke, mock)"
             )
         if not (1 <= self.image.num_inference_steps <= 150):
             errors.append(

--- a/src/utils/ollama.py
+++ b/src/utils/ollama.py
@@ -1,0 +1,333 @@
+"""Helpers for interacting with Ollama's local APIs."""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+from urllib import error, request
+
+from PIL import Image
+
+DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+
+
+class OllamaRequestError(RuntimeError):
+    """Raised when the Ollama host returns an invalid response."""
+
+
+@dataclass(frozen=True)
+class OllamaModelInfo:
+    """Normalized Ollama model metadata for the API/UI layer."""
+
+    name: str
+    size: int
+    modified: str
+    digest: str
+    format: str
+    family: str
+    capabilities: list[str]
+    can_prompt: bool
+    can_vision: bool
+    can_image: bool
+
+
+def ollama_host() -> str:
+    """Return the configured Ollama host without a trailing slash."""
+    return os.getenv("OLLAMA_HOST", DEFAULT_OLLAMA_HOST).rstrip("/")
+
+
+def _request_json(
+    path: str,
+    *,
+    payload: Optional[dict[str, Any]] = None,
+    timeout: int = 60,
+) -> dict[str, Any]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = request.Request(
+        f"{ollama_host()}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST" if payload is not None else "GET",
+    )
+
+    try:
+        with request.urlopen(req, timeout=timeout) as response:
+            raw = response.read()
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace").strip()
+        detail = body
+        if body:
+            try:
+                parsed = json.loads(body)
+            except json.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, dict):
+                detail = (
+                    (
+                        parsed.get("error", {}).get("message")
+                        if isinstance(parsed.get("error"), dict)
+                        else parsed.get("error")
+                    )
+                    or parsed.get("detail")
+                    or body
+                )
+        raise OllamaRequestError(
+            f"Ollama request to {path} failed with {exc.code}: {detail or exc.reason}"
+        ) from exc
+    except error.URLError as exc:
+        raise OllamaRequestError(
+            f"Failed to reach Ollama at {ollama_host()}: {exc.reason}"
+        ) from exc
+
+    if not raw:
+        return {}
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise OllamaRequestError(f"Ollama returned invalid JSON for {path}: {raw[:200]!r}") from exc
+
+    if not isinstance(parsed, dict):
+        raise OllamaRequestError(f"Ollama returned an unexpected payload for {path}")
+
+    return parsed
+
+
+def get_ollama_version(timeout: int = 10) -> str:
+    """Return the Ollama host version."""
+    return str(_request_json("/api/version", timeout=timeout).get("version", ""))
+
+
+def show_ollama_model(model_name: str, timeout: int = 30) -> dict[str, Any]:
+    """Fetch detailed metadata for one Ollama model."""
+    return _request_json("/api/show", payload={"model": model_name}, timeout=timeout)
+
+
+def _normalize_capabilities(capabilities: Iterable[Any]) -> list[str]:
+    return sorted({str(capability).strip().lower() for capability in capabilities if capability})
+
+
+def list_ollama_models(timeout: int = 30) -> list[OllamaModelInfo]:
+    """Fetch installed Ollama models plus their capability metadata."""
+    tags_payload = _request_json("/api/tags", timeout=timeout)
+    models: list[OllamaModelInfo] = []
+
+    for raw_model in tags_payload.get("models", []):
+        name = str(raw_model.get("name") or raw_model.get("model") or "").strip()
+        if not name:
+            continue
+
+        tag_details = raw_model.get("details") or {}
+        try:
+            show_payload = show_ollama_model(name, timeout=timeout)
+        except OllamaRequestError:
+            show_payload = {}
+
+        show_details = show_payload.get("details") or {}
+        capabilities = _normalize_capabilities(show_payload.get("capabilities") or [])
+
+        details = {
+            "format": str(show_details.get("format") or tag_details.get("format") or ""),
+            "family": str(show_details.get("family") or tag_details.get("family") or ""),
+        }
+        if not capabilities and details["format"].lower() == "safetensors":
+            capabilities = ["image"]
+
+        models.append(
+            OllamaModelInfo(
+                name=name,
+                size=int(raw_model.get("size") or 0),
+                modified=str(raw_model.get("modified_at") or ""),
+                digest=str(raw_model.get("digest") or ""),
+                format=details["format"],
+                family=details["family"],
+                capabilities=capabilities,
+                can_prompt="completion" in capabilities,
+                can_vision="vision" in capabilities,
+                can_image="image" in capabilities,
+            )
+        )
+
+    return models
+
+
+def _match_model_name(
+    configured_name: Optional[str],
+    models: list[OllamaModelInfo],
+) -> Optional[str]:
+    if not configured_name:
+        return None
+
+    configured_name = configured_name.strip()
+    model_names = {model.name for model in models}
+
+    if configured_name in model_names:
+        return configured_name
+
+    if ":" not in configured_name:
+        latest_name = f"{configured_name}:latest"
+        if latest_name in model_names:
+            return latest_name
+
+    if configured_name.endswith(":latest"):
+        bare_name = configured_name[: -len(":latest")]
+        if bare_name in model_names:
+            return bare_name
+
+    return None
+
+
+def resolve_ollama_model(
+    models: list[OllamaModelInfo],
+    configured_name: Optional[str],
+    capability: str,
+) -> Optional[str]:
+    """Pick a usable model for the requested capability."""
+    matched_name = _match_model_name(configured_name, models)
+    if matched_name:
+        matched_model = next(model for model in models if model.name == matched_name)
+        if capability in matched_model.capabilities:
+            return matched_model.name
+
+    candidate_models = [model for model in models if capability in model.capabilities]
+    if capability == "completion":
+        candidate_models.sort(key=lambda model: (model.size <= 0, model.size, model.name))
+
+    for model in candidate_models:
+        if capability in model.capabilities:
+            return model.name
+
+    return None
+
+
+def generate_image_via_ollama(
+    *,
+    model_name: str,
+    prompt: str,
+    width: int,
+    height: int,
+    timeout: int = 300,
+) -> Image.Image:
+    """Generate one image through Ollama's OpenAI-compatible image endpoint."""
+    payload = json.dumps(
+        {
+            "model": model_name,
+            "prompt": prompt,
+            "size": f"{width}x{height}",
+            "response_format": "b64_json",
+        }
+    ).encode("utf-8")
+
+    req = request.Request(
+        f"{ollama_host()}/v1/images/generations",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with request.urlopen(req, timeout=timeout) as response:
+            raw = response.read()
+            content_type = response.headers.get("Content-Type", "")
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace").strip()
+        detail = body
+        if body:
+            try:
+                parsed = json.loads(body)
+            except json.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, dict):
+                detail = (
+                    (
+                        parsed.get("error", {}).get("message")
+                        if isinstance(parsed.get("error"), dict)
+                        else parsed.get("error")
+                    )
+                    or parsed.get("detail")
+                    or body
+                )
+        raise OllamaRequestError(
+            f"Ollama image generation failed with {exc.code}: {detail or exc.reason}"
+        ) from exc
+    except error.URLError as exc:
+        raise OllamaRequestError(
+            f"Failed to reach Ollama at {ollama_host()}: {exc.reason}"
+        ) from exc
+
+    encoded_image = _extract_image_payload(raw, content_type)
+    if not encoded_image:
+        raise OllamaRequestError(
+            "Ollama accepted the image-generation request but returned no image bytes. "
+            "The host may not fully support the experimental image API yet."
+        )
+
+    if encoded_image.startswith("data:image/"):
+        encoded_image = encoded_image.split(",", 1)[-1]
+
+    try:
+        image_bytes = base64.b64decode(encoded_image)
+    except Exception as exc:  # noqa: BLE001 - convert to one consistent backend error
+        raise OllamaRequestError("Ollama returned invalid base64 image data") from exc
+
+    try:
+        image = Image.open(io.BytesIO(image_bytes))
+        image.load()
+        return image.convert("RGB")
+    except Exception as exc:  # noqa: BLE001 - convert to one consistent backend error
+        raise OllamaRequestError("Ollama returned unreadable image data") from exc
+
+
+def _extract_image_payload(raw: bytes, content_type: str) -> Optional[str]:
+    if not raw:
+        return None
+
+    decoded = raw.decode("utf-8", errors="replace")
+
+    if "ndjson" in content_type:
+        payloads = []
+        for line in decoded.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payloads.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+        for payload in reversed(payloads):
+            encoded = _extract_image_field(payload)
+            if encoded:
+                return encoded
+        return None
+
+    try:
+        payload = json.loads(decoded)
+    except json.JSONDecodeError:
+        return None
+
+    return _extract_image_field(payload)
+
+
+def _extract_image_field(payload: Any) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+
+    data_items = payload.get("data")
+    if isinstance(data_items, list):
+        for item in data_items:
+            if not isinstance(item, dict):
+                continue
+            encoded = item.get("b64_json") or item.get("image") or item.get("b64")
+            if isinstance(encoded, str) and encoded:
+                return encoded
+
+    direct_value = payload.get("b64_json") or payload.get("image")
+    if isinstance(direct_value, str) and direct_value:
+        return direct_value
+
+    return None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 from PIL import Image, ImageDraw
 
+from src.utils.ollama import OllamaModelInfo
 from src.utils.storage import metadata_path_for, write_image_metadata
 
 # Redirect OUTPUT_DIR to a temp directory BEFORE any server imports so that test
@@ -42,6 +43,7 @@ os.environ["CPU_ONLY"] = "false"
 os.environ["MPS_USE_FP16"] = "false"
 
 from src.api.server import app
+from src.api.server import config as api_config
 
 
 @pytest.fixture
@@ -86,7 +88,11 @@ def test_plugins_endpoint(client):
 
 def test_generate_endpoint(client):
     """Test the /api/generate endpoint with mock mode"""
-    payload = {"prompt": "A serene mountain landscape at sunset", "enable_plugins": True}
+    payload = {
+        "prompt": "A serene mountain landscape at sunset",
+        "enable_plugins": True,
+        "client_request_id": "req-generate-123",
+    }
 
     response = client.post("/api/generate", json=payload)
     assert response.status_code == 200
@@ -106,6 +112,26 @@ def test_generate_endpoint(client):
     # Verify image path format
     assert data["image_path"].startswith("/images/")
     assert data["image_path"].endswith(".png")
+
+
+def test_prompt_endpoint_accepts_client_request_id(client, monkeypatch):
+    """Prompt generation should accept a client request ID used for progress correlation."""
+
+    async def fake_generate_prompt(self, meta_prompt=None):
+        return f"prompt from {meta_prompt or 'default'}"
+
+    monkeypatch.setattr("src.api.server.PromptGenerator.generate_prompt", fake_generate_prompt)
+
+    response = client.post(
+        "/api/prompt",
+        json={
+            "meta_prompt": "cinematic alleyway",
+            "client_request_id": "req-prompt-123",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"prompt": "prompt from cinematic alleyway"}
 
 
 def test_generate_without_prompt(client):
@@ -132,6 +158,110 @@ def test_generate_with_seed(client):
 
     data = response.json()
     assert data["metadata"].get("seed") == 42
+
+
+def test_generation_config_endpoint(client):
+    """The generation config endpoint should expose backend and LoRA settings."""
+    response = client.get("/api/config/generation")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["image_backend"] == "mock"
+    assert isinstance(data["enabled_loras"], list)
+    assert isinstance(data["available_loras"], list)
+    assert "lora_application_probability" in data
+    assert "zimage_model_path" in data
+
+
+def test_set_generation_config_updates_backend_and_loras(client):
+    """Runtime generation settings should accept backend and LoRA updates."""
+    original_backend = api_config.model.image_backend
+    original_ollama_image_model = api_config.model.ollama_image_model
+    original_enabled_loras = list(api_config.model.lora.enabled_loras)
+    original_probability = api_config.model.lora.application_probability
+
+    try:
+        response = client.post(
+            "/api/config/generation",
+            json={
+                "image_backend": "small",
+                "ollama_image_model": "x/z-image-turbo:latest",
+                "enabled_loras": ["pixel-art", "comic"],
+                "lora_application_probability": 0.25,
+            },
+        )
+        assert response.status_code == 200
+
+        data = response.json()["config"]
+        assert data["image_backend"] == "small"
+        assert data["ollama_image_model"] == "x/z-image-turbo:latest"
+        assert data["enabled_loras"] == ["pixel-art", "comic"]
+        assert data["lora_application_probability"] == 0.25
+        assert api_config.model.image_backend == "small"
+        assert api_config.model.ollama_image_model == "x/z-image-turbo:latest"
+        assert api_config.model.lora.enabled_loras == ["pixel-art", "comic"]
+        assert api_config.model.lora.application_probability == 0.25
+    finally:
+        api_config.model.image_backend = original_backend
+        api_config.model.ollama_image_model = original_ollama_image_model
+        api_config.model.lora.enabled_loras = original_enabled_loras
+        api_config.model.lora.application_probability = original_probability
+
+
+def test_ollama_models_endpoint_includes_capabilities_and_resolved_models(client, monkeypatch):
+    """The Ollama models endpoint should expose capabilities plus resolved prompt/image selections."""
+    original_prompt_model = api_config.model.ollama_model
+    original_image_model = api_config.model.ollama_image_model
+
+    mock_models = [
+        OllamaModelInfo(
+            name="x/z-image-turbo:latest",
+            size=12_773_500_825,
+            modified="2026-04-23T20:11:47.7848211-05:00",
+            digest="digest-z",
+            format="safetensors",
+            family="ZImagePipeline",
+            capabilities=["image"],
+            can_prompt=False,
+            can_vision=False,
+            can_image=True,
+        ),
+        OllamaModelInfo(
+            name="qwen3.6:27b",
+            size=17_420_432_739,
+            modified="2026-04-23T11:00:26.2084332-05:00",
+            digest="digest-q",
+            format="gguf",
+            family="qwen35",
+            capabilities=["completion", "vision", "tools", "thinking"],
+            can_prompt=True,
+            can_vision=True,
+            can_image=False,
+        ),
+    ]
+
+    monkeypatch.setattr("src.api.server.list_ollama_models", lambda: mock_models)
+    monkeypatch.setattr("src.api.server.get_ollama_version", lambda: "0.21.2")
+
+    try:
+        api_config.model.ollama_model = "llama3.2:3b"
+        api_config.model.ollama_image_model = "x/z-image-turbo"
+
+        response = client.get("/api/ollama/models")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["current"] == "qwen3.6:27b"
+        assert data["configured_prompt"] == "llama3.2:3b"
+        assert data["current_image"] == "x/z-image-turbo:latest"
+        assert data["configured_image"] == "x/z-image-turbo"
+        assert data["version"] == "0.21.2"
+        assert data["models"][0]["can_image"] is True
+        assert data["models"][1]["can_prompt"] is True
+        assert "vision" in data["models"][1]["capabilities"]
+    finally:
+        api_config.model.ollama_model = original_prompt_model
+        api_config.model.ollama_image_model = original_image_model
 
 
 def test_gallery_endpoint(client):

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -1,0 +1,120 @@
+"""Targeted tests for Ollama-backed prompt and image generation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+
+from src.generators.ollama_image_generator import OllamaImageGenerator
+from src.generators.prompt_generator import PromptGenerator
+from src.utils.ollama import OllamaModelInfo
+
+
+def _completion_model(name: str) -> OllamaModelInfo:
+    return OllamaModelInfo(
+        name=name,
+        size=1,
+        modified="2026-04-24T00:00:00Z",
+        digest="digest",
+        format="gguf",
+        family="qwen",
+        capabilities=["completion"],
+        can_prompt=True,
+        can_vision=False,
+        can_image=False,
+    )
+
+
+def _image_model(name: str) -> OllamaModelInfo:
+    return OllamaModelInfo(
+        name=name,
+        size=1,
+        modified="2026-04-24T00:00:00Z",
+        digest="digest",
+        format="safetensors",
+        family="ZImagePipeline",
+        capabilities=["image"],
+        can_prompt=False,
+        can_vision=False,
+        can_image=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_prompt_generator_falls_back_to_available_completion_model(monkeypatch):
+    """Prompt generation should recover when the configured model is unavailable."""
+    config = MagicMock()
+    config.model.ollama_model = "llama3.2:3b"
+    config.model.ollama_temperature = 0.7
+
+    chat_calls: list[str] = []
+
+    fake_ollama = ModuleType("ollama")
+
+    def fake_chat(*, model, messages, options):
+        del messages, options
+        chat_calls.append(model)
+        return SimpleNamespace(message=SimpleNamespace(content="sunlit alley, cinematic framing"))
+
+    fake_ollama.chat = fake_chat
+    monkeypatch.setitem(sys.modules, "ollama", fake_ollama)
+    monkeypatch.setattr(
+        "src.generators.prompt_generator.list_ollama_models",
+        lambda: [_image_model("x/z-image-turbo:latest"), _completion_model("qwen3.6:27b")],
+    )
+    monkeypatch.setattr(
+        "src.generators.prompt_generator.get_context_with_descriptions",
+        lambda: {"results": [], "descriptions": []},
+    )
+    monkeypatch.setattr(
+        "src.generators.prompt_generator.get_temporal_descriptor",
+        lambda: "afternoon",
+    )
+
+    generator = PromptGenerator(config)
+    prompt = await generator.generate_prompt()
+
+    assert prompt == "sunlit alley, cinematic framing"
+    assert chat_calls == ["qwen3.6:27b"]
+    assert generator.model_name == "qwen3.6:27b"
+
+
+@pytest.mark.asyncio
+async def test_ollama_image_generator_uses_resolved_image_model(monkeypatch, tmp_path):
+    """The Ollama image backend should resolve an image-capable model and save the image."""
+    config = MagicMock()
+    config.model.ollama_image_model = "x/z-image-turbo"
+    config.image.width = 512
+    config.image.height = 512
+
+    monkeypatch.setattr(
+        "src.generators.ollama_image_generator.list_ollama_models",
+        lambda: [_image_model("x/z-image-turbo:latest")],
+    )
+    monkeypatch.setattr(
+        "src.generators.ollama_image_generator.generate_image_via_ollama",
+        lambda *, model_name, prompt, width, height: Image.new(
+            "RGB", (width, height), color=(0, 0, 255)
+        ),
+    )
+
+    generator = OllamaImageGenerator(config)
+    output_path = tmp_path / "ollama.png"
+    saved_path, _, model_name = await generator.generate_image(
+        "A bright blue square",
+        output_path,
+        seed=123,
+    )
+
+    assert saved_path == output_path
+    assert saved_path.exists()
+    assert model_name == "x/z-image-turbo:latest"
+    assert generator.last_generation_metadata["provider"] == "ollama"
+    assert generator.last_generation_metadata["ollama_model"] == "x/z-image-turbo:latest"
+    assert generator.last_generation_metadata["seed_supported"] is False
+    assert saved_path.with_suffix(".txt").read_text(encoding="utf-8") == "A bright blue square"

--- a/tests/test_plugin_cli.py
+++ b/tests/test_plugin_cli.py
@@ -2,7 +2,7 @@
 
 from typer.testing import CliRunner
 
-from src.plugins import initialize_plugins, plugin_manager
+from src.plugins import initialize_plugins, plugin_manager, register_lora_plugin
 from src.utils.cli import app
 from src.utils.config import Config
 
@@ -28,3 +28,15 @@ def test_enable_disable_plugin_changes_state():
 
     runner.invoke(app, ["plugins", "enable", "time_of_day"])
     assert plugin_manager.plugins["time_of_day"].enabled
+
+
+def test_register_lora_plugin_preserves_runtime_state():
+    """Re-registering the LoRA plugin should not clobber runtime toggles or order."""
+    config = Config()
+    plugin_manager.disable_plugin("lora")
+    plugin_manager.set_plugin_order("lora", 9)
+
+    register_lora_plugin(config)
+
+    assert not plugin_manager.plugins["lora"].enabled
+    assert plugin_manager.plugins["lora"].order == 9

--- a/tests/test_zimage_generator.py
+++ b/tests/test_zimage_generator.py
@@ -107,6 +107,66 @@ class TestZImageGeneratorWithMockZImage:
             "scheduler": MagicMock(),
         }
 
+    def test_load_model_uses_diffsynth_when_lora_selected(self, mock_config):
+        with patch("torch.cuda.is_available", return_value=False):
+            gen = ZImageGenerator(mock_config)
+
+        lora_path = Path("/tmp/loras/test/style.safetensors")
+        with patch.object(gen, "_get_selected_lora_path", return_value=lora_path):
+            with patch.object(gen, "_load_diffsynth_pipe") as mock_diffsynth:
+                with patch.object(gen, "_load_native_components") as mock_native:
+                    gen.load_model()
+
+        mock_diffsynth.assert_called_once_with(lora_path)
+        mock_native.assert_not_called()
+
+    def test_load_model_uses_native_path_without_lora(self, mock_config):
+        with patch("torch.cuda.is_available", return_value=False):
+            gen = ZImageGenerator(mock_config)
+
+        with patch.object(gen, "_get_selected_lora_path", return_value=None):
+            with patch.object(gen, "_load_diffsynth_pipe") as mock_diffsynth:
+                with patch.object(gen, "_load_native_components") as mock_native:
+                    gen.load_model()
+
+        mock_native.assert_called_once()
+        mock_diffsynth.assert_not_called()
+        assert gen.using_diffsynth is False
+
+    def test_build_diffsynth_model_configs_expands_local_shards(self, mock_config, tmp_path):
+        model_path = tmp_path / "Z-Image-Turbo"
+        transformer_dir = model_path / "transformer"
+        text_encoder_dir = model_path / "text_encoder"
+        vae_dir = model_path / "vae"
+
+        transformer_dir.mkdir(parents=True)
+        text_encoder_dir.mkdir(parents=True)
+        vae_dir.mkdir(parents=True)
+
+        transformer_shards = [
+            transformer_dir / "diffusion_pytorch_model-00002-of-00003.safetensors",
+            transformer_dir / "diffusion_pytorch_model-00001-of-00003.safetensors",
+        ]
+        text_encoder_shards = [
+            text_encoder_dir / "model-00002-of-00003.safetensors",
+            text_encoder_dir / "model-00001-of-00003.safetensors",
+        ]
+        vae_file = vae_dir / "diffusion_pytorch_model.safetensors"
+
+        for path in [*transformer_shards, *text_encoder_shards, vae_file]:
+            path.touch()
+
+        mock_config.model.zimage_model_path = model_path
+
+        with patch("torch.cuda.is_available", return_value=False):
+            gen = ZImageGenerator(mock_config)
+
+        configs = gen._build_diffsynth_model_configs()
+
+        assert configs[0].path == sorted(str(path) for path in transformer_shards)
+        assert configs[1].path == sorted(str(path) for path in text_encoder_shards)
+        assert configs[2].path == [str(vae_file)]
+
     @pytest.mark.asyncio
     async def test_generate_with_mocked_api(self, mock_config, mock_zimage_components, tmp_path):
         """Test generation with mocked Z-Image API."""
@@ -146,6 +206,36 @@ class TestZImageGeneratorWithMockZImage:
         assert result.model == "zimage"
         assert result.seed == 42
         assert result.steps == 8
+
+    @pytest.mark.asyncio
+    async def test_generate_with_diffsynth_pipe_and_lora(self, mock_config, tmp_path):
+        """Test generation through the DiffSynth LoRA path."""
+        mock_config.system.output_dir = tmp_path
+        mock_config.image.guidance_scale = 1.0
+
+        mock_image = MagicMock()
+
+        def mock_save(path):
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            Path(path).touch()
+
+        mock_image.save = mock_save
+
+        with patch("torch.cuda.is_available", return_value=False):
+            gen = ZImageGenerator(mock_config)
+            gen.using_diffsynth = True
+            gen.pipe = MagicMock(return_value=mock_image)
+
+            result = await gen.generate(
+                prompt="A lora-enhanced dog portrait",
+                height=1024,
+                width=1024,
+                seed=7,
+            )
+
+        assert result.metadata["using_diffsynth"] is True
+        assert result.metadata["lora_backend"] == "diffsynth"
+        gen.pipe.assert_called_once()
 
 
 class TestZImageGeneratorIntegration:

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,15 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version < '3.12'",
-    "python_full_version >= '3.12'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -229,7 +236,7 @@ name = "cffi"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
 wheels = [
@@ -437,7 +444,7 @@ name = "cryptography"
 version = "45.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/35/c495bffc2056f2dadb32434f1feedd79abde2a7f8363e1974afa9c33c7e2/cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971", size = 744980, upload-time = "2025-09-01T11:15:03.146Z" }
 wheels = [
@@ -466,6 +473,32 @@ wheels = [
 ]
 
 [[package]]
+name = "datasets"
+version = "4.8.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+    { name = "filelock" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/22/73e46ac7a8c25e7ef0b3bd6f10da3465021d90219a32eb0b4d2afea4c56e/datasets-4.8.4.tar.gz", hash = "sha256:a1429ed853275ce7943a01c6d2e25475b4501eb758934362106a280470df3a52", size = 604382, upload-time = "2026-03-23T14:21:17.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/e5/247d094108e42ac26363ab8dc57f168840cf7c05774b40ffeb0d78868fcc/datasets-4.8.4-py3-none-any.whl", hash = "sha256:cdc8bee4698e549d78bf1fed6aea2eebc760b22b084f07e6fc020c6577a6ce6d", size = 526991, upload-time = "2026-03-23T14:21:15.89Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.2.18"
 source = { registry = "https://pypi.org/simple" }
@@ -475,6 +508,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744, upload-time = "2025-01-27T10:46:25.7Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998, upload-time = "2025-01-27T10:46:09.186Z" },
+]
+
+[[package]]
+name = "diffsynth"
+version = "2.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accelerate" },
+    { name = "datasets" },
+    { name = "einops" },
+    { name = "ftfy" },
+    { name = "imageio", extra = ["ffmpeg"] },
+    { name = "modelscope" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "peft" },
+    { name = "protobuf" },
+    { name = "safetensors" },
+    { name = "sentencepiece" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/11/4d292ce9328783a1aa3e767e6d78a804c0bad50b67ed09079841d7951e89/diffsynth-2.0.9.tar.gz", hash = "sha256:53b472274cb1eae26e0d86d8a6f44aca6782d2b9a0f980f4441dad4104fa390f", size = 374057, upload-time = "2026-04-15T05:53:38.158Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/73/93996a694429e83f62a3a70649f9c13d80ec5cb5cb177ff52f481984812f/diffsynth-2.0.9-py3-none-any.whl", hash = "sha256:54d97ba653417c93060a278deb86f041abb54bfa9399cb5849a67a6c9f3f4445", size = 412917, upload-time = "2026-04-15T05:53:35.196Z" },
 ]
 
 [[package]]
@@ -531,11 +590,12 @@ wheels = [
 
 [[package]]
 name = "dreamgen"
-version = "1.0.1"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
     { name = "aiofiles" },
+    { name = "diffsynth" },
     { name = "diffusers" },
     { name = "fastapi" },
     { name = "huggingface-hub", extra = ["inference"] },
@@ -592,6 +652,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=23.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "diffsynth", specifier = ">=2.0.9" },
     { name = "diffusers", git = "https://github.com/huggingface/diffusers" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "huggingface-hub", extras = ["inference"], specifier = ">=0.20.0" },
@@ -614,7 +675,7 @@ requires-dist = [
     { name = "torch", specifier = "==2.6.0+cu124", index = "https://download.pytorch.org/whl/cu124" },
     { name = "torchaudio", specifier = "==2.6.0+cu124", index = "https://download.pytorch.org/whl/cu124" },
     { name = "torchvision", specifier = "==0.21.0+cu124", index = "https://download.pytorch.org/whl/cu124" },
-    { name = "transformers", specifier = ">=4.30.0,<4.55.0" },
+    { name = "transformers", specifier = ">=4.55.0,<4.58.0" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.23.0" },
     { name = "websockets", specifier = ">=12.0" },
@@ -635,6 +696,15 @@ dev = [
     { name = "python-semantic-release", specifier = ">=9.0.0" },
     { name = "ruff", specifier = ">=0.14.10" },
     { name = "twine", specifier = ">=4.0.0" },
+]
+
+[[package]]
+name = "einops"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
 ]
 
 [[package]]
@@ -744,6 +814,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/02/0835e6ab9cfc03916fe3f78c0956cfcdb6ff2669ffa6651065d5ebf7fc98/fsspec-2025.7.0.tar.gz", hash = "sha256:786120687ffa54b8283d942929540d8bc5ccfa820deb555a2b5d0ed2b737bf58", size = 304432, upload-time = "2025-07-15T16:05:21.19Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl", hash = "sha256:8b012e39f63c7d5f10474de957f3ab793b47b45ae7d39f2fb735f8bbe25c0e21", size = 199597, upload-time = "2025-07-15T16:05:19.529Z" },
+]
+
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
+]
+
+[[package]]
+name = "ftfy"
+version = "6.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927, upload-time = "2024-10-26T00:50:35.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083", size = 44821, upload-time = "2024-10-26T00:50:33.425Z" },
 ]
 
 [[package]]
@@ -903,6 +990,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "imageio"
+version = "2.37.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0", size = 317646, upload-time = "2026-03-09T11:31:10.771Z" },
+]
+
+[package.optional-dependencies]
+ffmpeg = [
+    { name = "imageio-ffmpeg" },
+    { name = "psutil" },
+]
+
+[[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
 ]
 
 [[package]]
@@ -1111,6 +1231,23 @@ wheels = [
 ]
 
 [[package]]
+name = "modelscope"
+version = "1.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "packaging" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "tqdm" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/ed/5b2728d9213a5f63bb8c9968011345afded17b5115efd87426eb626fb2cc/modelscope-1.36.2.tar.gz", hash = "sha256:1e6cb79259f46e7142c34e693278c6b1b9bbfaa232c0ac63604647565e828297", size = 4586047, upload-time = "2026-04-24T10:38:16.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/32/4410601929e82bef05503f6701bbcc92fff65ab59859b69be7ad10bdd7ce/modelscope-1.36.2-py3-none-any.whl", hash = "sha256:0ae2a599ff0d891caac959d852649ff7c25c6c3b1830d38ad899ae1f11cd22e5", size = 6081928, upload-time = "2026-04-24T10:38:12.867Z" },
+]
+
+[[package]]
 name = "more-itertools"
 version = "10.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1207,6 +1344,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/0a/2436550b1520091af0600dff547913cb2d66fbac27a8c33bc1b1bccd8d98/multidict-6.6.4-cp313-cp313t-win_amd64.whl", hash = "sha256:6d46a180acdf6e87cc41dc15d8f5c2986e1e8739dc25dbb7dac826731ef381a4", size = 53100, upload-time = "2025-08-11T12:08:13.823Z" },
     { url = "https://files.pythonhosted.org/packages/97/ea/43ac51faff934086db9c072a94d327d71b7d8b40cd5dcb47311330929ef0/multidict-6.6.4-cp313-cp313t-win_arm64.whl", hash = "sha256:756989334015e3335d087a27331659820d53ba432befdef6a718398b0a8493ad", size = 45501, upload-time = "2025-08-11T12:08:15.173Z" },
     { url = "https://files.pythonhosted.org/packages/fd/69/b547032297c7e63ba2af494edba695d781af8a0c6e89e4d06cf848b21d80/multidict-6.6.4-py3-none-any.whl", hash = "sha256:27d8f8e125c07cb954e54d75d04905a9bba8a439c1d84aca94949d4d03d8601c", size = 12313, upload-time = "2025-08-11T12:08:46.891Z" },
+]
+
+[[package]]
+name = "multiprocess"
+version = "0.70.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/fd/2ae3826f5be24c6ed87266bc4e59c46ea5b059a103f3d7e7eb76a52aeecb/multiprocess-0.70.18.tar.gz", hash = "sha256:f9597128e6b3e67b23956da07cf3d2e5cba79e2f4e0fba8d7903636663ec6d0d", size = 1798503, upload-time = "2025-04-17T03:11:27.742Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/4d/9af0d1279c84618bcd35bf5fd7e371657358c7b0a523e54a9cffb87461f8/multiprocess-0.70.18-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:8b8940ae30139e04b076da6c5b83e9398585ebdf0f2ad3250673fef5b2ff06d6", size = 144695, upload-time = "2025-04-17T03:11:09.161Z" },
+    { url = "https://files.pythonhosted.org/packages/17/bf/87323e79dd0562474fad3373c21c66bc6c3c9963b68eb2a209deb4c8575e/multiprocess-0.70.18-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0929ba95831adb938edbd5fb801ac45e705ecad9d100b3e653946b7716cb6bd3", size = 144742, upload-time = "2025-04-17T03:11:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/74/cb8c831e58dc6d5cf450b17c7db87f14294a1df52eb391da948b5e0a0b94/multiprocess-0.70.18-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4d77f8e4bfe6c6e2e661925bbf9aed4d5ade9a1c6502d5dfc10129b9d1141797", size = 144745, upload-time = "2025-04-17T03:11:11.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/0cba6cf51a1a31f20471fbc823a716170c73012ddc4fb85d706630ed6e8f/multiprocess-0.70.18-py310-none-any.whl", hash = "sha256:60c194974c31784019c1f459d984e8f33ee48f10fcf42c309ba97b30d9bd53ea", size = 134948, upload-time = "2025-04-17T03:11:20.223Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/88/9039f2fed1012ef584751d4ceff9ab4a51e5ae264898f0b7cbf44340a859/multiprocess-0.70.18-py311-none-any.whl", hash = "sha256:5aa6eef98e691281b3ad923be2832bf1c55dd2c859acd73e5ec53a66aae06a1d", size = 144462, upload-time = "2025-04-17T03:11:21.657Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b6/5f922792be93b82ec6b5f270bbb1ef031fd0622847070bbcf9da816502cc/multiprocess-0.70.18-py312-none-any.whl", hash = "sha256:9b78f8e5024b573730bfb654783a13800c2c0f2dfc0c25e70b40d184d64adaa2", size = 150287, upload-time = "2025-04-17T03:11:22.69Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/25/7d7e78e750bc1aecfaf0efbf826c69a791d2eeaf29cf20cba93ff4cced78/multiprocess-0.70.18-py313-none-any.whl", hash = "sha256:871743755f43ef57d7910a38433cfe41319e72be1bbd90b79c7a5ac523eb9334", size = 151917, upload-time = "2025-04-17T03:11:24.044Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c3/ca84c19bd14cdfc21c388fdcebf08b86a7a470ebc9f5c3c084fc2dbc50f7/multiprocess-0.70.18-py38-none-any.whl", hash = "sha256:dbf705e52a154fe5e90fb17b38f02556169557c2dd8bb084f2e06c2784d8279b", size = 132636, upload-time = "2025-04-17T03:11:24.936Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/28/dd72947e59a6a8c856448a5e74da6201cb5502ddff644fbc790e4bd40b9a/multiprocess-0.70.18-py39-none-any.whl", hash = "sha256:e78ca805a72b1b810c690b6b4cc32579eba34f403094bbbae962b7b5bf9dfcb8", size = 133478, upload-time = "2025-04-17T03:11:26.253Z" },
 ]
 
 [[package]]
@@ -1425,7 +1582,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.1.0.70"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/fd/713452cd72343f682b1c7b9321e23829f00b842ceaedcda96e742ea0b0b3/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl", hash = "sha256:165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f", size = 664752741, upload-time = "2024-04-22T15:24:15.253Z" },
@@ -1436,7 +1593,7 @@ name = "nvidia-cufft-cu12"
 version = "11.2.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/94/3266821f65b92b3138631e9c8e7fe1fb513804ac934485a8d05776e1dd43/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f083fc24912aa410be21fa16d157fed2055dab1cc4b6934a0e03cba69eb242b9", size = 211459117, upload-time = "2024-04-03T20:57:40.402Z" },
@@ -1455,9 +1612,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.6.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/e1/5b9089a4b2a4790dfdea8b3a006052cfecff58139d5a4e34cb1a51df8d6f/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl", hash = "sha256:19e33fa442bcfd085b3086c4ebf7e8debc07cfe01e11513cc6d332fd918ac260", size = 127936057, upload-time = "2024-04-03T20:58:28.735Z" },
@@ -1468,7 +1625,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.3.1.170"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/f7/97a9ea26ed4bbbfc2d470994b8b4f338ef663be97b8f677519ac195e113d/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ea4f11a2904e2a8dc4b1833cc1b5181cde564edd0d5cd33e3c168eff2d1863f1", size = 207454763, upload-time = "2024-04-03T20:58:59.995Z" },
@@ -1526,6 +1683,133 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.14'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.14'" },
+    { name = "pytz", marker = "python_full_version >= '3.14'" },
+    { name = "tzdata", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
+    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635, upload-time = "2025-09-29T23:25:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079, upload-time = "2025-09-29T23:26:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049, upload-time = "2025-09-29T23:27:15.384Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638, upload-time = "2025-09-29T23:27:51.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834, upload-time = "2025-09-29T23:28:21.289Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925, upload-time = "2025-09-29T23:28:58.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071, upload-time = "2025-09-29T23:32:27.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504, upload-time = "2025-09-29T23:29:31.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702, upload-time = "2025-09-29T23:29:54.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535, upload-time = "2025-09-29T23:30:21.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
+    { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
+    { name = "tzdata", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/35/6411db530c618e0e0005187e35aa02ce60ae4c4c4d206964a2f978217c27/pandas-3.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a727a73cbdba2f7458dc82449e2315899d5140b449015d822f515749a46cbbe0", size = 10326926, upload-time = "2026-03-31T06:46:08.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/d3/b7da1d5d7dbdc5ef52ed7debd2b484313b832982266905315dad5a0bf0b1/pandas-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dbbd4aa20ca51e63b53bbde6a0fa4254b1aaabb74d2f542df7a7959feb1d760c", size = 9926987, upload-time = "2026-03-31T06:46:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/52/77/9b1c2d6070b5dbe239a7bc889e21bfa58720793fb902d1e070695d87c6d0/pandas-3.0.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:339dda302bd8369dedeae979cb750e484d549b563c3f54f3922cb8ff4978c5eb", size = 10757067, upload-time = "2026-03-31T06:46:14.903Z" },
+    { url = "https://files.pythonhosted.org/packages/20/17/ec40d981705654853726e7ac9aea9ddbb4a5d9cf54d8472222f4f3de06c2/pandas-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61c2fd96d72b983a9891b2598f286befd4ad262161a609c92dc1652544b46b76", size = 11258787, upload-time = "2026-03-31T06:46:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e3/3f1126d43d3702ca8773871a81c9f15122a1f412342cc56284ffda5b1f70/pandas-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c934008c733b8bbea273ea308b73b3156f0181e5b72960790b09c18a2794fe1e", size = 11771616, upload-time = "2026-03-31T06:46:20.532Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cf/0f4e268e1f5062e44a6bda9f925806721cd4c95c2b808a4c82ebe914f96b/pandas-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:60a80bb4feacbef5e1447a3f82c33209c8b7e07f28d805cfd1fb951e5cb443aa", size = 12337623, upload-time = "2026-03-31T06:46:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/97a6339859d4acb2536efb24feb6708e82f7d33b2ed7e036f2983fcced82/pandas-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:ed72cb3f45190874eb579c64fa92d9df74e98fd63e2be7f62bce5ace0ade61df", size = 9897372, upload-time = "2026-03-31T06:46:26.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/eb/781516b808a99ddf288143cec46b342b3016c3414d137da1fdc3290d8860/pandas-3.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:f12b1a9e332c01e09510586f8ca9b108fd631fd656af82e452d7315ef6df5f9f", size = 9154922, upload-time = "2026-03-31T06:46:30.284Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b0/c20bd4d6d3f736e6bd6b55794e9cd0a617b858eaad27c8f410ea05d953b7/pandas-3.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:232a70ebb568c0c4d2db4584f338c1577d81e3af63292208d615907b698a0f18", size = 10347921, upload-time = "2026-03-31T06:46:33.36Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d0/4831af68ce30cc2d03c697bea8450e3225a835ef497d0d70f31b8cdde965/pandas-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:970762605cff1ca0d3f71ed4f3a769ea8f85fc8e6348f6e110b8fea7e6eb5a14", size = 9888127, upload-time = "2026-03-31T06:46:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a9/16ea9346e1fc4a96e2896242d9bc674764fb9049b0044c0132502f7a771e/pandas-3.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aff4e6f4d722e0652707d7bcb190c445fe58428500c6d16005b02401764b1b3d", size = 10399577, upload-time = "2026-03-31T06:46:39.224Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a8/3a61a721472959ab0ce865ef05d10b0d6bfe27ce8801c99f33d4fa996e65/pandas-3.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef8b27695c3d3dc78403c9a7d5e59a62d5464a7e1123b4e0042763f7104dc74f", size = 10880030, upload-time = "2026-03-31T06:46:42.412Z" },
+    { url = "https://files.pythonhosted.org/packages/da/65/7225c0ea4d6ce9cb2160a7fb7f39804871049f016e74782e5dade4d14109/pandas-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f8d68083e49e16b84734eb1a4dcae4259a75c90fb6e2251ab9a00b61120c06ab", size = 11409468, upload-time = "2026-03-31T06:46:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/46e7c76032639f2132359b5cf4c785dd8cf9aea5ea64699eac752f02b9db/pandas-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32cc41f310ebd4a296d93515fcac312216adfedb1894e879303987b8f1e2b97d", size = 11936381, upload-time = "2026-03-31T06:46:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/8b/721a9cff6fa6a91b162eb51019c6243b82b3226c71bb6c8ef4a9bd65cbc6/pandas-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a4785e1d6547d8427c5208b748ae2efb64659a21bd82bf440d4262d02bfa02a4", size = 9744993, upload-time = "2026-03-31T06:46:51.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/18/7f0bd34ae27b28159aa80f2a6799f47fda34f7fb938a76e20c7b7fe3b200/pandas-3.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:08504503f7101300107ecdc8df73658e4347586db5cfdadabc1592e9d7e7a0fd", size = 9056118, upload-time = "2026-03-31T06:46:54.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
 ]
 
 [[package]]
@@ -1779,6 +2063,56 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1946,6 +2280,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1998,6 +2344,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/af/75/fb578d1805dc482f619c82431b398ab3c0489817a1cdbe2fa1be48d3d7d3/python_semantic_release-10.3.1.tar.gz", hash = "sha256:16003292315ee29b6ad424fad9745946422cf965e19649269c4e2fb8271cb267", size = 323536, upload-time = "2025-08-06T04:41:10.135Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/49/0a74aafd0da45a7ee2c38b82112d576ee48a6795d813c8025cdf9cbaf159/python_semantic_release-10.3.1-py3-none-any.whl", hash = "sha256:b2677018e761dfbfdf5758eeee6b09963e136d67c43059f12f9bc6c441fcbf13", size = 142065, upload-time = "2025-08-06T04:41:08.056Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
 ]
 
 [[package]]
@@ -2224,8 +2579,8 @@ name = "secretstorage"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload-time = "2022-08-13T16:22:46.976Z" }
 wheels = [
@@ -2307,6 +2662,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2351,27 +2715,28 @@ wheels = [
 
 [[package]]
 name = "tokenizers"
-version = "0.21.4"
+version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/2f/402986d0823f8d7ca139d969af2917fefaa9b947d1fb32f6168c509f2492/tokenizers-0.21.4.tar.gz", hash = "sha256:fa23f85fbc9a02ec5c6978da172cdcbac23498c3ca9f3645c5c68740ac007880", size = 351253, upload-time = "2025-07-28T15:48:54.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/c6/fdb6f72bf6454f52eb4a2510be7fb0f614e541a2554d6210e370d85efff4/tokenizers-0.21.4-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2ccc10a7c3bcefe0f242867dc914fc1226ee44321eb618cfe3019b5df3400133", size = 2863987, upload-time = "2025-07-28T15:48:44.877Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a6/28975479e35ddc751dc1ddc97b9b69bf7fcf074db31548aab37f8116674c/tokenizers-0.21.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:5e2f601a8e0cd5be5cc7506b20a79112370b9b3e9cb5f13f68ab11acd6ca7d60", size = 2732457, upload-time = "2025-07-28T15:48:43.265Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/8f/24f39d7b5c726b7b0be95dca04f344df278a3fe3a4deb15a975d194cbb32/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39b376f5a1aee67b4d29032ee85511bbd1b99007ec735f7f35c8a2eb104eade5", size = 3012624, upload-time = "2025-07-28T13:22:43.895Z" },
-    { url = "https://files.pythonhosted.org/packages/58/47/26358925717687a58cb74d7a508de96649544fad5778f0cd9827398dc499/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2107ad649e2cda4488d41dfd031469e9da3fcbfd6183e74e4958fa729ffbf9c6", size = 2939681, upload-time = "2025-07-28T13:22:47.499Z" },
-    { url = "https://files.pythonhosted.org/packages/99/6f/cc300fea5db2ab5ddc2c8aea5757a27b89c84469899710c3aeddc1d39801/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c73012da95afafdf235ba80047699df4384fdc481527448a078ffd00e45a7d9", size = 3247445, upload-time = "2025-07-28T15:48:39.711Z" },
-    { url = "https://files.pythonhosted.org/packages/be/bf/98cb4b9c3c4afd8be89cfa6423704337dc20b73eb4180397a6e0d456c334/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f23186c40395fc390d27f519679a58023f368a0aad234af145e0f39ad1212732", size = 3428014, upload-time = "2025-07-28T13:22:49.569Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c7/96c1cc780e6ca7f01a57c13235dd05b7bc1c0f3588512ebe9d1331b5f5ae/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc88bb34e23a54cc42713d6d98af5f1bf79c07653d24fe984d2d695ba2c922a2", size = 3193197, upload-time = "2025-07-28T13:22:51.471Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/90/273b6c7ec78af547694eddeea9e05de771278bd20476525ab930cecaf7d8/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51b7eabb104f46c1c50b486520555715457ae833d5aee9ff6ae853d1130506ff", size = 3115426, upload-time = "2025-07-28T15:48:41.439Z" },
-    { url = "https://files.pythonhosted.org/packages/91/43/c640d5a07e95f1cf9d2c92501f20a25f179ac53a4f71e1489a3dcfcc67ee/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:714b05b2e1af1288bd1bc56ce496c4cebb64a20d158ee802887757791191e6e2", size = 9089127, upload-time = "2025-07-28T15:48:46.472Z" },
-    { url = "https://files.pythonhosted.org/packages/44/a1/dd23edd6271d4dca788e5200a807b49ec3e6987815cd9d0a07ad9c96c7c2/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1340ff877ceedfa937544b7d79f5b7becf33a4cfb58f89b3b49927004ef66f78", size = 9055243, upload-time = "2025-07-28T15:48:48.539Z" },
-    { url = "https://files.pythonhosted.org/packages/21/2b/b410d6e9021c4b7ddb57248304dc817c4d4970b73b6ee343674914701197/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3c1f4317576e465ac9ef0d165b247825a2a4078bcd01cba6b54b867bdf9fdd8b", size = 9298237, upload-time = "2025-07-28T15:48:50.443Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/0a/42348c995c67e2e6e5c89ffb9cfd68507cbaeb84ff39c49ee6e0a6dd0fd2/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c212aa4e45ec0bb5274b16b6f31dd3f1c41944025c2358faaa5782c754e84c24", size = 9461980, upload-time = "2025-07-28T15:48:52.325Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/d3/dacccd834404cd71b5c334882f3ba40331ad2120e69ded32cf5fda9a7436/tokenizers-0.21.4-cp39-abi3-win32.whl", hash = "sha256:6c42a930bc5f4c47f4ea775c91de47d27910881902b0f20e4990ebe045a415d0", size = 2329871, upload-time = "2025-07-28T15:48:56.841Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f2/fd673d979185f5dcbac4be7d09461cbb99751554ffb6718d0013af8604cb/tokenizers-0.21.4-cp39-abi3-win_amd64.whl", hash = "sha256:475d807a5c3eb72c59ad9b5fcdb254f6e17f53dfcbb9903233b0dfa9c943b597", size = 2507568, upload-time = "2025-07-28T15:48:55.456Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]
@@ -2450,13 +2815,13 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp311-cp311-linux_x86_64.whl", hash = "sha256:d4c3e9a8d31a7c0fcbb9da17c31a1917e1fac26c566a4cfbd8c9568ad7cade79" },
-    { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp311-cp311-win_amd64.whl", hash = "sha256:6a1fb2714e9323f11edb6e8abf7aad5f79e45ad25c081cde87681a18d99c29eb" },
-    { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl", hash = "sha256:a393b506844035c0dac2f30ea8478c343b8e95a429f06f3b3cadfc7f53adb597" },
-    { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl", hash = "sha256:3313061c1fec4c7310cf47944e84513dcd27b6173b72a349bb7ca68d0ee6e9c0" },
-    { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:0f3bc53c988ce9568cd876a2a5316761e84a8704135ec8068f5f81b4417979cb" },
-    { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:519330eef09534acad8110b6f423d2fe58c1d8e9ada999ed077a637a0021f908" },
-    { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313t-linux_x86_64.whl", hash = "sha256:35cba404c0d742406cdcba1609085874bc60facdfbc50e910c47a92405fef44c" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp311-cp311-linux_x86_64.whl", hash = "sha256:d4c3e9a8d31a7c0fcbb9da17c31a1917e1fac26c566a4cfbd8c9568ad7cade79", upload-time = "2025-01-30T00:55:01Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp311-cp311-win_amd64.whl", hash = "sha256:6a1fb2714e9323f11edb6e8abf7aad5f79e45ad25c081cde87681a18d99c29eb", upload-time = "2025-01-30T00:55:31Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl", hash = "sha256:a393b506844035c0dac2f30ea8478c343b8e95a429f06f3b3cadfc7f53adb597", upload-time = "2025-01-30T00:57:08Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl", hash = "sha256:3313061c1fec4c7310cf47944e84513dcd27b6173b72a349bb7ca68d0ee6e9c0", upload-time = "2025-01-30T00:57:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:0f3bc53c988ce9568cd876a2a5316761e84a8704135ec8068f5f81b4417979cb", upload-time = "2025-01-30T00:59:14Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:519330eef09534acad8110b6f423d2fe58c1d8e9ada999ed077a637a0021f908", upload-time = "2025-01-30T00:59:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313t-linux_x86_64.whl", hash = "sha256:35cba404c0d742406cdcba1609085874bc60facdfbc50e910c47a92405fef44c", upload-time = "2025-01-30T01:01:25Z" },
 ]
 
 [[package]]
@@ -2467,12 +2832,12 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp311-cp311-linux_x86_64.whl", hash = "sha256:b8c15d7e0e81a23630a2de552ebacfe6643990dc890f83f426e43ff62efe8651" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp311-cp311-win_amd64.whl", hash = "sha256:a25e146ce66ea9a6aed39008cc2001891bdf75253af479a4c32096678b2073b3" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl", hash = "sha256:3e5ffa69606171c74f3e2b969785ead50b782ca657e746aaee1ee7cc88dcfc08" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl", hash = "sha256:004ff6bcee0ac78747253c09db67d281add4308a9b87a7bf1769da5914998639" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:1bc23963f447c910a0060b130b04b407d2ea218b2a553e674c829d5f17eb8c8e" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:231eddbfd8bafd06b2c9f55cd6f33e61f58b25b19f2d51382a95e8f12887689f" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp311-cp311-linux_x86_64.whl", hash = "sha256:b8c15d7e0e81a23630a2de552ebacfe6643990dc890f83f426e43ff62efe8651", upload-time = "2025-01-30T01:04:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp311-cp311-win_amd64.whl", hash = "sha256:a25e146ce66ea9a6aed39008cc2001891bdf75253af479a4c32096678b2073b3", upload-time = "2025-01-30T01:04:24Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl", hash = "sha256:3e5ffa69606171c74f3e2b969785ead50b782ca657e746aaee1ee7cc88dcfc08", upload-time = "2025-01-30T01:04:24Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl", hash = "sha256:004ff6bcee0ac78747253c09db67d281add4308a9b87a7bf1769da5914998639", upload-time = "2025-01-30T01:04:24Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:1bc23963f447c910a0060b130b04b407d2ea218b2a553e674c829d5f17eb8c8e", upload-time = "2025-01-30T01:04:25Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchaudio-2.6.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:231eddbfd8bafd06b2c9f55cd6f33e61f58b25b19f2d51382a95e8f12887689f", upload-time = "2025-01-30T01:04:26Z" },
 ]
 
 [[package]]
@@ -2485,12 +2850,12 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp311-cp311-linux_x86_64.whl", hash = "sha256:137376805aca5ba57bd2c7a3ecb8569df961dbe82b128aac9b3b0a7125ef9385" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp311-cp311-win_amd64.whl", hash = "sha256:000a013584ad2304ab30496318145f284ac364622addb5ee3a5abd2769ba146f" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp312-cp312-linux_x86_64.whl", hash = "sha256:efb53ea0af7bf09b7b53e2a18b9be6d245f7d46a90b51d5cf97f37e9b929a991" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp312-cp312-win_amd64.whl", hash = "sha256:ec63c2ee792757492da40590e34b14f2fceda29050558c215f0c1f3b08149c0f" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:4b70acf3b4b96a0ceb1374116626c9bef9e8be016b57b1284e482260ca1896d6" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:8fcf55321b206de70ff8e01c884fa42e57a60b1cb749341b96e0f22c8a7c9ec7" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp311-cp311-linux_x86_64.whl", hash = "sha256:137376805aca5ba57bd2c7a3ecb8569df961dbe82b128aac9b3b0a7125ef9385", upload-time = "2025-01-30T01:04:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp311-cp311-win_amd64.whl", hash = "sha256:000a013584ad2304ab30496318145f284ac364622addb5ee3a5abd2769ba146f", upload-time = "2025-01-30T01:04:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp312-cp312-linux_x86_64.whl", hash = "sha256:efb53ea0af7bf09b7b53e2a18b9be6d245f7d46a90b51d5cf97f37e9b929a991", upload-time = "2025-01-30T01:04:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp312-cp312-win_amd64.whl", hash = "sha256:ec63c2ee792757492da40590e34b14f2fceda29050558c215f0c1f3b08149c0f", upload-time = "2025-01-30T01:04:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:4b70acf3b4b96a0ceb1374116626c9bef9e8be016b57b1284e482260ca1896d6", upload-time = "2025-01-30T01:04:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:8fcf55321b206de70ff8e01c884fa42e57a60b1cb749341b96e0f22c8a7c9ec7", upload-time = "2025-01-30T01:04:31Z" },
 ]
 
 [[package]]
@@ -2507,7 +2872,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.54.1"
+version = "4.57.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -2521,9 +2886,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/6c/4caeb57926f91d943f309b062e22ad1eb24a9f530421c5a65c1d89378a7a/transformers-4.54.1.tar.gz", hash = "sha256:b2551bb97903f13bd90c9467d0a144d41ca4d142defc044a99502bb77c5c1052", size = 9514288, upload-time = "2025-07-29T15:57:22.826Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/18/eb7578f84ef5a080d4e5ca9bc4f7c68e7aa9c1e464f1b3d3001e4c642fce/transformers-4.54.1-py3-none-any.whl", hash = "sha256:c89965a4f62a0d07009d45927a9c6372848a02ab9ead9c318c3d082708bab529", size = 11176397, upload-time = "2025-07-29T15:57:19.692Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
 ]
 
 [[package]]
@@ -2590,6 +2955,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
 ]
 
 [[package]]
@@ -2750,6 +3124,15 @@ wheels = [
 ]
 
 [[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2857,6 +3240,109 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160, upload-time = "2025-10-02T14:37:08.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/d4/cc2f0400e9154df4b9964249da78ebd72f318e35ccc425e9f403c392f22a/xxhash-3.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b47bbd8cf2d72797f3c2772eaaac0ded3d3af26481a26d7d7d41dc2d3c46b04a", size = 32844, upload-time = "2025-10-02T14:34:14.037Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ec/1cc11cd13e26ea8bc3cb4af4eaadd8d46d5014aebb67be3f71fb0b68802a/xxhash-3.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2b6821e94346f96db75abaa6e255706fb06ebd530899ed76d32cd99f20dc52fa", size = 30809, upload-time = "2025-10-02T14:34:15.484Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5f/19fe357ea348d98ca22f456f75a30ac0916b51c753e1f8b2e0e6fb884cce/xxhash-3.6.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d0a9751f71a1a65ce3584e9cae4467651c7e70c9d31017fa57574583a4540248", size = 194665, upload-time = "2025-10-02T14:34:16.541Z" },
+    { url = "https://files.pythonhosted.org/packages/90/3b/d1f1a8f5442a5fd8beedae110c5af7604dc37349a8e16519c13c19a9a2de/xxhash-3.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b29ee68625ab37b04c0b40c3fafdf24d2f75ccd778333cfb698f65f6c463f62", size = 213550, upload-time = "2025-10-02T14:34:17.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ef/3a9b05eb527457d5db13a135a2ae1a26c80fecd624d20f3e8dcc4cb170f3/xxhash-3.6.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6812c25fe0d6c36a46ccb002f40f27ac903bf18af9f6dd8f9669cb4d176ab18f", size = 212384, upload-time = "2025-10-02T14:34:19.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/18/ccc194ee698c6c623acbf0f8c2969811a8a4b6185af5e824cd27b9e4fd3e/xxhash-3.6.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4ccbff013972390b51a18ef1255ef5ac125c92dc9143b2d1909f59abc765540e", size = 445749, upload-time = "2025-10-02T14:34:20.659Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/86/cf2c0321dc3940a7aa73076f4fd677a0fb3e405cb297ead7d864fd90847e/xxhash-3.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:297b7fbf86c82c550e12e8fb71968b3f033d27b874276ba3624ea868c11165a8", size = 193880, upload-time = "2025-10-02T14:34:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fb/96213c8560e6f948a1ecc9a7613f8032b19ee45f747f4fca4eb31bb6d6ed/xxhash-3.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dea26ae1eb293db089798d3973a5fc928a18fdd97cc8801226fae705b02b14b0", size = 210912, upload-time = "2025-10-02T14:34:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/40/aa/4395e669b0606a096d6788f40dbdf2b819d6773aa290c19e6e83cbfc312f/xxhash-3.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7a0b169aafb98f4284f73635a8e93f0735f9cbde17bd5ec332480484241aaa77", size = 198654, upload-time = "2025-10-02T14:34:25.644Z" },
+    { url = "https://files.pythonhosted.org/packages/67/74/b044fcd6b3d89e9b1b665924d85d3f400636c23590226feb1eb09e1176ce/xxhash-3.6.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:08d45aef063a4531b785cd72de4887766d01dc8f362a515693df349fdb825e0c", size = 210867, upload-time = "2025-10-02T14:34:27.203Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fd/3ce73bf753b08cb19daee1eb14aa0d7fe331f8da9c02dd95316ddfe5275e/xxhash-3.6.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:929142361a48ee07f09121fe9e96a84950e8d4df3bb298ca5d88061969f34d7b", size = 414012, upload-time = "2025-10-02T14:34:28.409Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b3/5a4241309217c5c876f156b10778f3ab3af7ba7e3259e6d5f5c7d0129eb2/xxhash-3.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:51312c768403d8540487dbbfb557454cfc55589bbde6424456951f7fcd4facb3", size = 191409, upload-time = "2025-10-02T14:34:29.696Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/99bfbc15fb9abb9a72b088c1d95219fc4782b7d01fc835bd5744d66dd0b8/xxhash-3.6.0-cp311-cp311-win32.whl", hash = "sha256:d1927a69feddc24c987b337ce81ac15c4720955b667fe9b588e02254b80446fd", size = 30574, upload-time = "2025-10-02T14:34:31.028Z" },
+    { url = "https://files.pythonhosted.org/packages/65/79/9d24d7f53819fe301b231044ea362ce64e86c74f6e8c8e51320de248b3e5/xxhash-3.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:26734cdc2d4ffe449b41d186bbeac416f704a482ed835d375a5c0cb02bc63fef", size = 31481, upload-time = "2025-10-02T14:34:32.062Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4e/15cd0e3e8772071344eab2961ce83f6e485111fed8beb491a3f1ce100270/xxhash-3.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:d72f67ef8bf36e05f5b6c65e8524f265bd61071471cd4cf1d36743ebeeeb06b7", size = 27861, upload-time = "2025-10-02T14:34:33.555Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/d9412f3d7d462347e4511181dea65e47e0d0e16e26fbee2ea86a2aefb657/xxhash-3.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:01362c4331775398e7bb34e3ab403bc9ee9f7c497bc7dee6272114055277dd3c", size = 32744, upload-time = "2025-10-02T14:34:34.622Z" },
+    { url = "https://files.pythonhosted.org/packages/79/35/0429ee11d035fc33abe32dca1b2b69e8c18d236547b9a9b72c1929189b9a/xxhash-3.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b7b2df81a23f8cb99656378e72501b2cb41b1827c0f5a86f87d6b06b69f9f204", size = 30816, upload-time = "2025-10-02T14:34:36.043Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f2/57eb99aa0f7d98624c0932c5b9a170e1806406cdbcdb510546634a1359e0/xxhash-3.6.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:dc94790144e66b14f67b10ac8ed75b39ca47536bf8800eb7c24b50271ea0c490", size = 194035, upload-time = "2025-10-02T14:34:37.354Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ed/6224ba353690d73af7a3f1c7cdb1fc1b002e38f783cb991ae338e1eb3d79/xxhash-3.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93f107c673bccf0d592cdba077dedaf52fe7f42dcd7676eba1f6d6f0c3efffd2", size = 212914, upload-time = "2025-10-02T14:34:38.6Z" },
+    { url = "https://files.pythonhosted.org/packages/38/86/fb6b6130d8dd6b8942cc17ab4d90e223653a89aa32ad2776f8af7064ed13/xxhash-3.6.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2aa5ee3444c25b69813663c9f8067dcfaa2e126dc55e8dddf40f4d1c25d7effa", size = 212163, upload-time = "2025-10-02T14:34:39.872Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/e84875682b0593e884ad73b2d40767b5790d417bde603cceb6878901d647/xxhash-3.6.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7f99123f0e1194fa59cc69ad46dbae2e07becec5df50a0509a808f90a0f03f0", size = 445411, upload-time = "2025-10-02T14:34:41.569Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4f/426f91b96701ec2f37bb2b8cec664eff4f658a11f3fa9d94f0a887ea6d2b/xxhash-3.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49e03e6fe2cac4a1bc64952dd250cf0dbc5ef4ebb7b8d96bce82e2de163c82a2", size = 193883, upload-time = "2025-10-02T14:34:43.249Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5a/ddbb83eee8e28b778eacfc5a85c969673e4023cdeedcfcef61f36731610b/xxhash-3.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bd17fede52a17a4f9a7bc4472a5867cb0b160deeb431795c0e4abe158bc784e9", size = 210392, upload-time = "2025-10-02T14:34:45.042Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c2/ff69efd07c8c074ccdf0a4f36fcdd3d27363665bcdf4ba399abebe643465/xxhash-3.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6fb5f5476bef678f69db04f2bd1efbed3030d2aba305b0fc1773645f187d6a4e", size = 197898, upload-time = "2025-10-02T14:34:46.302Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ca/faa05ac19b3b622c7c9317ac3e23954187516298a091eb02c976d0d3dd45/xxhash-3.6.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:843b52f6d88071f87eba1631b684fcb4b2068cd2180a0224122fe4ef011a9374", size = 210655, upload-time = "2025-10-02T14:34:47.571Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/7a/06aa7482345480cc0cb597f5c875b11a82c3953f534394f620b0be2f700c/xxhash-3.6.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7d14a6cfaf03b1b6f5f9790f76880601ccc7896aff7ab9cd8978a939c1eb7e0d", size = 414001, upload-time = "2025-10-02T14:34:49.273Z" },
+    { url = "https://files.pythonhosted.org/packages/23/07/63ffb386cd47029aa2916b3d2f454e6cc5b9f5c5ada3790377d5430084e7/xxhash-3.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:418daf3db71e1413cfe211c2f9a528456936645c17f46b5204705581a45390ae", size = 191431, upload-time = "2025-10-02T14:34:50.798Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/93/14fde614cadb4ddf5e7cebf8918b7e8fac5ae7861c1875964f17e678205c/xxhash-3.6.0-cp312-cp312-win32.whl", hash = "sha256:50fc255f39428a27299c20e280d6193d8b63b8ef8028995323bf834a026b4fbb", size = 30617, upload-time = "2025-10-02T14:34:51.954Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5d/0d125536cbe7565a83d06e43783389ecae0c0f2ed037b48ede185de477c0/xxhash-3.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:c0f2ab8c715630565ab8991b536ecded9416d615538be8ecddce43ccf26cbc7c", size = 31534, upload-time = "2025-10-02T14:34:53.276Z" },
+    { url = "https://files.pythonhosted.org/packages/54/85/6ec269b0952ec7e36ba019125982cf11d91256a778c7c3f98a4c5043d283/xxhash-3.6.0-cp312-cp312-win_arm64.whl", hash = "sha256:eae5c13f3bc455a3bbb68bdc513912dc7356de7e2280363ea235f71f54064829", size = 27876, upload-time = "2025-10-02T14:34:54.371Z" },
+    { url = "https://files.pythonhosted.org/packages/33/76/35d05267ac82f53ae9b0e554da7c5e281ee61f3cad44c743f0fcd354f211/xxhash-3.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:599e64ba7f67472481ceb6ee80fa3bd828fd61ba59fb11475572cc5ee52b89ec", size = 32738, upload-time = "2025-10-02T14:34:55.839Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/3fbce1cd96534a95e35d5120637bf29b0d7f5d8fa2f6374e31b4156dd419/xxhash-3.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d8b8aaa30fca4f16f0c84a5c8d7ddee0e25250ec2796c973775373257dde8f1", size = 30821, upload-time = "2025-10-02T14:34:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ea/d387530ca7ecfa183cb358027f1833297c6ac6098223fd14f9782cd0015c/xxhash-3.6.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d597acf8506d6e7101a4a44a5e428977a51c0fadbbfd3c39650cca9253f6e5a6", size = 194127, upload-time = "2025-10-02T14:34:59.21Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/0c/71435dcb99874b09a43b8d7c54071e600a7481e42b3e3ce1eb5226a5711a/xxhash-3.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:858dc935963a33bc33490128edc1c12b0c14d9c7ebaa4e387a7869ecc4f3e263", size = 212975, upload-time = "2025-10-02T14:35:00.816Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7a/c2b3d071e4bb4a90b7057228a99b10d51744878f4a8a6dd643c8bd897620/xxhash-3.6.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba284920194615cb8edf73bf52236ce2e1664ccd4a38fdb543506413529cc546", size = 212241, upload-time = "2025-10-02T14:35:02.207Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/640b6eac0128e215f177df99eadcd0f1b7c42c274ab6a394a05059694c5a/xxhash-3.6.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b54219177f6c6674d5378bd862c6aedf64725f70dd29c472eaae154df1a2e89", size = 445471, upload-time = "2025-10-02T14:35:03.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1e/3c3d3ef071b051cc3abbe3721ffb8365033a172613c04af2da89d5548a87/xxhash-3.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42c36dd7dbad2f5238950c377fcbf6811b1cdb1c444fab447960030cea60504d", size = 193936, upload-time = "2025-10-02T14:35:05.013Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/bd/4a5f68381939219abfe1c22a9e3a5854a4f6f6f3c4983a87d255f21f2e5d/xxhash-3.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f22927652cba98c44639ffdc7aaf35828dccf679b10b31c4ad72a5b530a18eb7", size = 210440, upload-time = "2025-10-02T14:35:06.239Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/37/b80fe3d5cfb9faff01a02121a0f4d565eb7237e9e5fc66e73017e74dcd36/xxhash-3.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b45fad44d9c5c119e9c6fbf2e1c656a46dc68e280275007bbfd3d572b21426db", size = 197990, upload-time = "2025-10-02T14:35:07.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/fd/2c0a00c97b9e18f72e1f240ad4e8f8a90fd9d408289ba9c7c495ed7dc05c/xxhash-3.6.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6f2580ffab1a8b68ef2b901cde7e55fa8da5e4be0977c68f78fc80f3c143de42", size = 210689, upload-time = "2025-10-02T14:35:09.438Z" },
+    { url = "https://files.pythonhosted.org/packages/93/86/5dd8076a926b9a95db3206aba20d89a7fc14dd5aac16e5c4de4b56033140/xxhash-3.6.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40c391dd3cd041ebc3ffe6f2c862f402e306eb571422e0aa918d8070ba31da11", size = 414068, upload-time = "2025-10-02T14:35:11.162Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3c/0bb129170ee8f3650f08e993baee550a09593462a5cddd8e44d0011102b1/xxhash-3.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f205badabde7aafd1a31e8ca2a3e5a763107a71c397c4481d6a804eb5063d8bd", size = 191495, upload-time = "2025-10-02T14:35:12.971Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3a/6797e0114c21d1725e2577508e24006fd7ff1d8c0c502d3b52e45c1771d8/xxhash-3.6.0-cp313-cp313-win32.whl", hash = "sha256:2577b276e060b73b73a53042ea5bd5203d3e6347ce0d09f98500f418a9fcf799", size = 30620, upload-time = "2025-10-02T14:35:14.129Z" },
+    { url = "https://files.pythonhosted.org/packages/86/15/9bc32671e9a38b413a76d24722a2bf8784a132c043063a8f5152d390b0f9/xxhash-3.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:757320d45d2fbcce8f30c42a6b2f47862967aea7bf458b9625b4bbe7ee390392", size = 31542, upload-time = "2025-10-02T14:35:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c5/cc01e4f6188656e56112d6a8e0dfe298a16934b8c47a247236549a3f7695/xxhash-3.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:457b8f85dec5825eed7b69c11ae86834a018b8e3df5e77783c999663da2f96d6", size = 27880, upload-time = "2025-10-02T14:35:16.315Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/30/25e5321c8732759e930c555176d37e24ab84365482d257c3b16362235212/xxhash-3.6.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a42e633d75cdad6d625434e3468126c73f13f7584545a9cf34e883aa1710e702", size = 32956, upload-time = "2025-10-02T14:35:17.413Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3c/0573299560d7d9f8ab1838f1efc021a280b5ae5ae2e849034ef3dee18810/xxhash-3.6.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:568a6d743219e717b07b4e03b0a828ce593833e498c3b64752e0f5df6bfe84db", size = 31072, upload-time = "2025-10-02T14:35:18.844Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1c/52d83a06e417cd9d4137722693424885cc9878249beb3a7c829e74bf7ce9/xxhash-3.6.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bec91b562d8012dae276af8025a55811b875baace6af510412a5e58e3121bc54", size = 196409, upload-time = "2025-10-02T14:35:20.31Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/8e/c6d158d12a79bbd0b878f8355432075fc82759e356ab5a111463422a239b/xxhash-3.6.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78e7f2f4c521c30ad5e786fdd6bae89d47a32672a80195467b5de0480aa97b1f", size = 215736, upload-time = "2025-10-02T14:35:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/68/c4c80614716345d55071a396cf03d06e34b5f4917a467faf43083c995155/xxhash-3.6.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ed0df1b11a79856df5ffcab572cbd6b9627034c1c748c5566fa79df9048a7c5", size = 214833, upload-time = "2025-10-02T14:35:23.32Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e9/ae27c8ffec8b953efa84c7c4a6c6802c263d587b9fc0d6e7cea64e08c3af/xxhash-3.6.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0e4edbfc7d420925b0dd5e792478ed393d6e75ff8fc219a6546fb446b6a417b1", size = 448348, upload-time = "2025-10-02T14:35:25.111Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6b/33e21afb1b5b3f46b74b6bd1913639066af218d704cc0941404ca717fc57/xxhash-3.6.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fba27a198363a7ef87f8c0f6b171ec36b674fe9053742c58dd7e3201c1ab30ee", size = 196070, upload-time = "2025-10-02T14:35:26.586Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b6/fcabd337bc5fa624e7203aa0fa7d0c49eed22f72e93229431752bddc83d9/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:794fe9145fe60191c6532fa95063765529770edcdd67b3d537793e8004cabbfd", size = 212907, upload-time = "2025-10-02T14:35:28.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d3/9ee6160e644d660fcf176c5825e61411c7f62648728f69c79ba237250143/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:6105ef7e62b5ac73a837778efc331a591d8442f8ef5c7e102376506cb4ae2729", size = 200839, upload-time = "2025-10-02T14:35:29.857Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/98/e8de5baa5109394baf5118f5e72ab21a86387c4f89b0e77ef3e2f6b0327b/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f01375c0e55395b814a679b3eea205db7919ac2af213f4a6682e01220e5fe292", size = 213304, upload-time = "2025-10-02T14:35:31.222Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1d/71056535dec5c3177eeb53e38e3d367dd1d16e024e63b1cee208d572a033/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d706dca2d24d834a4661619dcacf51a75c16d65985718d6a7d73c1eeeb903ddf", size = 416930, upload-time = "2025-10-02T14:35:32.517Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6c/5cbde9de2cd967c322e651c65c543700b19e7ae3e0aae8ece3469bf9683d/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5f059d9faeacd49c0215d66f4056e1326c80503f51a1532ca336a385edadd033", size = 193787, upload-time = "2025-10-02T14:35:33.827Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fa/0172e350361d61febcea941b0cc541d6e6c8d65d153e85f850a7b256ff8a/xxhash-3.6.0-cp313-cp313t-win32.whl", hash = "sha256:1244460adc3a9be84731d72b8e80625788e5815b68da3da8b83f78115a40a7ec", size = 30916, upload-time = "2025-10-02T14:35:35.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e6/e8cf858a2b19d6d45820f072eff1bea413910592ff17157cabc5f1227a16/xxhash-3.6.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b1e420ef35c503869c4064f4a2f2b08ad6431ab7b229a05cce39d74268bca6b8", size = 31799, upload-time = "2025-10-02T14:35:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/064b197e855bfb7b343210e82490ae672f8bc7cdf3ddb02e92f64304ee8a/xxhash-3.6.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ec44b73a4220623235f67a996c862049f375df3b1052d9899f40a6382c32d746", size = 28044, upload-time = "2025-10-02T14:35:37.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/5e/0138bc4484ea9b897864d59fce9be9086030825bc778b76cb5a33a906d37/xxhash-3.6.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a40a3d35b204b7cc7643cbcf8c9976d818cb47befcfac8bbefec8038ac363f3e", size = 32754, upload-time = "2025-10-02T14:35:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d7/5dac2eb2ec75fd771957a13e5dda560efb2176d5203f39502a5fc571f899/xxhash-3.6.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a54844be970d3fc22630b32d515e79a90d0a3ddb2644d8d7402e3c4c8da61405", size = 30846, upload-time = "2025-10-02T14:35:39.6Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/71/8bc5be2bb00deb5682e92e8da955ebe5fa982da13a69da5a40a4c8db12fb/xxhash-3.6.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:016e9190af8f0a4e3741343777710e3d5717427f175adfdc3e72508f59e2a7f3", size = 194343, upload-time = "2025-10-02T14:35:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/52badfb2aecec2c377ddf1ae75f55db3ba2d321c5e164f14461c90837ef3/xxhash-3.6.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f6f72232f849eb9d0141e2ebe2677ece15adfd0fa599bc058aad83c714bb2c6", size = 213074, upload-time = "2025-10-02T14:35:42.29Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2b/ae46b4e9b92e537fa30d03dbc19cdae57ed407e9c26d163895e968e3de85/xxhash-3.6.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63275a8aba7865e44b1813d2177e0f5ea7eadad3dd063a21f7cf9afdc7054063", size = 212388, upload-time = "2025-10-02T14:35:43.929Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/80/49f88d3afc724b4ac7fbd664c8452d6db51b49915be48c6982659e0e7942/xxhash-3.6.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cd01fa2aa00d8b017c97eb46b9a794fbdca53fc14f845f5a328c71254b0abb7", size = 445614, upload-time = "2025-10-02T14:35:45.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ba/603ce3961e339413543d8cd44f21f2c80e2a7c5cfe692a7b1f2cccf58f3c/xxhash-3.6.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0226aa89035b62b6a86d3c68df4d7c1f47a342b8683da2b60cedcddb46c4d95b", size = 194024, upload-time = "2025-10-02T14:35:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d1/8e225ff7113bf81545cfdcd79eef124a7b7064a0bba53605ff39590b95c2/xxhash-3.6.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c6e193e9f56e4ca4923c61238cdaced324f0feac782544eb4c6d55ad5cc99ddd", size = 210541, upload-time = "2025-10-02T14:35:48.301Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/58/0f89d149f0bad89def1a8dd38feb50ccdeb643d9797ec84707091d4cb494/xxhash-3.6.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9176dcaddf4ca963d4deb93866d739a343c01c969231dbe21680e13a5d1a5bf0", size = 198305, upload-time = "2025-10-02T14:35:49.584Z" },
+    { url = "https://files.pythonhosted.org/packages/11/38/5eab81580703c4df93feb5f32ff8fa7fe1e2c51c1f183ee4e48d4bb9d3d7/xxhash-3.6.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c1ce4009c97a752e682b897aa99aef84191077a9433eb237774689f14f8ec152", size = 210848, upload-time = "2025-10-02T14:35:50.877Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6b/953dc4b05c3ce678abca756416e4c130d2382f877a9c30a20d08ee6a77c0/xxhash-3.6.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:8cb2f4f679b01513b7adbb9b1b2f0f9cdc31b70007eaf9d59d0878809f385b11", size = 414142, upload-time = "2025-10-02T14:35:52.15Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a9/238ec0d4e81a10eb5026d4a6972677cbc898ba6c8b9dbaec12ae001b1b35/xxhash-3.6.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:653a91d7c2ab54a92c19ccf43508b6a555440b9be1bc8be553376778be7f20b5", size = 191547, upload-time = "2025-10-02T14:35:53.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ee/3cf8589e06c2164ac77c3bf0aa127012801128f1feebf2a079272da5737c/xxhash-3.6.0-cp314-cp314-win32.whl", hash = "sha256:a756fe893389483ee8c394d06b5ab765d96e68fbbfe6fde7aa17e11f5720559f", size = 31214, upload-time = "2025-10-02T14:35:54.746Z" },
+    { url = "https://files.pythonhosted.org/packages/02/5d/a19552fbc6ad4cb54ff953c3908bbc095f4a921bc569433d791f755186f1/xxhash-3.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:39be8e4e142550ef69629c9cd71b88c90e9a5db703fecbcf265546d9536ca4ad", size = 32290, upload-time = "2025-10-02T14:35:55.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/11/dafa0643bc30442c887b55baf8e73353a344ee89c1901b5a5c54a6c17d39/xxhash-3.6.0-cp314-cp314-win_arm64.whl", hash = "sha256:25915e6000338999236f1eb68a02a32c3275ac338628a7eaa5a269c401995679", size = 28795, upload-time = "2025-10-02T14:35:57.162Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/db/0e99732ed7f64182aef4a6fb145e1a295558deec2a746265dcdec12d191e/xxhash-3.6.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c5294f596a9017ca5a3e3f8884c00b91ab2ad2933cf288f4923c3fd4346cf3d4", size = 32955, upload-time = "2025-10-02T14:35:58.267Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f4/2a7c3c68e564a099becfa44bb3d398810cc0ff6749b0d3cb8ccb93f23c14/xxhash-3.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1cf9dcc4ab9cff01dfbba78544297a3a01dafd60f3bde4e2bfd016cf7e4ddc67", size = 31072, upload-time = "2025-10-02T14:35:59.382Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d9/72a29cddc7250e8a5819dad5d466facb5dc4c802ce120645630149127e73/xxhash-3.6.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:01262da8798422d0685f7cef03b2bd3f4f46511b02830861df548d7def4402ad", size = 196579, upload-time = "2025-10-02T14:36:00.838Z" },
+    { url = "https://files.pythonhosted.org/packages/63/93/b21590e1e381040e2ca305a884d89e1c345b347404f7780f07f2cdd47ef4/xxhash-3.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51a73fb7cb3a3ead9f7a8b583ffd9b8038e277cdb8cb87cf890e88b3456afa0b", size = 215854, upload-time = "2025-10-02T14:36:02.207Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b8/edab8a7d4fa14e924b29be877d54155dcbd8b80be85ea00d2be3413a9ed4/xxhash-3.6.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b9c6df83594f7df8f7f708ce5ebeacfc69f72c9fbaaababf6cf4758eaada0c9b", size = 214965, upload-time = "2025-10-02T14:36:03.507Z" },
+    { url = "https://files.pythonhosted.org/packages/27/67/dfa980ac7f0d509d54ea0d5a486d2bb4b80c3f1bb22b66e6a05d3efaf6c0/xxhash-3.6.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:627f0af069b0ea56f312fd5189001c24578868643203bca1abbc2c52d3a6f3ca", size = 448484, upload-time = "2025-10-02T14:36:04.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/63/8ffc2cc97e811c0ca5d00ab36604b3ea6f4254f20b7bc658ca825ce6c954/xxhash-3.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa912c62f842dfd013c5f21a642c9c10cd9f4c4e943e0af83618b4a404d9091a", size = 196162, upload-time = "2025-10-02T14:36:06.182Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/77/07f0e7a3edd11a6097e990f6e5b815b6592459cb16dae990d967693e6ea9/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b465afd7909db30168ab62afe40b2fcf79eedc0b89a6c0ab3123515dc0df8b99", size = 213007, upload-time = "2025-10-02T14:36:07.733Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d8/bc5fa0d152837117eb0bef6f83f956c509332ce133c91c63ce07ee7c4873/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:a881851cf38b0a70e7c4d3ce81fc7afd86fbc2a024f4cfb2a97cf49ce04b75d3", size = 200956, upload-time = "2025-10-02T14:36:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/26/a5/d749334130de9411783873e9b98ecc46688dad5db64ca6e04b02acc8b473/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:9b3222c686a919a0f3253cfc12bb118b8b103506612253b5baeaac10d8027cf6", size = 213401, upload-time = "2025-10-02T14:36:10.585Z" },
+    { url = "https://files.pythonhosted.org/packages/89/72/abed959c956a4bfc72b58c0384bb7940663c678127538634d896b1195c10/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:c5aa639bc113e9286137cec8fadc20e9cd732b2cc385c0b7fa673b84fc1f2a93", size = 417083, upload-time = "2025-10-02T14:36:12.276Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b3/62fd2b586283b7d7d665fb98e266decadf31f058f1cf6c478741f68af0cb/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5c1343d49ac102799905e115aee590183c3921d475356cb24b4de29a4bc56518", size = 193913, upload-time = "2025-10-02T14:36:14.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/c19c42c5b3f5a4aad748a6d5b4f23df3bed7ee5445accc65a0fb3ff03953/xxhash-3.6.0-cp314-cp314t-win32.whl", hash = "sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119", size = 31586, upload-time = "2025-10-02T14:36:15.603Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/4cc450345be9924fd5dc8c590ceda1db5b43a0a889587b0ae81a95511360/xxhash-3.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f", size = 32526, upload-time = "2025-10-02T14:36:16.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c9/7243eb3f9eaabd1a88a5a5acadf06df2d83b100c62684b7425c6a11bcaa8/xxhash-3.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95", size = 28898, upload-time = "2025-10-02T14:36:17.843Z" },
+    { url = "https://files.pythonhosted.org/packages/93/1e/8aec23647a34a249f62e2398c42955acd9b4c6ed5cf08cbea94dc46f78d2/xxhash-3.6.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0f7b7e2ec26c1666ad5fc9dbfa426a6a3367ceaf79db5dd76264659d509d73b0", size = 30662, upload-time = "2025-10-02T14:37:01.743Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/b14510b38ba91caf43006209db846a696ceea6a847a0c9ba0a5b1adc53d6/xxhash-3.6.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5dc1e14d14fa0f5789ec29a7062004b5933964bb9b02aae6622b8f530dc40296", size = 41056, upload-time = "2025-10-02T14:37:02.879Z" },
+    { url = "https://files.pythonhosted.org/packages/50/55/15a7b8a56590e66ccd374bbfa3f9ffc45b810886c8c3b614e3f90bd2367c/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:881b47fc47e051b37d94d13e7455131054b56749b91b508b0907eb07900d1c13", size = 36251, upload-time = "2025-10-02T14:37:04.44Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/5ac99a041a29e58e95f907876b04f7067a0242cb85b5f39e726153981503/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6dc31591899f5e5666f04cc2e529e69b4072827085c1ef15294d91a004bc1bd", size = 32481, upload-time = "2025-10-02T14:37:05.869Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/8d95e906764a386a3d3b596f3c68bb63687dfca806373509f51ce8eea81f/xxhash-3.6.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:15e0dac10eb9309508bfc41f7f9deaa7755c69e35af835db9cb10751adebc35d", size = 31565, upload-time = "2025-10-02T14:37:06.966Z" },
 ]
 
 [[package]]

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -3,10 +3,8 @@
 import { startTransition, useCallback, useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import {
-  Bot,
+  Check,
   Clock3,
-  Cpu,
-  GalleryHorizontalEnd,
   Image as ImageIcon,
   Loader2,
   Play,
@@ -19,7 +17,22 @@ import { AnimatePresence, motion } from "framer-motion";
 
 import Gallery from "@/components/Gallery";
 import Settings from "@/components/Settings";
-import { API_BASE, api, GenerateResponse, SystemStatus } from "@/lib/api";
+import TaskProgress from "@/components/TaskProgress";
+import {
+  API_BASE,
+  api,
+  GenerateResponse,
+  GenerationConfig,
+  PluginInfo,
+  SystemStatus,
+} from "@/lib/api";
+import {
+  createClientRequestId,
+  getFallbackProgress,
+  getTaskProgressUpdate,
+  INITIAL_IMAGE_PROGRESS,
+  type ProgressSnapshot,
+} from "@/lib/task-progress";
 import { cn } from "@/lib/utils";
 import galleryCache from "@/lib/cache";
 
@@ -37,11 +50,6 @@ type RecentImage = {
   created_at: string;
 };
 
-type HeroNote = {
-  label: string;
-  value: string;
-};
-
 const CADENCE_OPTIONS: CadenceOption[] = [
   { label: "5 min", minutes: 5, description: "Fast drip" },
   { label: "15 min", minutes: 15, description: "Steady stream" },
@@ -49,6 +57,15 @@ const CADENCE_OPTIONS: CadenceOption[] = [
   { label: "3 hours", minutes: 180, description: "Slow drift" },
   { label: "Daily", minutes: 1440, description: "One image a day" },
 ];
+
+const DASHBOARD_BACKEND_OPTIONS = [
+  { id: "auto", label: "Auto" },
+  { id: "zimage", label: "Z-Image" },
+  { id: "ollama", label: "Ollama" },
+  { id: "small", label: "Small SD" },
+  { id: "turbo", label: "Turbo" },
+  { id: "mock", label: "Mock" },
+] as const;
 
 const STORAGE_KEYS = {
   promptSeed: "dreamgen.promptSeed",
@@ -94,26 +111,22 @@ const formatCountdown = (target: Date | null) => {
 const truncatePrompt = (prompt: string, max = 88) =>
   prompt.length > max ? `${prompt.slice(0, max).trim()}...` : prompt;
 
-const HERO_NOTES: HeroNote[] = [
-  { label: "Local-first", value: "Tiny fallback is ready immediately." },
-  { label: "Recurring", value: "Loop runs while this tab stays open." },
-  { label: "Entropy", value: "Plugins keep the feed from going flat." },
-];
-
 export default function Home() {
   const [activeTab, setActiveTab] = useState<TabId>("generate");
   const [promptSeed, setPromptSeed] = useState("");
   const [cadenceMinutes, setCadenceMinutes] = useState(60);
   const [loopEnabled, setLoopEnabled] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [generationProgress, setGenerationProgress] = useState<ProgressSnapshot | null>(null);
   const [currentImage, setCurrentImage] = useState<GenerateResponse | null>(null);
   const [recentImages, setRecentImages] = useState<RecentImage[]>([]);
   const [status, setStatus] = useState<SystemStatus | null>(null);
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+  const [generationConfig, setGenerationConfig] = useState<GenerationConfig | null>(null);
   const [nextRunAt, setNextRunAt] = useState<Date | null>(null);
   const [, setClockTick] = useState(Date.now());
   const [sessionCount, setSessionCount] = useState(0);
   const [logs, setLogs] = useState<string[]>(["DreamGen is ready."]);
-  const [showLogs, setShowLogs] = useState(false);
 
   const promptSeedRef = useRef(promptSeed);
   const cadenceMinutesRef = useRef(cadenceMinutes);
@@ -122,9 +135,9 @@ export default function Home() {
   const runGenerationRef = useRef<(source: "manual" | "loop") => Promise<void>>(
     async () => {}
   );
+  const generationRequestIdRef = useRef<string | null>(null);
+  const generationResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const cadence =
-    CADENCE_OPTIONS.find((option) => option.minutes === cadenceMinutes) ?? CADENCE_OPTIONS[2];
   const currentBackend =
     currentImage?.metadata.backend && currentImage.metadata.backend !== "unknown"
       ? currentImage.metadata.backend
@@ -134,6 +147,12 @@ export default function Home() {
       ? currentImage.metadata.plugins_used.length
       : status?.active_plugins?.length ?? 0;
   const isSmokeBackend = currentBackend === "smoke-test";
+  const enabledPlugins = plugins.filter((plugin) => plugin.enabled);
+  const selectedBackend = generationConfig?.image_backend ?? "auto";
+  const enabledLoras = generationConfig?.enabled_loras ?? [];
+  const lastActivity = logs[logs.length - 1];
+  const selectedCadence =
+    CADENCE_OPTIONS.find((option) => option.minutes === cadenceMinutes) ?? CADENCE_OPTIONS[2];
 
   const addLog = (message: string, type: "info" | "error" = "info") => {
     const timestamp = new Date().toLocaleTimeString();
@@ -171,11 +190,32 @@ export default function Home() {
     }
   }, []);
 
+  const loadDashboardControls = useCallback(async () => {
+    try {
+      const [pluginList, runtimeConfig] = await Promise.all([
+        api.getPlugins(),
+        api.getGenerationConfig(),
+      ]);
+      startTransition(() => {
+        setPlugins(pluginList);
+        setGenerationConfig(runtimeConfig);
+      });
+    } catch (error) {
+      console.error("Failed to load dashboard controls:", error);
+    }
+  }, []);
+
   runGenerationRef.current = async (source: "manual" | "loop") => {
     if (isGeneratingRef.current) return;
 
+    const clientRequestId = createClientRequestId(source);
+    generationRequestIdRef.current = clientRequestId;
+    if (generationResetTimeoutRef.current) {
+      clearTimeout(generationResetTimeoutRef.current);
+    }
     isGeneratingRef.current = true;
     setIsGenerating(true);
+    setGenerationProgress(INITIAL_IMAGE_PROGRESS);
     const activeCadence =
       CADENCE_OPTIONS.find((option) => option.minutes === cadenceMinutesRef.current) ??
       CADENCE_OPTIONS[2];
@@ -190,6 +230,7 @@ export default function Home() {
       const response = await api.generate({
         prompt: promptSeedRef.current.trim() || undefined,
         enable_plugins: true,
+        client_request_id: clientRequestId,
       });
 
       startTransition(() => {
@@ -198,12 +239,25 @@ export default function Home() {
       });
 
       addLog(`Image created with ${response.metadata.backend}.`);
+      setGenerationProgress({
+        progress: 100,
+        title: "Image ready",
+        detail: "The generated image is saved and ready to review.",
+      });
+      if (generationResetTimeoutRef.current) {
+        clearTimeout(generationResetTimeoutRef.current);
+      }
+      generationResetTimeoutRef.current = setTimeout(() => {
+        setGenerationProgress(null);
+      }, 1200);
       await galleryCache.clear();
-      await loadRecentImages();
+      await Promise.all([loadRecentImages(), loadDashboardControls(), api.getStatus().then(setStatus)]);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : "Unknown error";
       addLog(`Generation failed: ${errorMsg}`, "error");
+      setGenerationProgress(null);
     } finally {
+      generationRequestIdRef.current = null;
       isGeneratingRef.current = false;
       setIsGenerating(false);
     }
@@ -243,8 +297,20 @@ export default function Home() {
   useEffect(() => {
     api.getStatus().then(setStatus).catch(console.error);
     loadRecentImages();
+    loadDashboardControls();
 
-    api.connectWebSocket((data) => {
+    const unsubscribe = api.subscribeWebSocket((data) => {
+      const nextProgress = getTaskProgressUpdate(
+        data,
+        "image_generation",
+        generationRequestIdRef.current
+      );
+      if (nextProgress) {
+        setGenerationProgress((prev) =>
+          prev && prev.progress > nextProgress.progress ? prev : nextProgress
+        );
+      }
+
       if (typeof data !== "object" || data === null || !("type" in data)) return;
 
       const msg = data as Record<string, unknown>;
@@ -258,9 +324,24 @@ export default function Home() {
     });
 
     return () => {
-      api.disconnectWebSocket();
+      unsubscribe();
+      if (generationResetTimeoutRef.current) {
+        clearTimeout(generationResetTimeoutRef.current);
+      }
     };
-  }, [loadRecentImages]);
+  }, [loadDashboardControls, loadRecentImages]);
+
+  useEffect(() => {
+    if (!isGenerating || !generationProgress || generationProgress.progress >= 96) return;
+
+    const timeoutId = setTimeout(() => {
+      setGenerationProgress((prev) =>
+        prev ? getFallbackProgress("image_generation", prev) : prev
+      );
+    }, 2500);
+
+    return () => clearTimeout(timeoutId);
+  }, [generationProgress, isGenerating]);
 
   useEffect(() => {
     if (!loopEnabled) {
@@ -289,18 +370,47 @@ export default function Home() {
   }, [cadenceMinutes, loopEnabled, nextRunAt]);
 
   const tabs = [
-    { id: "generate" as const, label: "Generator", icon: Sparkles },
+    { id: "generate" as const, label: "Create", icon: Sparkles },
     { id: "gallery" as const, label: "Gallery", icon: ImageIcon },
     { id: "settings" as const, label: "Settings", icon: SettingsIcon },
     { id: "playground" as const, label: "Advanced", icon: Wand2 },
   ];
 
+  const togglePlugin = async (pluginName: string) => {
+    try {
+      const response = await api.togglePlugin(pluginName);
+      addLog(`${pluginName} ${response.enabled ? "enabled" : "disabled"}.`);
+      const [pluginList, refreshedStatus] = await Promise.all([api.getPlugins(), api.getStatus()]);
+      startTransition(() => {
+        setPlugins(pluginList);
+        setStatus(refreshedStatus);
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      addLog(`Failed to update ${pluginName}: ${message}`, "error");
+    }
+  };
+
+  const updateBackend = async (backend: (typeof DASHBOARD_BACKEND_OPTIONS)[number]["id"]) => {
+    try {
+      const response = await api.setGenerationConfig({ image_backend: backend });
+      const refreshedStatus = await api.getStatus();
+      startTransition(() => {
+        setGenerationConfig(response.config);
+        setStatus(refreshedStatus);
+      });
+      addLog(`Image backend set to ${backend}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      addLog(`Failed to change backend: ${message}`, "error");
+    }
+  };
+
   return (
     <div className="relative flex h-screen overflow-hidden bg-background">
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute inset-0 bg-[linear-gradient(hsl(var(--border)/0.08)_1px,transparent_1px),linear-gradient(90deg,hsl(var(--border)/0.08)_1px,transparent_1px)] bg-[size:72px_72px] opacity-[0.14]" />
-        <div className="absolute -left-24 top-24 h-80 w-80 rounded-full bg-primary/10 blur-3xl" />
-        <div className="absolute right-0 top-0 h-72 w-72 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute inset-x-0 top-0 h-64 bg-[radial-gradient(circle_at_top_left,hsl(var(--primary)/0.16),transparent_36rem)]" />
+        <div className="absolute right-0 top-0 h-72 w-72 rounded-full bg-accent/8 blur-3xl" />
       </div>
 
       <div className="relative z-10 flex h-full w-full flex-col overflow-hidden">
@@ -366,334 +476,348 @@ export default function Home() {
               exit={{ opacity: 0, y: -8 }}
               className="h-full overflow-y-auto"
             >
-              <div className="mx-auto grid max-w-7xl gap-6 px-4 py-6 sm:px-6 lg:grid-cols-[390px_minmax(0,1fr)]">
-                <section className="space-y-5">
-                  <div className="ambient-panel rounded-3xl border border-border/80 p-5">
-                    <div className="mb-4 flex items-start justify-between gap-4">
+              <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6">
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <div className="ambient-panel rounded-2xl border border-primary/35 bg-primary/10 p-5">
+                    <div className="flex items-start justify-between gap-4">
                       <div>
-                        <div className="mb-3 inline-flex rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[11px] uppercase tracking-[0.22em] text-primary">
-                          recurring image feed
+                        <div className="text-[11px] uppercase tracking-[0.22em] text-primary">
+                          Ad-hoc
                         </div>
-                        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-                          Make images on a rhythm
-                        </h1>
-                        <p className="mt-3 max-w-md text-sm leading-6 text-muted-foreground">
-                          Leave the prompt blank for full entropy, or give DreamGen a seed phrase.
-                          Start the session loop and it keeps creating while this page stays open.
-                        </p>
+                        <h2 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">
+                          Generate once
+                        </h2>
                       </div>
-                      <div className="rounded-[1.25rem] border border-border/80 bg-background/80 px-3 py-3 text-right shadow-[0_12px_30px_rgba(0,0,0,0.16)]">
-                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                          Session
-                        </div>
-                        <div className="text-2xl font-semibold tracking-tight text-foreground">{sessionCount}</div>
-                      </div>
+                      <Sparkles className="h-5 w-5 text-primary" />
                     </div>
+                    <div className="mt-4 flex flex-wrap items-center gap-3">
+                      <button
+                        onClick={() => void runGenerationRef.current("manual")}
+                        disabled={isGenerating}
+                        className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-3 text-sm font-medium text-primary-foreground transition hover:opacity-95 disabled:opacity-60"
+                      >
+                        {isGenerating ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Sparkles className="h-4 w-4" />
+                        )}
+                        {isGenerating
+                          ? `Generating ${generationProgress?.progress ?? INITIAL_IMAGE_PROGRESS.progress}%`
+                          : "Generate once"}
+                      </button>
+                      <span className="text-xs text-muted-foreground">
+                        {promptSeed.trim() ? "Using prompt seed" : "Using generated prompt"}
+                      </span>
+                    </div>
+                  </div>
 
-                    <div className="mb-5 grid gap-2">
-                      {HERO_NOTES.map((note) => (
-                        <div
-                          key={note.label}
-                          className="flex items-start gap-3 rounded-2xl border border-border/70 bg-background/55 px-4 py-2.5"
-                        >
-                          <span className="mt-1 h-2 w-2 rounded-full bg-primary" />
-                          <div>
-                            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                              {note.label}
-                            </p>
-                            <p className="mt-1 text-sm leading-5 text-foreground/90">{note.value}</p>
-                          </div>
+                  <div
+                    className={cn(
+                      "ambient-panel rounded-2xl border p-5",
+                      loopEnabled
+                        ? "border-destructive/35 bg-destructive/10"
+                        : "border-border/80 bg-card/70"
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <div className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+                          Schedule
                         </div>
+                        <h2 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">
+                          Scheduled loop
+                        </h2>
+                        <div className="mt-2 inline-flex rounded-full border border-primary/35 bg-primary/10 px-3 py-1 text-xs font-medium text-foreground">
+                          Cadence: {selectedCadence.label}
+                        </div>
+                      </div>
+                      {loopEnabled ? (
+                        <Square className="h-5 w-5 text-foreground" />
+                      ) : (
+                        <Play className="h-5 w-5 text-foreground" />
+                      )}
+                    </div>
+                    <div className="mt-4 flex flex-wrap items-center gap-3">
+                      <button
+                        onClick={() => setLoopEnabled((value) => !value)}
+                        className={cn(
+                          "inline-flex items-center gap-2 rounded-full px-5 py-3 text-sm font-medium transition",
+                          loopEnabled
+                            ? "bg-destructive text-destructive-foreground hover:opacity-95"
+                            : "bg-foreground text-background hover:opacity-95"
+                        )}
+                      >
+                        {loopEnabled ? <Square className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+                        {loopEnabled ? "Stop schedule" : "Start schedule"}
+                      </button>
+                      <span className="text-xs text-muted-foreground">
+                        Next run: {loopEnabled ? formatCountdown(nextRunAt) : "Not scheduled"}
+                      </span>
+                    </div>
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {CADENCE_OPTIONS.map((option) => (
+                        <button
+                          key={option.minutes}
+                          aria-pressed={cadenceMinutes === option.minutes}
+                          onClick={() => setCadenceMinutes(option.minutes)}
+                          className={cn(
+                            "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition",
+                            cadenceMinutes === option.minutes
+                              ? "border-primary bg-primary text-primary-foreground shadow-[0_0_0_3px_hsl(var(--primary)/0.16)]"
+                              : "border-border/70 bg-background/70 text-muted-foreground hover:border-primary/30 hover:text-foreground"
+                          )}
+                        >
+                          {cadenceMinutes === option.minutes ? (
+                            <Check className="h-3 w-3" />
+                          ) : null}
+                          {option.label}
+                        </button>
                       ))}
                     </div>
+                  </div>
+                </div>
 
-                    <div className="space-y-4">
-                      <div className="rounded-2xl border border-primary/20 bg-primary/10 px-4 py-3">
-                        <div className="text-[11px] uppercase tracking-[0.22em] text-primary">
-                          Start Here
+                <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_300px]">
+                  <section className="grid content-start gap-5">
+                    <div className="ambient-panel rounded-[2rem] border border-border/80 p-6">
+                      <div className="flex flex-wrap items-start justify-between gap-4">
+                        <div>
+                          <div className="text-[11px] uppercase tracking-[0.22em] text-primary">
+                            One-off prompt
+                          </div>
+                          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-foreground">
+                            Seed the next image.
+                          </h1>
+                          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                            Leave the field empty for DreamGen to compose a prompt from the active plugins.
+                          </p>
                         </div>
-                        <p className="mt-2 text-sm leading-6 text-foreground/90">
-                          Use <span className="font-medium text-foreground">Generate now</span> for one
-                          image, or <span className="font-medium text-foreground">Start loop</span> to let
-                          DreamGen keep building the feed.
-                        </p>
+
+                        <div className="flex flex-wrap gap-2">
+                          <span className="status-pill capitalize">{currentBackend}</span>
+                          <span className="status-pill">{enabledPlugins.length} plugins</span>
+                        </div>
                       </div>
 
-                      <div>
-                        <label className="mb-2 block text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                          Theme seed
-                        </label>
-                        <textarea
-                          value={promptSeed}
-                          onChange={(event) => setPromptSeed(event.target.value)}
-                          rows={3}
-                          placeholder="Optional: brutalist gardens, retrofuturist machinery, haunted motel, etc."
-                          className="w-full rounded-2xl border border-input/80 bg-background/80 px-3 py-3 text-sm leading-6 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
-                        />
-                        <p className="mt-2 text-xs text-muted-foreground">
-                          Empty means fully AI-generated prompts with your active plugins.
-                        </p>
-                      </div>
-
-                      <div>
-                        <label className="mb-2 block text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                          Cadence
-                        </label>
-                        <div className="grid grid-cols-2 gap-2">
-                          {CADENCE_OPTIONS.map((option) => (
+                      <div className="mt-4">
+                        <div className="mb-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                          Plugins
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          {plugins.map((plugin) => (
                             <button
-                              key={option.minutes}
-                              onClick={() => setCadenceMinutes(option.minutes)}
+                              key={plugin.name}
+                              onClick={() => void togglePlugin(plugin.name)}
                               className={cn(
-                                "rounded-2xl border px-3 py-3 text-left transition",
-                                cadenceMinutes === option.minutes
-                                  ? "border-primary/40 bg-primary/12 shadow-[0_8px_24px_rgba(39,229,166,0.1)]"
-                                  : "border-border/70 bg-background/45 hover:border-primary/30 hover:bg-muted/35"
+                                "rounded-full border px-3 py-2 text-sm transition",
+                                plugin.enabled
+                                  ? "border-primary/35 bg-primary/10 text-foreground"
+                                  : "border-border/70 bg-background/75 text-muted-foreground hover:border-primary/25 hover:text-foreground"
                               )}
                             >
-                              <div className="text-sm font-medium text-foreground">{option.label}</div>
-                              <div className="text-xs text-muted-foreground">{option.description}</div>
+                              {plugin.name.replaceAll("_", " ")}
                             </button>
                           ))}
                         </div>
-                      </div>
-
-                      <div className="grid grid-cols-2 gap-3">
-                        <button
-                          onClick={() => void runGenerationRef.current("manual")}
-                          disabled={isGenerating}
-                          className="flex items-center justify-center gap-2 rounded-2xl bg-primary px-4 py-3 text-sm font-medium text-primary-foreground shadow-[0_16px_40px_rgba(39,229,166,0.18)] transition hover:translate-y-[-1px] hover:opacity-95 disabled:opacity-50"
-                        >
-                          {isGenerating ? (
-                            <>
-                              <Loader2 className="h-4 w-4 animate-spin" />
-                              Working...
-                            </>
-                          ) : (
-                            <>
-                              <Sparkles className="h-4 w-4" />
-                              Generate now
-                            </>
-                          )}
-                        </button>
-
-                        <button
-                          onClick={() => setLoopEnabled((value) => !value)}
-                          className={cn(
-                            "flex items-center justify-center gap-2 rounded-2xl border px-4 py-3 text-sm font-medium transition",
-                            loopEnabled
-                              ? "border-destructive/40 bg-destructive/10 text-foreground hover:bg-destructive/15"
-                              : "border-border/70 bg-background/75 text-foreground hover:border-primary/30 hover:bg-muted/50"
-                          )}
-                        >
-                          {loopEnabled ? (
-                            <>
-                              <Square className="h-4 w-4" />
-                              Stop loop
-                            </>
-                          ) : (
-                            <>
-                              <Play className="h-4 w-4" />
-                              Start loop
-                            </>
-                          )}
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="ambient-panel rounded-3xl border border-border/80 p-5">
-                    <div className="mb-4 flex items-center gap-2">
-                      <Clock3 className="h-4 w-4 text-primary" />
-                      <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                        Loop status
-                      </h2>
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-3">
-                      <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
-                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                          Mode
-                        </div>
-                        <div className="mt-2 text-lg font-semibold text-foreground">
-                          {loopEnabled ? "Running" : "Idle"}
+                        <div className="mt-2 text-xs leading-6 text-muted-foreground">
+                          {selectedBackend === "zimage" && enabledLoras.length > 0
+                            ? `LoRA path armed: ${enabledLoras.slice(0, 3).join(", ")}${enabledLoras.length > 3 ? "..." : ""}.`
+                            : selectedBackend === "ollama"
+                              ? `Ollama image backend${generationConfig?.ollama_image_model ? ` using ${generationConfig.ollama_image_model}` : " using auto model selection"}.`
+                              : "Use Settings for downloads, auth, and deeper model configuration."}
                         </div>
                       </div>
-                      <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
-                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                          Next run
-                        </div>
-                        <div className="mt-2 text-lg font-semibold text-foreground">
-                          {loopEnabled ? formatCountdown(nextRunAt) : "Not scheduled"}
-                        </div>
-                      </div>
-                    </div>
 
-                    <div className="mt-3 rounded-2xl border border-border/60 bg-background/65 px-4 py-3 text-sm text-muted-foreground">
-                      Cadence: <span className="font-medium text-foreground">{cadence.label}</span>
-                      <span className="ml-2 text-muted-foreground/80">{cadence.description}</span>
-                    </div>
+                      <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.9fr)]">
+                        <div className="grid content-start gap-4">
+                          <div>
+                            <label className="mb-2 block text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                              Prompt seed
+                            </label>
+                            <textarea
+                              value={promptSeed}
+                              onChange={(event) => setPromptSeed(event.target.value)}
+                              rows={5}
+                              placeholder="Optional: brutalist greenhouse, paper diorama city, weathered arcade shrine..."
+                              className="w-full rounded-[1.75rem] border border-input/85 bg-background/95 px-4 py-4 text-sm leading-6 text-foreground outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                            />
+                          </div>
 
-                    <div className="mt-4 rounded-2xl border border-dashed border-border/80 px-4 py-3 text-xs leading-6 text-muted-foreground">
-                      Session loop runs while this browser tab stays open. For true background jobs,
-                      use <code className="mx-1 rounded bg-background px-1 py-0.5">uv run dreamgen loop</code>.
-                    </div>
-                  </div>
-
-                  <div className="ambient-panel rounded-3xl border border-border/80 p-5">
-                    <div className="mb-4 flex items-center gap-2">
-                      <Bot className="h-4 w-4 text-primary" />
-                      <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                        Active engine
-                      </h2>
-                    </div>
-
-                    <div className="space-y-3 text-sm">
-                      <div className="flex items-center justify-between rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
-                        <span className="text-muted-foreground">Backend</span>
-                        <span className="font-medium capitalize text-foreground">
-                          {status?.backend ?? "unknown"}
-                        </span>
-                      </div>
-                      <div className="flex items-center justify-between rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
-                        <span className="text-muted-foreground">GPU</span>
-                        <span className="font-medium text-foreground">
-                          {status?.gpu_available ? "Available" : "Unavailable"}
-                        </span>
-                      </div>
-                      <div className="flex items-center justify-between rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
-                        <span className="text-muted-foreground">Entropy plugins</span>
-                        <span className="font-medium text-foreground">
-                          {status?.active_plugins?.length ?? 0} active
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </section>
-
-                <section className="grid content-start gap-6">
-                  <div className="ambient-panel rounded-[2rem] border border-border/80 p-5">
-                    <div className="mb-4 flex items-center justify-between gap-4">
-                      <div>
-                        <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                          Current output
-                        </div>
-                        <div className="mt-1 text-lg font-semibold text-foreground">
-                          {currentImage ? "Latest generation" : "Waiting for first image"}
-                        </div>
-                        <div className="mt-3 flex flex-wrap gap-2">
-                          <span className="status-pill capitalize">{currentBackend}</span>
-                          <span className="status-pill">{currentPluginCount} plugins</span>
-                          {isSmokeBackend ? (
-                            <span className="status-pill">smoke-test quality</span>
-                          ) : null}
-                        </div>
-                      </div>
-                      <a
-                        href="/playground"
-                        className="rounded-full border border-border/80 bg-background/75 px-3 py-2 text-xs text-muted-foreground transition hover:border-primary/30 hover:text-foreground"
-                      >
-                        Open advanced playground
-                      </a>
-                    </div>
-
-                    <div className="min-h-[420px] rounded-[1.5rem] border border-border/70 bg-background/70 p-4">
-                      <AnimatePresence mode="wait">
-                        {isGenerating ? (
-                          <motion.div
-                            key="loading"
-                            initial={{ opacity: 0, scale: 0.96 }}
-                            animate={{ opacity: 1, scale: 1 }}
-                            exit={{ opacity: 0, scale: 0.96 }}
-                            className="text-center"
-                          >
-                            <Loader2 className="mx-auto mb-4 h-16 w-16 animate-spin text-primary" />
-                            <p className="text-sm text-foreground">DreamGen is creating a new image.</p>
-                            <p className="mt-2 text-xs text-muted-foreground">
-                              Small fallback is ready faster. FLUX can take longer on first load.
-                            </p>
-                          </motion.div>
-                        ) : currentImage ? (
-                          <motion.div
-                            key={currentImage.id}
-                            initial={{ opacity: 0, scale: 0.97 }}
-                            animate={{ opacity: 1, scale: 1 }}
-                            exit={{ opacity: 0, scale: 0.97 }}
-                            className="flex w-full flex-col items-center"
-                          >
-                            <div className="flex min-h-[380px] w-full items-center justify-center rounded-[1.75rem] border border-border/60 bg-[radial-gradient(circle_at_top,hsl(var(--accent)/0.08),transparent_22rem)] px-4 py-6">
-                              {/* Backend-served generated files are not routed through Next image optimization. */}
-                              {/* eslint-disable-next-line @next/next/no-img-element */}
-                              <img
-                                src={`${API_BASE}${currentImage.image_path}`}
-                                alt="Generated image"
-                                className="max-h-[68vh] max-w-full rounded-2xl object-contain shadow-[0_24px_80px_rgba(0,0,0,0.34)]"
-                              />
+                          <div className="rounded-[1.75rem] border border-border/70 bg-background/80 px-4 py-4">
+                            <div className="text-sm text-foreground">
+                              {promptSeed.trim()
+                                ? "The one-off action will use this prompt seed."
+                                : "The one-off action will request a generated prompt."}
                             </div>
-                            <div className="mt-4 w-full max-w-5xl rounded-2xl border border-border/60 bg-background/80 px-4 py-3">
-                              <p className="text-center text-sm leading-7 text-muted-foreground">
-                                {currentImage.prompt}
-                              </p>
-                            </div>
-                          </motion.div>
-                        ) : (
-                          <div className="text-center">
-                            <ImageIcon className="mx-auto mb-4 h-16 w-16 text-muted-foreground/30" />
-                            <p className="text-sm text-muted-foreground">
-                              Use the controls on the left to generate once or start the loop.
-                            </p>
-                            <div className="mt-6 grid gap-3 text-left sm:grid-cols-3">
-                              <div className="rounded-2xl border border-border/60 bg-card/70 p-4">
-                                <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                                  First run
-                                </div>
-                                <p className="mt-2 text-sm text-foreground/90">
-                                  Small fallback gives usable first images before FLUX is ready.
-                                </p>
-                              </div>
-                              <div className="rounded-2xl border border-border/60 bg-card/70 p-4">
-                                <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                                  Prompt seed
-                                </div>
-                                <p className="mt-2 text-sm text-foreground/90">
-                                  Give it a loose theme or leave it empty for maximum entropy.
-                                </p>
-                              </div>
-                              <div className="rounded-2xl border border-border/60 bg-card/70 p-4">
-                                <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                                  Continuous
-                                </div>
-                                <p className="mt-2 text-sm text-foreground/90">
-                                  Use the session loop here, or run the CLI loop for background jobs.
-                                </p>
-                              </div>
+                            <div className="mt-2 text-xs leading-6 text-muted-foreground">
+                              Last activity: {lastActivity}
                             </div>
                           </div>
-                        )}
-                      </AnimatePresence>
-                    </div>
-                  </div>
 
-                  <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
-                    <div className="ambient-panel rounded-3xl border border-border/80 p-5">
+                          <div className="flex flex-wrap gap-2">
+                            <button
+                              onClick={() => setPromptSeed("")}
+                              className="rounded-full border border-border/70 px-4 py-3 text-sm text-muted-foreground transition hover:border-primary/30 hover:text-foreground"
+                            >
+                              Clear prompt
+                            </button>
+                          </div>
+                        </div>
+
+                        <div className="grid content-start gap-4">
+                          <div className="rounded-[1.75rem] border border-border/70 bg-background/82 p-4">
+                            <div className="mb-3 flex items-center justify-between gap-3">
+                              <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                                Image backend
+                              </div>
+                              <div className="text-xs text-muted-foreground capitalize">{selectedBackend}</div>
+                            </div>
+                            <div className="grid grid-cols-2 gap-2">
+                              {DASHBOARD_BACKEND_OPTIONS.map((option) => (
+                                <button
+                                  key={option.id}
+                                  onClick={() => void updateBackend(option.id)}
+                                  className={cn(
+                                    "rounded-2xl border px-3 py-2 text-sm transition",
+                                    selectedBackend === option.id
+                                      ? "border-primary/40 bg-primary/12 text-foreground"
+                                      : "border-border/70 bg-background/75 text-muted-foreground hover:border-primary/30 hover:text-foreground"
+                                  )}
+                                >
+                                  {option.label}
+                                </button>
+                              ))}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="ambient-panel rounded-[2rem] border border-border/80 p-5">
+                      <div className="mb-4 flex items-center justify-between gap-4">
+                        <div>
+                          <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                            Current output
+                          </div>
+                          <div className="mt-1 text-lg font-semibold text-foreground">
+                            {currentImage ? "Latest generation" : "Waiting for first image"}
+                          </div>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          <span className="status-pill capitalize">{currentBackend}</span>
+                          <span className="status-pill">{currentPluginCount} plugins</span>
+                          {isSmokeBackend ? <span className="status-pill">smoke-test quality</span> : null}
+                        </div>
+                      </div>
+
+                      <div className="min-h-[380px] rounded-[1.5rem] border border-border/70 bg-background/70 p-4">
+                        <AnimatePresence mode="wait">
+                          {isGenerating ? (
+                            <motion.div
+                              key="loading"
+                              initial={{ opacity: 0, scale: 0.97 }}
+                              animate={{ opacity: 1, scale: 1 }}
+                              exit={{ opacity: 0, scale: 0.97 }}
+                              className="flex min-h-[340px] flex-col items-center justify-center text-center"
+                            >
+                              <TaskProgress progress={generationProgress ?? INITIAL_IMAGE_PROGRESS} />
+                            </motion.div>
+                          ) : currentImage ? (
+                            <motion.div
+                              key={currentImage.id}
+                              initial={{ opacity: 0, scale: 0.97 }}
+                              animate={{ opacity: 1, scale: 1 }}
+                              exit={{ opacity: 0, scale: 0.97 }}
+                              className="flex w-full flex-col items-center"
+                            >
+                              <div className="flex min-h-[320px] w-full items-center justify-center rounded-[1.5rem] border border-border/60 bg-[radial-gradient(circle_at_top,hsl(var(--accent)/0.08),transparent_22rem)] px-4 py-6">
+                                {/* Backend-served generated files are not routed through Next image optimization. */}
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                  src={`${API_BASE}${currentImage.image_path}`}
+                                  alt="Generated image"
+                                  className="max-h-[62vh] max-w-full rounded-2xl object-contain shadow-[0_24px_80px_rgba(0,0,0,0.34)]"
+                                />
+                              </div>
+                              <div className="mt-4 w-full rounded-2xl border border-border/60 bg-background/80 px-4 py-3">
+                                <p className="text-sm leading-7 text-muted-foreground">
+                                  {currentImage.prompt}
+                                </p>
+                              </div>
+                            </motion.div>
+                          ) : (
+                            <div className="flex min-h-[340px] flex-col items-center justify-center text-center">
+                              <ImageIcon className="mb-4 h-14 w-14 text-muted-foreground/30" />
+                              <p className="text-sm text-muted-foreground">
+                                Generate once when the prompt and runtime controls are ready.
+                              </p>
+                            </div>
+                          )}
+                        </AnimatePresence>
+                      </div>
+                    </div>
+                  </section>
+
+                  <aside className="grid content-start gap-4">
+                    <div className="ambient-panel rounded-[1.75rem] border border-border/80 p-5">
+                      <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                        Session
+                      </div>
+                      <div className="mt-4 grid gap-3">
+                        <div className="rounded-2xl border border-border/60 bg-background/78 px-4 py-3">
+                          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                            <Clock3 className="h-4 w-4 text-primary" />
+                            {loopEnabled ? "Loop running" : "Loop stopped"}
+                          </div>
+                          <div className="mt-2 text-xs leading-6 text-muted-foreground">
+                            Next run: {loopEnabled ? formatCountdown(nextRunAt) : "Not scheduled"}
+                          </div>
+                        </div>
+
+                        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+                          <div className="rounded-2xl border border-border/60 bg-background/78 px-4 py-3">
+                            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                              Backend
+                            </div>
+                            <div className="mt-2 text-sm font-medium capitalize text-foreground">
+                              {currentBackend}
+                            </div>
+                          </div>
+                          <div className="rounded-2xl border border-border/60 bg-background/78 px-4 py-3">
+                            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                              This session
+                            </div>
+                            <div className="mt-2 text-sm font-medium text-foreground">
+                              {sessionCount} images
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="rounded-2xl border border-border/60 bg-background/78 px-4 py-3">
+                          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                            Last activity
+                          </div>
+                          <div className="mt-2 text-sm leading-6 text-foreground">{lastActivity}</div>
+                        </div>
+                      </div>
+
+                    </div>
+
+                    <div className="ambient-panel rounded-[1.75rem] border border-border/80 p-5">
                       <div className="mb-4 flex items-center justify-between gap-3">
-                        <div className="flex items-center gap-2">
-                          <GalleryHorizontalEnd className="h-4 w-4 text-primary" />
-                          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                        <div>
+                          <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
                             Recent outputs
+                          </div>
+                          <h2 className="mt-1 text-lg font-semibold text-foreground">
+                            Quick picks
                           </h2>
                         </div>
-                        <button
-                          onClick={() => void loadRecentImages()}
-                          className="text-xs text-muted-foreground transition hover:text-foreground"
-                        >
-                          refresh
-                        </button>
                       </div>
 
                       {recentImages.length > 0 ? (
-                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-                          {recentImages.map((image) => (
+                        <div className="space-y-3">
+                          {recentImages.slice(0, 3).map((image) => (
                             <button
                               key={image.path}
                               onClick={() => {
@@ -708,71 +832,34 @@ export default function Home() {
                                   created_at: image.created_at,
                                 });
                               }}
-                              className="overflow-hidden rounded-2xl border border-border bg-background text-left transition hover:border-primary/40 hover:bg-muted/30"
+                              className="flex w-full items-center gap-3 rounded-2xl border border-border/60 bg-background/78 p-3 text-left transition hover:border-primary/35 hover:bg-background/90"
                             >
                               {/* Backend-served generated files are not routed through Next image optimization. */}
                               {/* eslint-disable-next-line @next/next/no-img-element */}
                               <img
                                 src={`${API_BASE}${image.path}`}
                                 alt="Recent generation"
-                                className="h-36 w-full object-cover"
+                                className="h-16 w-16 rounded-xl object-cover"
                               />
-                              <div className="p-3">
+                              <div className="min-w-0">
                                 <p className="text-xs text-muted-foreground">
                                   {new Date(image.created_at).toLocaleString()}
                                 </p>
-                                <p className="mt-1 text-xs text-foreground">
-                                  {truncatePrompt(image.prompt)}
+                                <p className="mt-1 text-sm leading-6 text-foreground">
+                                  {truncatePrompt(image.prompt, 58)}
                                 </p>
                               </div>
                             </button>
                           ))}
                         </div>
                       ) : (
-                        <div className="rounded-2xl bg-background px-4 py-10 text-center text-sm text-muted-foreground">
+                        <div className="rounded-2xl border border-border/60 bg-background/78 px-4 py-8 text-center text-sm text-muted-foreground">
                           No recent images yet.
                         </div>
                       )}
                     </div>
-
-                    <div className="ambient-panel rounded-3xl border border-border/80 p-5">
-                      <button
-                        onClick={() => setShowLogs((value) => !value)}
-                        className="mb-4 flex w-full items-center justify-between gap-3"
-                      >
-                        <div className="flex items-center gap-2">
-                          <Cpu className="h-4 w-4 text-primary" />
-                          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                            Session log
-                          </h2>
-                        </div>
-                        <span className="text-xs text-muted-foreground">
-                          {showLogs ? "hide" : "show"}
-                        </span>
-                      </button>
-
-                      {showLogs ? (
-                        <div className="space-y-2 rounded-2xl border border-border/60 bg-background/80 p-4 font-mono text-xs">
-                          {logs.map((log, index) => (
-                            <div
-                              key={`${log}-${index}`}
-                              className={cn(
-                                "break-words",
-                                log.includes("[ERROR]") ? "text-destructive" : "text-primary"
-                              )}
-                            >
-                              {log}
-                            </div>
-                          ))}
-                        </div>
-                      ) : (
-                        <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-10 text-center text-sm text-muted-foreground">
-                          Logs hidden.
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </section>
+                  </aside>
+                </div>
               </div>
             </motion.div>
           )}

--- a/web-ui/app/playground/page.tsx
+++ b/web-ui/app/playground/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 /* eslint-disable @next/next/no-img-element */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Sparkles,
   Loader2,
@@ -17,14 +17,27 @@ import { api, GenerateResponse, PluginInfo, API_BASE } from "@/lib/api";
 import { motion, AnimatePresence } from "framer-motion";
 import MetaPromptModal from "@/components/MetaPromptModal";
 import AdvancedControls from "@/components/AdvancedControls";
+import TaskProgress from "@/components/TaskProgress";
+import {
+  createClientRequestId,
+  getFallbackProgress,
+  getTaskProgressUpdate,
+  INITIAL_IMAGE_PROGRESS,
+  INITIAL_PROMPT_PROGRESS,
+  type ProgressSnapshot,
+} from "@/lib/task-progress";
 
 export default function Playground() {
   // State management
   const [metaPrompt, setMetaPrompt] = useState("");
   const [generatedPrompt, setGeneratedPrompt] = useState("");
   const [finalPrompt, setFinalPrompt] = useState("");
+  const [promptError, setPromptError] = useState<string | null>(null);
+  const [imageError, setImageError] = useState<string | null>(null);
   const [isGeneratingPrompt, setIsGeneratingPrompt] = useState(false);
   const [isGeneratingImage, setIsGeneratingImage] = useState(false);
+  const [promptProgress, setPromptProgress] = useState<ProgressSnapshot | null>(null);
+  const [imageProgress, setImageProgress] = useState<ProgressSnapshot | null>(null);
   const [currentImage, setCurrentImage] = useState<GenerateResponse | null>(null);
   const [recentGenerations, setRecentGenerations] = useState<GenerateResponse[]>([]);
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
@@ -36,10 +49,83 @@ export default function Playground() {
     history: true
   });
   const [seed, setSeed] = useState<number | null>(null);
+  const promptRequestIdRef = useRef<string | null>(null);
+  const imageRequestIdRef = useRef<string | null>(null);
+  const promptResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const imageResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     loadPlugins();
   }, []);
+
+  useEffect(() => {
+    const unsubscribe = api.subscribeWebSocket((data) => {
+      const nextPromptProgress = getTaskProgressUpdate(
+        data,
+        "prompt_generation",
+        promptRequestIdRef.current
+      );
+      if (nextPromptProgress) {
+        setPromptProgress((prev) =>
+          prev && prev.progress > nextPromptProgress.progress ? prev : nextPromptProgress
+        );
+      }
+
+      const nextImageProgress = getTaskProgressUpdate(
+        data,
+        "image_generation",
+        imageRequestIdRef.current
+      );
+      if (nextImageProgress) {
+        setImageProgress((prev) =>
+          prev && prev.progress > nextImageProgress.progress ? prev : nextImageProgress
+        );
+      }
+
+      if (typeof data !== "object" || data === null || !("type" in data)) return;
+
+      const msg = data as Record<string, unknown>;
+      if (
+        msg.type === "generation_error" &&
+        msg.client_request_id === imageRequestIdRef.current
+      ) {
+        setImageError(String(msg.error ?? "Failed to generate image"));
+        setIsGeneratingImage(false);
+        setImageProgress(null);
+        imageRequestIdRef.current = null;
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      if (promptResetTimeoutRef.current) clearTimeout(promptResetTimeoutRef.current);
+      if (imageResetTimeoutRef.current) clearTimeout(imageResetTimeoutRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isGeneratingPrompt || !promptProgress || promptProgress.progress >= 96) return;
+
+    const timeoutId = setTimeout(() => {
+      setPromptProgress((prev) =>
+        prev ? getFallbackProgress("prompt_generation", prev) : prev
+      );
+    }, 1800);
+
+    return () => clearTimeout(timeoutId);
+  }, [isGeneratingPrompt, promptProgress]);
+
+  useEffect(() => {
+    if (!isGeneratingImage || !imageProgress || imageProgress.progress >= 96) return;
+
+    const timeoutId = setTimeout(() => {
+      setImageProgress((prev) =>
+        prev ? getFallbackProgress("image_generation", prev) : prev
+      );
+    }, 2500);
+
+    return () => clearTimeout(timeoutId);
+  }, [isGeneratingImage, imageProgress]);
 
   const loadPlugins = async () => {
     try {
@@ -51,15 +137,32 @@ export default function Playground() {
   };
 
   const handleGeneratePrompt = async () => {
+    const clientRequestId = createClientRequestId("prompt");
+    promptRequestIdRef.current = clientRequestId;
+    if (promptResetTimeoutRef.current) clearTimeout(promptResetTimeoutRef.current);
     setIsGeneratingPrompt(true);
+    setPromptError(null);
+    setPromptProgress(INITIAL_PROMPT_PROGRESS);
     try {
-      const response = await api.generatePrompt(metaPrompt || undefined);
+      const response = await api.generatePrompt(metaPrompt || undefined, clientRequestId);
 
       setGeneratedPrompt(response.prompt);
       setFinalPrompt(response.prompt);
+      setPromptProgress({
+        progress: 100,
+        title: "Prompt ready",
+        detail: "The generated prompt is ready to edit or use directly.",
+      });
+      if (promptResetTimeoutRef.current) clearTimeout(promptResetTimeoutRef.current);
+      promptResetTimeoutRef.current = setTimeout(() => {
+        setPromptProgress(null);
+      }, 900);
     } catch (error) {
       console.error('Failed to generate prompt:', error);
+      setPromptError(error instanceof Error ? error.message : 'Failed to generate prompt');
+      setPromptProgress(null);
     } finally {
+      promptRequestIdRef.current = null;
       setIsGeneratingPrompt(false);
     }
   };
@@ -67,21 +170,39 @@ export default function Playground() {
   const handleGenerateImage = async () => {
     if (!finalPrompt.trim()) return;
 
+    const clientRequestId = createClientRequestId("image");
+    imageRequestIdRef.current = clientRequestId;
+    if (imageResetTimeoutRef.current) clearTimeout(imageResetTimeoutRef.current);
     setIsGeneratingImage(true);
+    setImageError(null);
+    setImageProgress(INITIAL_IMAGE_PROGRESS);
     try {
       const response = await api.generate({
         prompt: finalPrompt,
         enable_plugins: true,
-        seed: seed ?? undefined
+        seed: seed ?? undefined,
+        client_request_id: clientRequestId,
       });
 
       setCurrentImage(response);
 
       // Add to recent generations (keep last 10)
       setRecentGenerations(prev => [response, ...prev].slice(0, 10));
+      setImageProgress({
+        progress: 100,
+        title: "Image ready",
+        detail: "The generated image is saved and ready to review.",
+      });
+      if (imageResetTimeoutRef.current) clearTimeout(imageResetTimeoutRef.current);
+      imageResetTimeoutRef.current = setTimeout(() => {
+        setImageProgress(null);
+      }, 1200);
     } catch (error) {
       console.error('Failed to generate image:', error);
+      setImageError(error instanceof Error ? error.message : 'Failed to generate image');
+      setImageProgress(null);
     } finally {
+      imageRequestIdRef.current = null;
       setIsGeneratingImage(false);
     }
   };
@@ -156,6 +277,16 @@ export default function Playground() {
                         )}
                       </button>
 
+                      {isGeneratingPrompt && promptProgress && (
+                        <TaskProgress progress={promptProgress} compact />
+                      )}
+
+                      {promptError && (
+                        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                          {promptError}
+                        </div>
+                      )}
+
                       {/* Generated Prompt Display */}
                       {generatedPrompt && (
                         <div className="space-y-2">
@@ -196,6 +327,16 @@ export default function Playground() {
                           </div>
                         )}
                       </button>
+
+                      {isGeneratingImage && imageProgress && (
+                        <TaskProgress progress={imageProgress} compact />
+                      )}
+
+                      {imageError && (
+                        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                          {imageError}
+                        </div>
+                      )}
                     </div>
                   </motion.div>
                 )}
@@ -287,11 +428,9 @@ export default function Playground() {
                 initial={{ opacity: 0, scale: 0.9 }}
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.9 }}
-                className="text-center"
+                className="w-full px-6"
               >
-                <Loader2 className="w-16 h-16 text-primary animate-spin mx-auto mb-4" />
-                <p className="text-sm text-foreground">Generating image...</p>
-                <p className="text-xs text-muted-foreground mt-2">This may take a moment</p>
+                <TaskProgress progress={imageProgress ?? INITIAL_IMAGE_PROGRESS} />
               </motion.div>
             ) : currentImage ? (
               <motion.div

--- a/web-ui/components/Gallery.tsx
+++ b/web-ui/components/Gallery.tsx
@@ -1,7 +1,7 @@
 "use client";
 /* eslint-disable @next/next/no-img-element */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Trash2, Download, X, Loader2, Clock, FileText,
   Calendar, Grid, ChevronRight, Folder
@@ -35,6 +35,40 @@ interface WeekGroup {
 
 type ViewMode = "week" | "all";
 
+const ALL_PAGE_SIZE = 20;
+const WEEK_PAGE_SIZE = 200;
+const CACHE_TIMEOUT_MS = 800;
+const GALLERY_TIMEOUT_MS = 30000;
+
+const withTimeout = async <T,>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  fallback: T
+): Promise<T> => (
+  new Promise((resolve) => {
+    let settled = false;
+    const timeoutId = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve(fallback);
+    }, timeoutMs);
+
+    promise
+      .then((value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        resolve(value);
+      })
+      .catch(() => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        resolve(fallback);
+      });
+  })
+);
+
 export default function Gallery() {
   const [images, setImages] = useState<GalleryImage[]>([]);
   const [weekGroups, setWeekGroups] = useState<WeekGroup[]>([]);
@@ -46,8 +80,9 @@ export default function Gallery() {
   const [deleting, setDeleting] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>("week");
+  const loadRequestRef = useRef(0);
 
-  const imagesPerPage = viewMode === "all" ? 20 : 200; // Load reasonable amount for week view
+  const imagesPerPage = viewMode === "all" ? ALL_PAGE_SIZE : WEEK_PAGE_SIZE;
 
   const organizeByWeek = useCallback((images: GalleryImage[]) => {
     const groups = new Map<string, WeekGroup>();
@@ -88,40 +123,27 @@ export default function Gallery() {
   }, []);
 
   const loadImages = useCallback(async () => {
+    const requestId = loadRequestRef.current + 1;
+    loadRequestRef.current = requestId;
+    const limit = viewMode === "all" ? ALL_PAGE_SIZE : WEEK_PAGE_SIZE;
+    const offset = viewMode === "all" ? page * ALL_PAGE_SIZE : 0;
+    const cacheKey = `gallery_${viewMode}_${page}_${limit}`;
+
     setLoading(true);
     setError(null);
 
     try {
-      // Create cache key based on view mode and page
-      const cacheKey = `gallery_${viewMode}_${page}_${viewMode === "all" ? imagesPerPage : 200}`;
-
-      // Try to get from cache first
-      const cachedData = await galleryCache.get<GalleryResponse>(cacheKey);
-
-      if (cachedData && cachedData.total > 0) {
-        console.log('Loading gallery from cache');
-        setImages(cachedData.images);
-        setTotal(cachedData.total);
-
-        if (viewMode === "week") {
-          organizeByWeek(cachedData.images);
-        }
-        setLoading(false);
-        return;
-      }
-
-      // If not in cache or expired, fetch from API
       console.log('Fetching gallery from API');
-      const response: GalleryResponse = await api.getGallery(
-        viewMode === "all" ? imagesPerPage : 200, // Load reasonable amount for week view
-        viewMode === "all" ? page * imagesPerPage : 0
-      );
+      const response: GalleryResponse = await api.getGallery(limit, offset, GALLERY_TIMEOUT_MS);
 
-      // Save to cache
-      await galleryCache.set(cacheKey, {
+      if (loadRequestRef.current !== requestId) return;
+
+      void withTimeout(galleryCache.set(cacheKey, {
         images: response.images,
-        total: response.total
-      });
+        total: response.total,
+        limit: response.limit,
+        offset: response.offset,
+      }), CACHE_TIMEOUT_MS, undefined);
 
       setImages(response.images);
       setTotal(response.total);
@@ -130,31 +152,35 @@ export default function Gallery() {
         organizeByWeek(response.images);
       }
     } catch (err) {
-      setError("Failed to load gallery");
       console.error('Gallery load error:', err);
 
-      // Try to load from cache even if API fails
-      try {
-        const cacheKey = `gallery_${viewMode}_${page}_${viewMode === "all" ? imagesPerPage : 200}`;
-        const cachedData = await galleryCache.get<GalleryResponse>(cacheKey);
+      const cachedData = await withTimeout(
+        galleryCache.get<GalleryResponse>(cacheKey),
+        CACHE_TIMEOUT_MS,
+        null
+      );
 
-        if (cachedData && cachedData.total > 0) {
-          console.log('API failed, using cached data');
-          setImages(cachedData.images);
-          setTotal(cachedData.total);
+      if (loadRequestRef.current !== requestId) return;
 
-          if (viewMode === "week") {
-            organizeByWeek(cachedData.images);
-          }
-          setError(null); // Clear error if cache loads successfully
+      if (cachedData && cachedData.total > 0) {
+        console.log('API failed, using cached data');
+        setImages(cachedData.images);
+        setTotal(cachedData.total);
+
+        if (viewMode === "week") {
+          organizeByWeek(cachedData.images);
         }
-      } catch (cacheErr) {
-        console.error('Cache fallback failed:', cacheErr);
+        setError(null);
+      } else {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        setError(`Failed to load gallery. ${message}`);
       }
     } finally {
-      setLoading(false);
+      if (loadRequestRef.current === requestId) {
+        setLoading(false);
+      }
     }
-  }, [imagesPerPage, organizeByWeek, page, viewMode]);
+  }, [organizeByWeek, page, viewMode]);
 
   const getWeekNumber = (date: Date): number => {
     const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
@@ -203,7 +229,7 @@ export default function Gallery() {
       await api.deleteImage(relativePath);
 
       // Clear cache after deletion
-      await galleryCache.clear();
+      await withTimeout(galleryCache.clear(), CACHE_TIMEOUT_MS, undefined);
 
       await loadImages();
       if (selectedImage?.path === imagePath) {
@@ -382,8 +408,8 @@ export default function Gallery() {
 
               <button
                 onClick={async () => {
-                  await galleryCache.clear(); // Clear cache on manual refresh
-                  loadImages();
+                  await withTimeout(galleryCache.clear(), CACHE_TIMEOUT_MS, undefined);
+                  void loadImages();
                 }}
                 className="text-sm text-muted-foreground hover:text-foreground"
                 disabled={loading}

--- a/web-ui/components/Settings.tsx
+++ b/web-ui/components/Settings.tsx
@@ -17,18 +17,42 @@ import {
   HardDrive,
   RefreshCw,
   ArrowUp,
-  ArrowDown
+  ArrowDown,
+  SlidersHorizontal,
+  Sparkles,
 } from "lucide-react";
-import { api, ModelStatus, ModelInfo, HFTokenStatus, SystemStatus, OllamaModelsResponse, PluginInfo } from "@/lib/api";
+import {
+  api,
+  ModelStatus,
+  ModelInfo,
+  HFTokenStatus,
+  SystemStatus,
+  OllamaModelsResponse,
+  PluginInfo,
+  GenerationConfig,
+} from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface SettingsProps {
   systemStatus: SystemStatus | null;
 }
 
+const IMAGE_BACKEND_OPTIONS = [
+  { id: "auto", label: "Auto", description: "Use the best ready local backend." },
+  { id: "zimage", label: "Z-Image", description: "Use the Z-Image stack and local LoRAs." },
+  { id: "ollama", label: "Ollama Image", description: "Use an image-capable Ollama model over the local Ollama host API." },
+  { id: "flux", label: "FLUX", description: "Prefer the FLUX transformer path." },
+  { id: "small", label: "Small SD", description: "Use the lightweight public fallback." },
+  { id: "turbo", label: "Turbo", description: "Run the fast SD Turbo backend." },
+  { id: "smoke", label: "Smoke", description: "Use the tiny smoke-test model." },
+  { id: "mock", label: "Mock", description: "Generate placeholders without loading a model." },
+] as const;
+
 export default function Settings({ systemStatus }: SettingsProps) {
   const [activeSection, setActiveSection] = useState("models");
   const [modelStatus, setModelStatus] = useState<ModelStatus | null>(null);
+  const [generationConfig, setGenerationConfig] = useState<GenerationConfig | null>(null);
+  const [loadingGenerationConfig, setLoadingGenerationConfig] = useState(false);
   const [hfTokenStatus, setHFTokenStatus] = useState<HFTokenStatus | null>(null);
   const [hfToken, setHFToken] = useState("");
   const [showToken, setShowToken] = useState(false);
@@ -42,6 +66,7 @@ export default function Settings({ systemStatus }: SettingsProps) {
 
   useEffect(() => {
     loadModelStatus();
+    loadGenerationConfig();
     loadHFTokenStatus();
     loadOllamaModels();
     loadPlugins();
@@ -49,27 +74,28 @@ export default function Settings({ systemStatus }: SettingsProps) {
 
   useEffect(() => {
     // Handle WebSocket messages for model download progress
-    if (api) {
-      const handleWebSocketMessage = (data: unknown) => {
-        if (typeof data === 'object' && data !== null && 'type' in data) {
-          const msg = data as Record<string, unknown>;
+    const handleWebSocketMessage = (data: unknown) => {
+      if (typeof data === 'object' && data !== null && 'type' in data) {
+        const msg = data as Record<string, unknown>;
 
-          if (msg.type === 'model_download_started') {
-            setDownloadingModels(prev => new Set(prev).add(msg.model_id as string));
-          } else if (msg.type === 'model_download_completed' || msg.type === 'model_download_error') {
-            setDownloadingModels(prev => {
-              const newSet = new Set(prev);
-              newSet.delete(msg.model_id as string);
-              return newSet;
-            });
-            loadModelStatus(); // Refresh model status
-          }
+        if (msg.type === 'model_download_started') {
+          setDownloadingModels(prev => new Set(prev).add(msg.model_id as string));
+        } else if (msg.type === 'model_download_completed' || msg.type === 'model_download_error') {
+          setDownloadingModels(prev => {
+            const newSet = new Set(prev);
+            newSet.delete(msg.model_id as string);
+            return newSet;
+          });
+          loadModelStatus(); // Refresh model status
         }
-      };
+      }
+    };
 
-      // Connect with our message handler
-      api.connectWebSocket(handleWebSocketMessage);
-    }
+    const unsubscribe = api.subscribeWebSocket(handleWebSocketMessage);
+
+    return () => {
+      unsubscribe();
+    };
   }, []);
 
   const loadModelStatus = async () => {
@@ -78,6 +104,19 @@ export default function Settings({ systemStatus }: SettingsProps) {
       setModelStatus(status);
     } catch (error) {
       console.error('Failed to load model status:', error);
+    }
+  };
+
+  const loadGenerationConfig = async () => {
+    setLoadingGenerationConfig(true);
+    try {
+      const currentConfig = await api.getGenerationConfig();
+      setGenerationConfig(currentConfig);
+    } catch (error) {
+      console.error('Failed to load generation config:', error);
+      setMessage({ type: 'error', text: 'Failed to load generation settings' });
+    } finally {
+      setLoadingGenerationConfig(false);
     }
   };
 
@@ -116,6 +155,26 @@ export default function Settings({ systemStatus }: SettingsProps) {
     }
   };
 
+  const updateGenerationConfig = async (
+    updates: Partial<GenerationConfig>,
+    successText?: string
+  ) => {
+    try {
+      const response = await api.setGenerationConfig(updates);
+      setGenerationConfig(response.config);
+      if (successText) {
+        setMessage({ type: 'success', text: successText });
+        setTimeout(() => setMessage(null), 4000);
+      }
+    } catch (error) {
+      setMessage({
+        type: 'error',
+        text: `Failed to update generation settings: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      });
+      setTimeout(() => setMessage(null), 5000);
+    }
+  };
+
   const handleOllamaModelSelect = async (modelName: string) => {
     try {
       await api.setOllamaModel(modelName);
@@ -129,6 +188,14 @@ export default function Settings({ systemStatus }: SettingsProps) {
     }
 
     setTimeout(() => setMessage(null), 5000);
+  };
+
+  const handleOllamaImageModelSelect = async (modelName: string) => {
+    await updateGenerationConfig(
+      { ollama_image_model: modelName },
+      `Switched Ollama image model to ${modelName}`
+    );
+    await loadOllamaModels();
   };
 
   const handlePluginToggle = async (pluginName: string) => {
@@ -218,6 +285,20 @@ export default function Settings({ systemStatus }: SettingsProps) {
     setTimeout(() => setMessage(null), 5000);
   };
 
+  const toggleEnabledLora = async (loraName: string) => {
+    const enabledLoras = generationConfig?.enabled_loras ?? [];
+    const nextEnabledLoras = enabledLoras.includes(loraName)
+      ? enabledLoras.filter((name) => name !== loraName)
+      : [...enabledLoras, loraName];
+
+    await updateGenerationConfig(
+      { enabled_loras: nextEnabledLoras },
+      nextEnabledLoras.includes(loraName)
+        ? `Enabled LoRA ${loraName}`
+        : `Disabled LoRA ${loraName}`
+    );
+  };
+
   const formatFileSize = (bytes: number) => {
     if (bytes === 0) return '0 B';
     const k = 1024;
@@ -251,6 +332,18 @@ export default function Settings({ systemStatus }: SettingsProps) {
       default: return <AlertCircle className="w-4 h-4 text-gray-400" />;
     }
   };
+
+  const loraPluginEnabled = plugins.some((plugin) => plugin.name === "lora" && plugin.enabled);
+  const selectedBackend = generationConfig?.image_backend ?? "auto";
+  const availableLoras = generationConfig?.available_loras ?? [];
+  const enabledLoras = generationConfig?.enabled_loras ?? [];
+  const loraProbability = generationConfig?.lora_application_probability ?? 0;
+  const promptCapableModels = ollamaModels?.models.filter((model) => model.can_prompt) ?? [];
+  const imageCapableModels = ollamaModels?.models.filter((model) => model.can_image) ?? [];
+  const configuredPromptModel = ollamaModels?.configured_prompt ?? "";
+  const activePromptModel = ollamaModels?.current ?? null;
+  const configuredImageModel = generationConfig?.ollama_image_model ?? ollamaModels?.configured_image ?? "";
+  const activeImageModel = ollamaModels?.current_image ?? null;
 
   const sections = [
     { id: "models", label: "Models", icon: Database },
@@ -314,7 +407,10 @@ export default function Settings({ systemStatus }: SettingsProps) {
                     </p>
                   </div>
                   <button
-                    onClick={loadModelStatus}
+                    onClick={() => {
+                      loadModelStatus();
+                      loadGenerationConfig();
+                    }}
                     className="p-2 hover:bg-background rounded-md transition-colors"
                     title="Refresh model status"
                   >
@@ -333,6 +429,168 @@ export default function Settings({ systemStatus }: SettingsProps) {
                     </code>
                   </div>
                 )}
+
+                <div className="mb-6 space-y-6">
+                  <div className="border border-border rounded-lg p-4">
+                    <div className="flex items-center gap-2 mb-3">
+                      <SlidersHorizontal className="w-4 h-4 text-primary" />
+                      <div>
+                        <h4 className="font-medium">Active Image Backend</h4>
+                        <p className="text-sm text-muted-foreground">
+                          Choose which backend DreamGen uses for new generations.
+                        </p>
+                      </div>
+                    </div>
+
+                    {loadingGenerationConfig ? (
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        Loading generation settings...
+                      </div>
+                    ) : (
+                      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
+                        {IMAGE_BACKEND_OPTIONS.map((backend) => {
+                          const isActive = selectedBackend === backend.id;
+                          return (
+                            <button
+                              key={backend.id}
+                              type="button"
+                              onClick={() =>
+                                updateGenerationConfig(
+                                  { image_backend: backend.id },
+                                  `Switched image backend to ${backend.label}`
+                                )
+                              }
+                              className={cn(
+                                "rounded-lg border p-3 text-left transition-colors",
+                                isActive
+                                  ? "border-primary bg-primary/5"
+                                  : "border-border hover:bg-muted/40"
+                              )}
+                            >
+                              <div className="flex items-center justify-between gap-2">
+                                <span className="font-medium">{backend.label}</span>
+                                {isActive && (
+                                  <span className="text-[11px] px-2 py-0.5 rounded-full bg-primary/15 text-primary">
+                                    Active
+                                  </span>
+                                )}
+                              </div>
+                              <p className="mt-2 text-xs text-muted-foreground">
+                                {backend.description}
+                              </p>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    {selectedBackend === "ollama" && (
+                      <div className="mt-4 rounded-md bg-muted/50 p-3 text-sm text-muted-foreground">
+                        DreamGen will call Ollama&apos;s experimental image API with the selected Ollama image model.
+                        {activeImageModel ? (
+                          <span className="block mt-1 text-foreground">
+                            Active image model: {activeImageModel}
+                          </span>
+                        ) : (
+                          <span className="block mt-1 text-amber-600 dark:text-amber-300">
+                            No image-capable Ollama model is currently available.
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="border border-border rounded-lg p-4">
+                    <div className="flex items-start justify-between gap-3 mb-4">
+                      <div className="flex items-start gap-2">
+                        <Sparkles className="w-4 h-4 text-primary mt-0.5" />
+                        <div>
+                          <h4 className="font-medium">Local LoRA Library</h4>
+                          <p className="text-sm text-muted-foreground">
+                            Select which local LoRAs are eligible when the <code className="text-xs">lora</code> plugin runs.
+                          </p>
+                        </div>
+                      </div>
+                      <span className="text-xs px-2 py-1 rounded-full bg-muted text-muted-foreground">
+                        {availableLoras.length} detected
+                      </span>
+                    </div>
+
+                    <div className="space-y-4">
+                      <div className="rounded-md bg-muted/50 p-3">
+                        <div className="text-xs font-medium text-foreground mb-1">LoRA Directory</div>
+                        <code className="text-xs text-muted-foreground break-all">
+                          {generationConfig?.lora_dir ?? "./loras"}
+                        </code>
+                      </div>
+
+                      <div>
+                        <div className="flex items-center justify-between mb-1">
+                          <label className="text-sm font-medium">Application probability</label>
+                          <span className="text-xs text-muted-foreground">
+                            {Math.round(loraProbability * 100)}%
+                          </span>
+                        </div>
+                        <input
+                          type="range"
+                          min="0"
+                          max="1"
+                          step="0.05"
+                          value={loraProbability}
+                          onChange={(e) =>
+                            updateGenerationConfig({
+                              lora_application_probability: parseFloat(e.target.value),
+                            })
+                          }
+                          className="w-full"
+                        />
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Higher values make LoRA selection more likely when the plugin is enabled.
+                        </p>
+                      </div>
+
+                      {!loraPluginEnabled && (
+                        <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                          The <code>lora</code> plugin is currently disabled. Enable it in the Plugins tab if you want these adapters to be applied.
+                        </div>
+                      )}
+
+                      {selectedBackend === "zimage" && !generationConfig?.zimage_native_available && enabledLoras.length === 0 && (
+                        <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                          Z-Image without an active LoRA still expects a local <code>ref-repos/Z-Image</code> checkout. If you want the simplified DiffSynth path, keep at least one LoRA enabled.
+                        </div>
+                      )}
+
+                      {availableLoras.length > 0 ? (
+                        <div className="flex flex-wrap gap-2">
+                          {availableLoras.map((loraName) => {
+                            const isEnabled = enabledLoras.includes(loraName);
+                            return (
+                              <button
+                                key={loraName}
+                                type="button"
+                                onClick={() => toggleEnabledLora(loraName)}
+                                className={cn(
+                                  "rounded-full border px-3 py-1.5 text-sm transition-colors",
+                                  isEnabled
+                                    ? "border-primary bg-primary text-primary-foreground"
+                                    : "border-border hover:bg-muted/40"
+                                )}
+                              >
+                                {loraName}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        <div className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
+                          No LoRAs found yet. Add adapters under <code>{generationConfig?.lora_dir ?? "./loras"}</code> and refresh this page.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
 
                 <div className="space-y-4">
                   {modelStatus?.models.map((model) => {
@@ -369,6 +627,11 @@ export default function Settings({ systemStatus }: SettingsProps) {
                                   {model.incomplete_files} files downloading...
                                 </div>
                               )}
+                              {model.path && model.id === "local:zimage" && (
+                                <div className="text-xs text-muted-foreground mt-1 break-all">
+                                  {model.path}
+                                </div>
+                              )}
                             </div>
                           </div>
 
@@ -378,7 +641,7 @@ export default function Settings({ systemStatus }: SettingsProps) {
                                 onClick={() => handleModelDownload(model.id)}
                                 className="px-3 py-1.5 bg-primary text-primary-foreground text-xs rounded-md hover:opacity-90 transition-opacity"
                               >
-                                Download
+                                {model.id === "local:zimage" ? "Download Local Copy" : "Download"}
                               </button>
                             )}
                             {isDownloading && (
@@ -417,7 +680,7 @@ export default function Settings({ systemStatus }: SettingsProps) {
                   <div>
                     <h3 className="text-xl font-semibold">Ollama Model Selection</h3>
                     <p className="text-sm text-muted-foreground mt-1">
-                      Select which Ollama model to use for prompt generation
+                      Select which Ollama models DreamGen uses for prompt generation and the Ollama image backend
                     </p>
                   </div>
                   <button
@@ -432,13 +695,22 @@ export default function Settings({ systemStatus }: SettingsProps) {
 
                 {ollamaModels && (
                   <div className="mb-6 p-4 bg-muted/50 rounded-lg">
-                    <div className="flex items-center gap-2 mb-2">
-                      <Server className="w-4 h-4 text-muted-foreground" />
-                      <span className="text-sm font-medium">Ollama Host</span>
+                    <div className="flex flex-wrap items-center gap-4 text-sm">
+                      <div className="flex items-center gap-2">
+                        <Server className="w-4 h-4 text-muted-foreground" />
+                        <span className="font-medium">Ollama Host</span>
+                        <code className="text-xs text-muted-foreground">
+                          {ollamaModels.host}
+                        </code>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Cpu className="w-4 h-4 text-muted-foreground" />
+                        <span className="font-medium">Version</span>
+                        <code className="text-xs text-muted-foreground">
+                          {ollamaModels.version || "unknown"}
+                        </code>
+                      </div>
                     </div>
-                    <code className="text-xs text-muted-foreground">
-                      {ollamaModels.host}
-                    </code>
                   </div>
                 )}
 
@@ -447,49 +719,142 @@ export default function Settings({ systemStatus }: SettingsProps) {
                     <Loader2 className="w-8 h-8 animate-spin text-primary" />
                   </div>
                 ) : ollamaModels && ollamaModels.models.length > 0 ? (
-                  <div className="space-y-2">
-                    {ollamaModels.models.map((model) => {
-                      const isCurrent = model.name === ollamaModels.current;
-                      const sizeInGB = (model.size / (1024 * 1024 * 1024)).toFixed(2);
+                  <div className="space-y-6">
+                    {configuredPromptModel && activePromptModel && configuredPromptModel !== activePromptModel && (
+                      <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                        Configured prompt model <code>{configuredPromptModel}</code> is not usable on this host. DreamGen is falling back to <code>{activePromptModel}</code>.
+                      </div>
+                    )}
 
-                      return (
-                        <button
-                          key={model.name}
-                          onClick={() => handleOllamaModelSelect(model.name)}
-                          className={cn(
-                            "w-full border rounded-lg p-4 transition-all text-left",
-                            "hover:bg-muted/50 hover:border-primary/50",
-                            isCurrent
-                              ? "border-primary bg-primary/5"
-                              : "border-border"
-                          )}
-                        >
-                          <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-3 flex-1">
-                              <div className={cn(
-                                "w-2 h-2 rounded-full",
-                                isCurrent ? "bg-primary" : "bg-muted-foreground"
-                              )} />
-                              <div className="flex-1">
-                                <div className="flex items-center gap-2">
-                                  <h4 className="font-medium">{model.name}</h4>
-                                  {isCurrent && (
-                                    <span className="text-xs px-2 py-0.5 bg-primary/20 text-primary rounded-full">
-                                      Active
-                                    </span>
-                                  )}
+                    <div>
+                      <div className="mb-3">
+                        <h4 className="font-medium">Prompt Models</h4>
+                        <p className="text-sm text-muted-foreground mt-1">
+                          Completion-capable models used for the Generate Prompt action.
+                        </p>
+                      </div>
+
+                      {promptCapableModels.length > 0 ? (
+                        <div className="space-y-2">
+                          {promptCapableModels.map((model) => {
+                            const isCurrent = model.name === activePromptModel;
+                            const sizeInGB = (model.size / (1024 * 1024 * 1024)).toFixed(2);
+
+                            return (
+                              <button
+                                key={`prompt-${model.name}`}
+                                onClick={() => handleOllamaModelSelect(model.name)}
+                                className={cn(
+                                  "w-full border rounded-lg p-4 transition-all text-left",
+                                  "hover:bg-muted/50 hover:border-primary/50",
+                                  isCurrent ? "border-primary bg-primary/5" : "border-border"
+                                )}
+                              >
+                                <div className="flex items-start justify-between gap-3">
+                                  <div className="flex-1">
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                      <h5 className="font-medium">{model.name}</h5>
+                                      {isCurrent && (
+                                        <span className="text-xs px-2 py-0.5 bg-primary/20 text-primary rounded-full">
+                                          Active Prompt
+                                        </span>
+                                      )}
+                                      {model.can_vision && (
+                                        <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                                          Vision
+                                        </span>
+                                      )}
+                                    </div>
+                                    <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1 flex-wrap">
+                                      <span>{sizeInGB} GB</span>
+                                      {model.format && (
+                                        <>
+                                          <span>•</span>
+                                          <span>{model.format}</span>
+                                        </>
+                                      )}
+                                      <span>•</span>
+                                      <span>{new Date(model.modified).toLocaleDateString()}</span>
+                                    </div>
+                                  </div>
                                 </div>
-                                <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
-                                  <span>{sizeInGB} GB</span>
-                                  <span>•</span>
-                                  <span>{new Date(model.modified).toLocaleDateString()}</span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        <div className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
+                          No completion-capable Ollama models found. Install a chat/completion model to use prompt generation.
+                        </div>
+                      )}
+                    </div>
+
+                    <div>
+                      <div className="mb-3">
+                        <h4 className="font-medium">Image Models</h4>
+                        <p className="text-sm text-muted-foreground mt-1">
+                          Image-capable Ollama models used when the backend is set to <code>Ollama Image</code>.
+                        </p>
+                      </div>
+
+                      {configuredImageModel && activeImageModel && configuredImageModel !== activeImageModel && (
+                        <div className="mb-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                          Configured Ollama image model <code>{configuredImageModel}</code> is not usable on this host. DreamGen is falling back to <code>{activeImageModel}</code>.
+                        </div>
+                      )}
+
+                      {imageCapableModels.length > 0 ? (
+                        <div className="space-y-2">
+                          {imageCapableModels.map((model) => {
+                            const isCurrent = model.name === activeImageModel;
+                            const sizeInGB = (model.size / (1024 * 1024 * 1024)).toFixed(2);
+
+                            return (
+                              <button
+                                key={`image-${model.name}`}
+                                onClick={() => handleOllamaImageModelSelect(model.name)}
+                                className={cn(
+                                  "w-full border rounded-lg p-4 transition-all text-left",
+                                  "hover:bg-muted/50 hover:border-primary/50",
+                                  isCurrent ? "border-primary bg-primary/5" : "border-border"
+                                )}
+                              >
+                                <div className="flex items-start justify-between gap-3">
+                                  <div className="flex-1">
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                      <h5 className="font-medium">{model.name}</h5>
+                                      {isCurrent && (
+                                        <span className="text-xs px-2 py-0.5 bg-primary/20 text-primary rounded-full">
+                                          Active Image
+                                        </span>
+                                      )}
+                                      <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                                        {model.family || model.format || "image"}
+                                      </span>
+                                    </div>
+                                    <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1 flex-wrap">
+                                      <span>{sizeInGB} GB</span>
+                                      {model.format && (
+                                        <>
+                                          <span>•</span>
+                                          <span>{model.format}</span>
+                                        </>
+                                      )}
+                                      <span>•</span>
+                                      <span>{new Date(model.modified).toLocaleDateString()}</span>
+                                    </div>
+                                  </div>
                                 </div>
-                              </div>
-                            </div>
-                          </div>
-                        </button>
-                      );
-                    })}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        <div className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
+                          No image-capable Ollama models found. Install one like <code>x/z-image-turbo</code> or <code>x/flux2-klein</code> to use the Ollama image backend.
+                        </div>
+                      )}
+                    </div>
                   </div>
                 ) : (
                   <div className="text-center py-12">

--- a/web-ui/components/TaskProgress.tsx
+++ b/web-ui/components/TaskProgress.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { ProgressSnapshot } from "@/lib/task-progress";
+
+interface TaskProgressProps {
+  progress: ProgressSnapshot;
+  className?: string;
+  compact?: boolean;
+}
+
+export default function TaskProgress({
+  progress,
+  className,
+  compact = false,
+}: TaskProgressProps) {
+  const width = `${Math.max(0, Math.min(100, Math.round(progress.progress)))}%`;
+
+  if (compact) {
+    return (
+      <div className={cn("w-full space-y-2", className)}>
+        <div className="flex items-center gap-2 text-sm text-foreground">
+          <Loader2 className="h-4 w-4 animate-spin text-primary" />
+          <span className="font-medium">{progress.title}</span>
+          <span className="ml-auto text-xs text-muted-foreground">{width}</span>
+        </div>
+        <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-[width] duration-500 ease-out"
+            style={{ width }}
+          />
+        </div>
+        <p className="text-xs leading-5 text-muted-foreground">{progress.detail}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("mx-auto max-w-md text-center", className)}>
+      <Loader2 className="mx-auto mb-4 h-14 w-14 animate-spin text-primary" />
+      <p className="text-sm font-medium text-foreground">{progress.title}</p>
+      <p className="mt-2 text-xs leading-6 text-muted-foreground">{progress.detail}</p>
+      <div className="mt-4 overflow-hidden rounded-full bg-muted">
+        <div
+          className="flex h-2.5 items-center justify-end rounded-full bg-primary pr-2 text-[10px] font-medium text-primary-foreground transition-[width] duration-500 ease-out"
+          style={{ width: `max(${width}, 3.5rem)` }}
+        >
+          {width}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -16,6 +16,7 @@ export interface GenerateRequest {
   use_mock?: boolean;
   enable_plugins?: boolean;
   seed?: number;
+  client_request_id?: string;
 }
 
 export interface GenerateResponse {
@@ -26,6 +27,11 @@ export interface GenerateResponse {
     backend: string;
     plugins_used: string[];
     seed?: number;
+    provider?: string;
+    ollama_model?: string | null;
+    lora_backend?: string | null;
+    using_diffsynth?: boolean;
+    selected_lora?: string | null;
   };
   created_at: string;
 }
@@ -88,17 +94,29 @@ export interface PromptResponse {
   prompt: string;
 }
 
+type WebSocketSubscriber = (data: unknown) => void;
+
 export interface OllamaModel {
   name: string;
   size: number;
   modified: string;
   digest: string;
+  format: string;
+  family: string;
+  capabilities: string[];
+  can_prompt: boolean;
+  can_vision: boolean;
+  can_image: boolean;
 }
 
 export interface OllamaModelsResponse {
   models: OllamaModel[];
-  current: string;
+  current: string | null;
+  configured_prompt: string;
+  current_image: string | null;
+  configured_image: string;
   host: string;
+  version: string;
 }
 
 export interface GenerationConfig {
@@ -108,12 +126,38 @@ export interface GenerationConfig {
   guidance_scale: number;
   true_cfg_scale: number;
   ollama_temperature: number;
+  image_backend?: string;
+  ollama_image_model?: string;
+  enabled_loras?: string[];
+  available_loras?: string[];
+  lora_application_probability?: number;
+  lora_dir?: string;
+  zimage_model_path?: string;
+  zimage_native_available?: boolean;
 }
+
+const extractErrorMessage = async (response: Response, fallback: string) => {
+  try {
+    const data = await response.json();
+    if (typeof data?.detail === 'string' && data.detail.trim()) return data.detail;
+    if (typeof data?.error === 'string' && data.error.trim()) return data.error;
+    if (typeof data?.message === 'string' && data.message.trim()) return data.message;
+    if (typeof data?.detail?.message === 'string' && data.detail.message.trim()) {
+      return data.detail.message;
+    }
+  } catch {
+    // Ignore invalid/non-JSON error payloads and fall back to the generic label.
+  }
+
+  return fallback;
+};
 
 export class ImageGenAPI {
   private baseUrl: string;
   private ws: WebSocket | null = null;
   private intentionalClose: boolean = false;
+  private subscribers: Set<WebSocketSubscriber> = new Set();
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(baseUrl: string = API_BASE) {
     this.baseUrl = baseUrl;
@@ -121,13 +165,13 @@ export class ImageGenAPI {
 
   async getStatus(): Promise<SystemStatus> {
     const response = await fetch(`${this.baseUrl}/api/status`);
-    if (!response.ok) throw new Error('Failed to get status');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get status'));
     return response.json();
   }
 
   async getPlugins(): Promise<PluginInfo[]> {
     const response = await fetch(`${this.baseUrl}/api/plugins`);
-    if (!response.ok) throw new Error('Failed to get plugins');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get plugins'));
     return response.json();
   }
 
@@ -135,7 +179,7 @@ export class ImageGenAPI {
     const response = await fetch(`${this.baseUrl}/api/plugins/${pluginName}/toggle`, {
       method: 'POST',
     });
-    if (!response.ok) throw new Error('Failed to toggle plugin');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to toggle plugin'));
     return response.json();
   }
 
@@ -147,7 +191,7 @@ export class ImageGenAPI {
       },
       body: JSON.stringify({ ordered_names: orderedNames }),
     });
-    if (!response.ok) throw new Error('Failed to update plugin order');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to update plugin order'));
     return response.json();
   }
 
@@ -159,13 +203,13 @@ export class ImageGenAPI {
       },
       body: JSON.stringify(request),
     });
-    if (!response.ok) throw new Error('Failed to generate image');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to generate image'));
     return response.json();
   }
 
-  async getGallery(limit: number = 50, offset: number = 0) {
+  async getGallery(limit: number = 50, offset: number = 0, timeoutMs: number = 20000) {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
       const response = await fetch(
@@ -174,12 +218,12 @@ export class ImageGenAPI {
       );
       clearTimeout(timeoutId);
 
-      if (!response.ok) throw new Error('Failed to get gallery');
+      if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get gallery'));
       return response.json();
     } catch (error) {
       clearTimeout(timeoutId);
       if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error('Gallery request timed out');
+        throw new Error(`Gallery request timed out after ${Math.round(timeoutMs / 1000)}s`);
       }
       throw error;
     }
@@ -189,23 +233,28 @@ export class ImageGenAPI {
     const response = await fetch(`${this.baseUrl}/api/gallery/${encodeURIComponent(imagePath)}`, {
       method: 'DELETE',
     });
-    if (!response.ok) throw new Error('Failed to delete image');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to delete image'));
     return response.json();
   }
 
-  async generatePrompt(metaPrompt?: string): Promise<PromptResponse> {
+  async generatePrompt(metaPrompt?: string, clientRequestId?: string): Promise<PromptResponse> {
     const response = await fetch(`${this.baseUrl}/api/prompt`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ meta_prompt: metaPrompt }),
+      body: JSON.stringify({
+        meta_prompt: metaPrompt,
+        client_request_id: clientRequestId,
+      }),
     });
-    if (!response.ok) throw new Error('Failed to generate prompt');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to generate prompt'));
     return response.json();
   }
 
-  connectWebSocket(onMessage: (data: unknown) => void): void {
+  private connectSocket(): void {
+    if (this.ws || this.subscribers.size === 0) return;
+
     const wsBase = process.env.NEXT_PUBLIC_WS_URL
       ? normalizeBase(process.env.NEXT_PUBLIC_WS_URL, WS_BASE)
       : this.baseUrl.replace(/^http/, 'ws');
@@ -215,12 +264,18 @@ export class ImageGenAPI {
 
       this.ws.onopen = () => {
         console.log('WebSocket connected');
+        if (this.reconnectTimer) {
+          clearTimeout(this.reconnectTimer);
+          this.reconnectTimer = null;
+        }
       };
 
       this.ws.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
-          onMessage(data);
+          for (const subscriber of this.subscribers) {
+            subscriber(data);
+          }
         } catch (error) {
           console.warn('Failed to parse WebSocket message:', error instanceof Error ? error.message : 'Unknown error');
         }
@@ -234,21 +289,44 @@ export class ImageGenAPI {
 
       this.ws.onclose = (event) => {
         console.log('WebSocket disconnected');
+        this.ws = null;
         // Only reconnect if it wasn't an intentional closure
-        if (!this.intentionalClose && event.code !== 1000) {
+        if (!this.intentionalClose && event.code !== 1000 && this.subscribers.size > 0) {
           // Attempt reconnection after 3 seconds
-          setTimeout(() => this.connectWebSocket(onMessage), 3000);
+          this.reconnectTimer = setTimeout(() => this.connectSocket(), 3000);
         }
         this.intentionalClose = false;
       };
     } catch (error) {
       console.error('Failed to create WebSocket connection:', error instanceof Error ? error.message : 'Unknown error');
       // Retry connection after 3 seconds
-      setTimeout(() => this.connectWebSocket(onMessage), 3000);
+      if (this.subscribers.size > 0) {
+        this.reconnectTimer = setTimeout(() => this.connectSocket(), 3000);
+      }
     }
   }
 
+  subscribeWebSocket(onMessage: WebSocketSubscriber): () => void {
+    this.subscribers.add(onMessage);
+    this.connectSocket();
+
+    return () => {
+      this.subscribers.delete(onMessage);
+      if (this.subscribers.size === 0) {
+        this.disconnectWebSocket();
+      }
+    };
+  }
+
+  connectWebSocket(onMessage: WebSocketSubscriber): void {
+    this.subscribeWebSocket(onMessage);
+  }
+
   disconnectWebSocket(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     if (this.ws) {
       this.intentionalClose = true;
       this.ws.close(1000, 'Client disconnect');
@@ -264,7 +342,7 @@ export class ImageGenAPI {
 
   async getModelStatus(): Promise<ModelStatus> {
     const response = await fetch(`${this.baseUrl}/api/models/status`);
-    if (!response.ok) throw new Error('Failed to get model status');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get model status'));
     return response.json();
   }
 
@@ -272,7 +350,7 @@ export class ImageGenAPI {
     const response = await fetch(`${this.baseUrl}/api/models/${encodeURIComponent(modelId)}/download`, {
       method: 'POST',
     });
-    if (!response.ok) throw new Error('Failed to start model download');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to start model download'));
     return response.json();
   }
 
@@ -284,13 +362,13 @@ export class ImageGenAPI {
       },
       body: JSON.stringify({ token }),
     });
-    if (!response.ok) throw new Error('Failed to set HF token');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to set HF token'));
     return response.json();
   }
 
   async getHFTokenStatus(): Promise<HFTokenStatus> {
     const response = await fetch(`${this.baseUrl}/api/config/hf-token-status`);
-    if (!response.ok) throw new Error('Failed to get HF token status');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get HF token status'));
     return response.json();
   }
 
@@ -306,13 +384,13 @@ export class ImageGenAPI {
       method: 'POST',
       body: formData,
     });
-    if (!response.ok) throw new Error('Failed to edit image');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to edit image'));
     return response.json();
   }
 
   async getOllamaModels(): Promise<OllamaModelsResponse> {
     const response = await fetch(`${this.baseUrl}/api/ollama/models`);
-    if (!response.ok) throw new Error('Failed to get Ollama models');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get Ollama models'));
     return response.json();
   }
 
@@ -324,17 +402,17 @@ export class ImageGenAPI {
       },
       body: JSON.stringify({ model }),
     });
-    if (!response.ok) throw new Error('Failed to set Ollama model');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to set Ollama model'));
     return response.json();
   }
 
   async getGenerationConfig(): Promise<GenerationConfig> {
     const response = await fetch(`${this.baseUrl}/api/config/generation`);
-    if (!response.ok) throw new Error('Failed to get generation config');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get generation config'));
     return response.json();
   }
 
-  async setGenerationConfig(config: Partial<GenerationConfig>): Promise<{ message: string; config: Partial<GenerationConfig> }> {
+  async setGenerationConfig(config: Partial<GenerationConfig>): Promise<{ message: string; config: GenerationConfig }> {
     const response = await fetch(`${this.baseUrl}/api/config/generation`, {
       method: 'POST',
       headers: {
@@ -342,7 +420,7 @@ export class ImageGenAPI {
       },
       body: JSON.stringify(config),
     });
-    if (!response.ok) throw new Error('Failed to set generation config');
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to set generation config'));
     return response.json();
   }
 }

--- a/web-ui/lib/cache.ts
+++ b/web-ui/lib/cache.ts
@@ -12,21 +12,52 @@ class GalleryCache {
   private version = 2;
   private ttl = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
   private db: IDBDatabase | null = null;
+  private initPromise: Promise<void> | null = null;
 
   async init(): Promise<void> {
     if (this.db) return;
+    if (typeof indexedDB === 'undefined') return;
+    if (this.initPromise) return this.initPromise;
 
-    return new Promise((resolve, reject) => {
+    this.initPromise = new Promise((resolve, reject) => {
       const request = indexedDB.open(this.dbName, this.version);
+      let settled = false;
+
+      const timeoutId = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        this.initPromise = null;
+        reject(new Error('Gallery cache open timed out'));
+      }, 1500);
+
+      const resolveOnce = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        resolve();
+      };
+
+      const rejectOnce = (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        this.initPromise = null;
+        reject(error);
+      };
 
       request.onerror = () => {
         console.error('Failed to open IndexedDB');
-        reject(request.error);
+        rejectOnce(request.error);
       };
 
       request.onsuccess = () => {
         this.db = request.result;
-        resolve();
+        resolveOnce();
+      };
+
+      request.onblocked = () => {
+        console.warn('Gallery cache upgrade blocked by another browser tab');
+        resolveOnce();
       };
 
       request.onupgradeneeded = (event) => {
@@ -40,6 +71,8 @@ class GalleryCache {
         store.createIndex('timestamp', 'timestamp', { unique: false });
       };
     });
+
+    return this.initPromise;
   }
 
   async get<T = unknown>(key: string): Promise<T | null> {

--- a/web-ui/lib/task-progress.ts
+++ b/web-ui/lib/task-progress.ts
@@ -1,0 +1,130 @@
+export type ProgressSnapshot = {
+  progress: number;
+  title: string;
+  detail: string;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+export const INITIAL_PROMPT_PROGRESS: ProgressSnapshot = {
+  progress: 12,
+  title: "Preparing prompt generation",
+  detail: "Collecting your meta prompt and warming up the prompt model.",
+};
+
+export const INITIAL_IMAGE_PROGRESS: ProgressSnapshot = {
+  progress: 8,
+  title: "Preparing image request",
+  detail: "Collecting the prompt, active plugins, and runtime settings.",
+};
+
+const PROMPT_FALLBACK_STEPS: ProgressSnapshot[] = [
+  INITIAL_PROMPT_PROGRESS,
+  {
+    progress: 34,
+    title: "Building prompt context",
+    detail: "Gathering plugin context and preparing the prompt request.",
+  },
+  {
+    progress: 58,
+    title: "Generating prompt",
+    detail: "Asking Ollama to draft the next image prompt.",
+  },
+  {
+    progress: 82,
+    title: "Refining prompt",
+    detail: "Finalizing the wording before it appears in the editor.",
+  },
+  {
+    progress: 94,
+    title: "Wrapping up prompt",
+    detail: "Waiting for the generated prompt to come back from the backend.",
+  },
+];
+
+const IMAGE_FALLBACK_STEPS: ProgressSnapshot[] = [
+  INITIAL_IMAGE_PROGRESS,
+  {
+    progress: 22,
+    title: "Building prompt context",
+    detail: "Collecting plugin context and preparing the prompt for this run.",
+  },
+  {
+    progress: 38,
+    title: "Generating prompt",
+    detail: "Turning the current theme into a final prompt for the image model.",
+  },
+  {
+    progress: 56,
+    title: "Preparing backend",
+    detail: "Loading the selected image backend and checking runtime resources.",
+  },
+  {
+    progress: 74,
+    title: "Rendering image",
+    detail: "The backend is synthesizing the image now.",
+  },
+  {
+    progress: 90,
+    title: "Finalizing output",
+    detail: "Saving metadata and writing the image to the gallery.",
+  },
+];
+
+const clampProgress = (value: number) => Math.max(0, Math.min(100, Math.round(value)));
+
+export const createClientRequestId = (prefix: string) => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+export const getTaskProgressUpdate = (
+  data: unknown,
+  task: "prompt_generation" | "image_generation",
+  clientRequestId: string | null
+): ProgressSnapshot | null => {
+  if (!clientRequestId || typeof data !== "object" || data === null) return null;
+
+  const msg = data as UnknownRecord;
+  if (msg.type !== "task_progress" || msg.task !== task) return null;
+  if (msg.client_request_id !== clientRequestId) return null;
+
+  const progress =
+    typeof msg.progress === "number" ? clampProgress(msg.progress) : clampProgress(0);
+  const title =
+    typeof msg.label === "string" && msg.label.trim()
+      ? msg.label
+      : typeof msg.message === "string" && msg.message.trim()
+        ? msg.message
+        : task === "prompt_generation"
+          ? "Generating prompt"
+          : "Generating image";
+  const detail =
+    typeof msg.detail === "string" && msg.detail.trim()
+      ? msg.detail
+      : typeof msg.message === "string" && msg.message.trim()
+        ? msg.message
+        : "Working...";
+
+  return { progress, title, detail };
+};
+
+export const getFallbackProgress = (
+  task: "prompt_generation" | "image_generation",
+  current: ProgressSnapshot
+): ProgressSnapshot => {
+  const steps = task === "prompt_generation" ? PROMPT_FALLBACK_STEPS : IMAGE_FALLBACK_STEPS;
+  const next = steps.find((step) => step.progress > current.progress);
+
+  if (next) return next;
+
+  if (current.progress >= 96) return current;
+
+  return {
+    ...current,
+    progress: clampProgress(current.progress + 1),
+  };
+};


### PR DESCRIPTION
## Summary
- Adds Z-Image DiffSynth LoRA support and the Ollama image backend integration.
- Updates the dashboard, playground, settings, progress feedback, and gallery loading UX so the feature is usable from Docker.
- Adds Docker/config/docs updates, gitignores for generated model/output folders, and coverage for the new integration paths.

## Validation
- `npm run build`
- `UV_PROJECT_ENVIRONMENT=$TEMP/dreamgen-uv-ci uv run pytest tests/test_zimage_generator.py tests/test_ollama_integration.py tests/test_api.py tests/test_plugin_cli.py -q` -> `34 passed, 1 skipped`.
- Docker frontend rebuilt and gallery verified in Chrome headless: gallery API returned 200 and rendered week groups.

## Notes
- The local `.venv` is not a valid Windows venv, so Python tests were run in a temporary uv environment outside the repo.
- The temporary Windows pytest run printed a native access violation from DiffSynth/pyarrow after pytest reported success; the command returned exit code 0.