### PR TITLE
[codex] Automate Cloudflare deployments

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -1,0 +1,73 @@
+name: Cloudflare Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "cloudflare-gallery/**"
+      - "host-image/**"
+      - ".github/workflows/cloudflare-deploy.yml"
+  workflow_dispatch:
+    inputs:
+      deploy_gallery:
+        description: "Deploy dreamgen-gallery Pages"
+        required: true
+        type: boolean
+        default: true
+      deploy_host:
+        description: "Deploy host-image Worker"
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-gallery:
+    name: Deploy gallery Pages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || inputs.deploy_gallery == true
+    defaults:
+      run:
+        working-directory: cloudflare-gallery
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Deploy Cloudflare Pages
+        run: npx wrangler@4 pages deploy public --project-name dreamgen-gallery --branch main
+
+  deploy-host:
+    name: Deploy host-image Worker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || inputs.deploy_host == true
+    defaults:
+      run:
+        working-directory: host-image
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Deploy Worker
+        run: npx wrangler@4 deploy

--- a/docs/CLOUDFLARE_SYNC.md
+++ b/docs/CLOUDFLARE_SYNC.md
@@ -73,6 +73,25 @@ just deploy-gallery     # Deploy gallery Pages app
 just deploy             # Deploy both + sync
 ```
 
+### Automated code deploys
+
+Cloudflare code deployment is automated by `.github/workflows/cloudflare-deploy.yml`.
+On pushes to `main` that change `cloudflare-gallery/**`, `host-image/**`, or the workflow
+itself, GitHub Actions deploys:
+
+- `cloudflare-gallery` to the `dreamgen-gallery` Pages project.
+- `host-image` to the `host-image` Worker.
+
+The workflow can also be run manually from GitHub Actions with `workflow_dispatch`.
+It expects these repository secrets:
+
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_API_TOKEN`
+
+Generated image publishing is still a separate local sync step because `output/` is ignored
+and may contain local mock/test artifacts. Use `just sync-gallery` or `just sync` only after
+confirming the local `output/` contents are intended for the public gallery.
+
 ## Troubleshooting
 
 ### "Access Denied" errors


### PR DESCRIPTION
## Summary
- Add a Cloudflare deploy workflow for `dreamgen-gallery` Pages and the `host-image` Worker.
- Run deploys on `main` when Cloudflare code or the workflow changes, and allow manual `workflow_dispatch` redeploys.
- Document required GitHub secrets and clarify that generated image sync remains a deliberate local step because `output/` can contain mock/test artifacts.

## Validation
- `npx wrangler@4 pages deploy public --project-name dreamgen-gallery --branch main` succeeded and created production deployment `206a1f56` for commit `23afd26`.
- `npx wrangler@4 deploy --dry-run` succeeded for `host-image` and validated the `DREAM_BUCKET` R2 binding.
- Pre-commit hooks passed, including YAML syntax validation.

## Notes
- Current Pages production deployment was previously 3 months old and ad hoc/manual.
- `/api/images` still reflects the R2 bucket contents; image publishing is separate from code deploys and should not blindly sync local `output/` while mock test artifacts are present.