### PR TITLE
[codex] Gate Worker deploy behind manual dispatch

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -19,7 +19,7 @@ on:
         description: "Deploy host-image Worker"
         required: true
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -52,7 +52,7 @@ jobs:
   deploy-host:
     name: Deploy host-image Worker
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || inputs.deploy_host == true
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy_host == true
     defaults:
       run:
         working-directory: host-image

--- a/docs/CLOUDFLARE_SYNC.md
+++ b/docs/CLOUDFLARE_SYNC.md
@@ -80,13 +80,17 @@ On pushes to `main` that change `cloudflare-gallery/**`, `host-image/**`, or the
 itself, GitHub Actions deploys:
 
 - `cloudflare-gallery` to the `dreamgen-gallery` Pages project.
-- `host-image` to the `host-image` Worker.
 
 The workflow can also be run manually from GitHub Actions with `workflow_dispatch`.
-It expects these repository secrets:
+The manual run can optionally deploy `host-image` to the `host-image` Worker when
+`deploy_host` is enabled. It expects these repository secrets:
 
 - `CLOUDFLARE_ACCOUNT_ID`
 - `CLOUDFLARE_API_TOKEN`
+
+The API token used for `host-image` Worker deployment must include Workers edit/deploy
+permissions in addition to Pages permissions. Tokens scoped only for Pages should leave
+`deploy_host` disabled.
 
 Generated image publishing is still a separate local sync step because `output/` is ignored
 and may contain local mock/test artifacts. Use `just sync-gallery` or `just sync` only after


### PR DESCRIPTION
## Summary
- Keep `dreamgen-gallery` Pages deploys automatic on `main`.
- Change `host-image` Worker deploys to manual opt-in only because the current Cloudflare API token can deploy Pages but lacks Workers deploy permissions.
- Document the extra Worker token-scope requirement.

## Validation
- GitHub Actions rerun proved Pages deploy succeeds once repo secrets are set.
- The Worker job failed with Cloudflare authentication code 10000, confirming this is token scope rather than workflow syntax.
- Pre-commit YAML syntax and line-ending hooks passed.