### PR TITLE
[codex] Add safe R2 gallery publisher

### DIFF
--- a/docs/CLOUDFLARE_SYNC.md
+++ b/docs/CLOUDFLARE_SYNC.md
@@ -18,7 +18,10 @@ DreamGen uses **two R2 buckets** for different purposes:
 
 ```bash
 just sync              # Sync to BOTH buckets (recommended)
-just sync-gallery      # Sync only full collection
+just publish-gallery   # Dry-run approved gallery publishing
+just -- publish-gallery --execute  # Publish approved gallery assets
+just publish-gallery-smoke # Validate remote R2 write/delete access
+just sync-gallery      # Legacy raw rclone mirror of output/
 just sync-latest       # Sync only latest image
 just r2-list           # List contents of both buckets
 ```
@@ -92,9 +95,25 @@ The API token used for `host-image` Worker deployment must include Workers edit/
 permissions in addition to Pages permissions. Tokens scoped only for Pages should leave
 `deploy_host` disabled.
 
-Generated image publishing is still a separate local sync step because `output/` is ignored
-and may contain local mock/test artifacts. Use `just sync-gallery` or `just sync` only after
-confirming the local `output/` contents are intended for the public gallery.
+Generated image publishing is still a separate local step because `output/` is ignored
+and may contain local mock/test artifacts. Use `just publish-gallery` first to preview
+the non-placeholder assets that would be uploaded, then run:
+
+```bash
+just publish-gallery-smoke
+just -- publish-gallery --execute
+```
+
+`scripts/publish_gallery.py` skips image files whose `.meta.json` sidecar marks them
+as `is_placeholder` or `backend: mock`, and includes matching `.txt` prompt sidecars.
+It uses remote R2 by default through Wrangler; pass `--local` only when intentionally
+testing Wrangler's local R2 simulation.
+
+Cloudflare's R2 token documentation lists the relevant write permissions as
+`Workers R2 Storage Write` at the account level, or `Workers R2 Storage Bucket Item Write`
+for scoped bucket object access. The token used by this repository must be able to write
+objects in the `dreamgen-gallery` bucket for `just publish-gallery-smoke` and publishing
+to succeed.
 
 ## Troubleshooting
 

--- a/justfile
+++ b/justfile
@@ -183,7 +183,15 @@ sync:
     @just sync-latest
     @echo "✓ Both buckets synced!"
 
-# Sync only to gallery bucket (full collection)
+# Publish approved, non-placeholder local output to the gallery bucket
+publish-gallery *args:
+    uv run python scripts/publish_gallery.py {{args}}
+
+# Validate remote R2 object write/delete access before publishing
+publish-gallery-smoke:
+    uv run python scripts/publish_gallery.py --smoke-test --execute --limit 1
+
+# Legacy full mirror to gallery bucket. Prefer `just -- publish-gallery --execute`.
 sync-gallery:
     rclone sync output/ r2:dreamgen-gallery --progress --transfers 8 --fast-list
 

--- a/scripts/publish_gallery.py
+++ b/scripts/publish_gallery.py
@@ -1,0 +1,211 @@
+"""Publish approved DreamGen gallery assets to Cloudflare R2.
+
+This is intentionally conservative: dry-run is the default, mock placeholders
+are skipped from metadata, and remote deletion/pruning is not implemented here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_BUCKET = "dreamgen-gallery"
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+
+
+@dataclass(frozen=True)
+class PublishAsset:
+    path: Path
+    key: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Publish non-placeholder DreamGen gallery assets to Cloudflare R2."
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("output"))
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="Only include files modified on or after YYYY-MM-DD.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Upload files. Without this flag the command only prints a dry-run plan.",
+    )
+    parser.add_argument(
+        "--smoke-test",
+        action="store_true",
+        help="Upload and delete a tiny smoke-test object before publishing.",
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Use Wrangler's local R2 simulation instead of remote Cloudflare R2.",
+    )
+    parser.add_argument(
+        "--wrangler-package",
+        default="wrangler@4",
+        help="Package passed to npx, for example wrangler@4.",
+    )
+    return parser.parse_args()
+
+
+def read_metadata(image_path: Path) -> dict:
+    metadata_path = image_path.with_suffix(".meta.json")
+    if not metadata_path.exists():
+        return {}
+
+    try:
+        return json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def is_placeholder(image_path: Path) -> bool:
+    metadata = read_metadata(image_path)
+    return bool(metadata.get("is_placeholder")) or metadata.get("backend") == "mock"
+
+
+def parse_since(value: str | None) -> float | None:
+    if not value:
+        return None
+    return datetime.strptime(value, "%Y-%m-%d").timestamp()
+
+
+def object_key(path: Path, output_dir: Path) -> str:
+    return path.relative_to(output_dir).as_posix()
+
+
+def discover_assets(output_dir: Path, since: float | None, limit: int | None) -> list[PublishAsset]:
+    if not output_dir.exists():
+        raise SystemExit(f"Output directory does not exist: {output_dir}")
+
+    assets: list[PublishAsset] = []
+    images = sorted(
+        (
+            path
+            for path in output_dir.rglob("*")
+            if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS
+        ),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+
+    included_images = 0
+    for image_path in images:
+        if since and image_path.stat().st_mtime < since:
+            continue
+        if is_placeholder(image_path):
+            continue
+
+        assets.append(PublishAsset(image_path, object_key(image_path, output_dir)))
+        included_images += 1
+        prompt_path = image_path.with_suffix(".txt")
+        if prompt_path.exists():
+            assets.append(PublishAsset(prompt_path, object_key(prompt_path, output_dir)))
+
+        if limit is not None and included_images >= limit:
+            break
+
+    return assets
+
+
+def wrangler_base_args(package: str) -> list[str]:
+    npx = shutil.which("npx") or shutil.which("npx.cmd")
+    if not npx:
+        raise SystemExit("npx is required to run Wrangler R2 commands.")
+    return [npx, package, "r2", "object"]
+
+
+def run_wrangler(args: list[str]) -> None:
+    result = subprocess.run(args, check=False, text=True)
+    if result.returncode != 0:
+        raise SystemExit(
+            "Wrangler R2 command failed. Confirm CLOUDFLARE_API_TOKEN has "
+            "Workers R2 Storage Write or Workers R2 Storage Bucket Item Write "
+            "for dreamgen-gallery, then rerun the command."
+        )
+
+
+def put_object(package: str, bucket: str, asset: PublishAsset, remote: bool) -> None:
+    args = [
+        *wrangler_base_args(package),
+        "put",
+        f"{bucket}/{asset.key}",
+        "--file",
+        str(asset.path),
+    ]
+    if remote:
+        args.append("--remote")
+    run_wrangler(args)
+
+
+def delete_object(package: str, bucket: str, key: str, remote: bool) -> None:
+    args = [*wrangler_base_args(package), "delete", f"{bucket}/{key}"]
+    if remote:
+        args.append("--remote")
+    run_wrangler(args)
+
+
+def smoke_test(package: str, bucket: str, remote: bool) -> None:
+    key = f".smoke/publish-validation-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}.txt"
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as file:
+        file.write("dreamgen publish smoke test\n")
+        smoke_path = Path(file.name)
+
+    try:
+        put_object(package, bucket, PublishAsset(smoke_path, key), remote)
+        delete_object(package, bucket, key, remote)
+    finally:
+        try:
+            smoke_path.unlink()
+        except OSError:
+            pass
+
+
+def main() -> None:
+    args = parse_args()
+    since = parse_since(args.since)
+    remote = not args.local
+    assets = discover_assets(args.output_dir, since, args.limit)
+
+    image_count = len([asset for asset in assets if asset.path.suffix.lower() in IMAGE_EXTENSIONS])
+    print(f"bucket={args.bucket}")
+    print(f"target={'remote' if remote else 'local'}")
+    print(f"images={image_count}")
+    print(f"files={len(assets)}")
+
+    if not args.execute:
+        for asset in assets[:20]:
+            print(f"DRY-RUN {asset.key}")
+        if len(assets) > 20:
+            print(f"DRY-RUN ... {len(assets) - 20} more files")
+        print("Add --execute to upload.")
+        return
+
+    if remote and not os.getenv("CLOUDFLARE_API_TOKEN"):
+        raise SystemExit("CLOUDFLARE_API_TOKEN is required for remote R2 publishing.")
+    if remote and not os.getenv("CLOUDFLARE_ACCOUNT_ID"):
+        raise SystemExit("CLOUDFLARE_ACCOUNT_ID is required for remote R2 publishing.")
+
+    if args.smoke_test:
+        smoke_test(args.wrangler_package, args.bucket, remote)
+
+    for asset in assets:
+        print(f"UPLOAD {asset.key}")
+        put_object(args.wrangler_package, args.bucket, asset, remote)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_publish_gallery.py
+++ b/tests/test_publish_gallery.py
@@ -1,0 +1,43 @@
+import json
+
+from scripts.publish_gallery import discover_assets
+
+
+def test_discover_assets_skips_mock_placeholders_and_includes_prompt(tmp_path):
+    output_dir = tmp_path / "output"
+    week_dir = output_dir / "2026" / "week_17"
+    week_dir.mkdir(parents=True)
+
+    real_image = week_dir / "real.png"
+    real_prompt = week_dir / "real.txt"
+    real_image.write_bytes(b"png")
+    real_prompt.write_text("prompt", encoding="utf-8")
+
+    mock_image = week_dir / "mock.png"
+    mock_image.write_bytes(b"png")
+    mock_image.with_suffix(".meta.json").write_text(
+        json.dumps({"backend": "mock", "is_placeholder": True}),
+        encoding="utf-8",
+    )
+
+    assets = discover_assets(output_dir, since=None, limit=None)
+
+    assert [asset.key for asset in assets] == [
+        "2026/week_17/real.png",
+        "2026/week_17/real.txt",
+    ]
+
+
+def test_discover_assets_limit_counts_images_not_prompts(tmp_path):
+    output_dir = tmp_path / "output"
+    week_dir = output_dir / "2026" / "week_17"
+    week_dir.mkdir(parents=True)
+
+    for name in ("one", "two"):
+        (week_dir / f"{name}.png").write_bytes(b"png")
+        (week_dir / f"{name}.txt").write_text("prompt", encoding="utf-8")
+
+    assets = discover_assets(output_dir, since=None, limit=1)
+
+    assert len([asset for asset in assets if asset.path.suffix == ".png"]) == 1
+    assert len(assets) == 2


### PR DESCRIPTION
## Summary

- Add a conservative `scripts/publish_gallery.py` command for publishing non-placeholder DreamGen gallery assets to the `dreamgen-gallery` R2 bucket.
- Add `just publish-gallery` and `just publish-gallery-smoke` shortcuts while keeping the old raw rclone mirror as a legacy path.
- Document the required Cloudflare R2 write permissions and add tests for placeholder filtering and image-count limits.

## Issue #22 status

This addresses the local/GitHub publishing safety and validation pieces for #22. The live remote smoke test still fails with `403 Forbidden`, which confirms the remaining blocker is Cloudflare token scope: the token needs `Workers R2 Storage Write` at account level or `Workers R2 Storage Bucket Item Write` for the `dreamgen-gallery` bucket.

## Validation

- `uv run black scripts/publish_gallery.py tests/test_publish_gallery.py`
- `uv run pytest tests/test_publish_gallery.py`
- `uv run pytest tests/` - 65 passed, 1 skipped; pytest exited 0, with an existing post-summary Windows access violation trace while importing `pyarrow` through `diffsynth`
- `uv run python scripts/publish_gallery.py --limit 3`
- `uv run python scripts/publish_gallery.py --smoke-test --execute --limit 1` - reaches remote R2 and fails with expected `403 Forbidden` under the current token scope