### PR TITLE
[codex] Fix gallery R2 listing pagination

### DIFF
--- a/cloudflare-gallery/functions/api/images/[[path]].js
+++ b/cloudflare-gallery/functions/api/images/[[path]].js
@@ -3,8 +3,8 @@ export async function onRequestGet(ctx) {
 
   // List all images with metadata
   if (!path) {
-    const list = await ctx.env.GALLERY.list();
-    const images = list.objects
+    const objects = await listAllObjects(ctx.env.GALLERY);
+    const images = objects
       .filter(o => /\.(png|jpg|jpeg|webp|gif)$/i.test(o.key))
       .sort((a, b) => new Date(b.uploaded) - new Date(a.uploaded))
       .map(o => ({
@@ -13,7 +13,11 @@ export async function onRequestGet(ctx) {
         dateStr: extractDateFromFilename(o.key),
         captionKey: o.key.replace(/\.(png|jpg|jpeg|webp|gif)$/i, '.txt')
       }));
-    return Response.json(images);
+    return Response.json(images, {
+      headers: {
+        'Cache-Control': 'no-store'
+      }
+    });
   }
 
   // Serve individual file (image or txt)
@@ -39,6 +43,19 @@ export async function onRequestGet(ctx) {
       'Access-Control-Allow-Origin': '*'
     }
   });
+}
+
+async function listAllObjects(bucket) {
+  const objects = [];
+  let cursor;
+
+  do {
+    const page = await bucket.list({ limit: 1000, cursor });
+    objects.push(...page.objects);
+    cursor = page.truncated ? page.cursor : undefined;
+  } while (cursor);
+
+  return objects;
 }
 
 function extractDateFromFilename(filename) {

--- a/docs/CLOUDFLARE_SYNC.md
+++ b/docs/CLOUDFLARE_SYNC.md
@@ -109,11 +109,15 @@ as `is_placeholder` or `backend: mock`, and includes matching `.txt` prompt side
 It uses remote R2 by default through Wrangler; pass `--local` only when intentionally
 testing Wrangler's local R2 simulation.
 
+Keep the Pages deploy token and R2 publishing token separate when possible:
+
+- `CLOUDFLARE_API_TOKEN`: Pages deploy token used by GitHub Actions.
+- `CLOUDFLARE_R2_API_TOKEN`: R2 object write token used by local/gallery publishing.
+
 Cloudflare's R2 token documentation lists the relevant write permissions as
 `Workers R2 Storage Write` at the account level, or `Workers R2 Storage Bucket Item Write`
-for scoped bucket object access. The token used by this repository must be able to write
-objects in the `dreamgen-gallery` bucket for `just publish-gallery-smoke` and publishing
-to succeed.
+for scoped bucket object access. The R2 token must be able to write objects in the
+`dreamgen-gallery` bucket for `just publish-gallery-smoke` and publishing to succeed.
 
 ## Troubleshooting
 

--- a/justfile
+++ b/justfile
@@ -189,7 +189,7 @@ publish-gallery *args:
 
 # Validate remote R2 object write/delete access before publishing
 publish-gallery-smoke:
-    uv run python scripts/publish_gallery.py --smoke-test --execute --limit 1
+    uv run python scripts/publish_gallery.py --smoke-test --smoke-test-only --execute --limit 1
 
 # Legacy full mirror to gallery bucket. Prefer `just -- publish-gallery --execute`.
 sync-gallery:

--- a/scripts/publish_gallery.py
+++ b/scripts/publish_gallery.py
@@ -49,6 +49,11 @@ def parse_args() -> argparse.Namespace:
         help="Upload and delete a tiny smoke-test object before publishing.",
     )
     parser.add_argument(
+        "--smoke-test-only",
+        action="store_true",
+        help="Only run the smoke test; do not publish gallery assets afterward.",
+    )
+    parser.add_argument(
         "--local",
         action="store_true",
         help="Use Wrangler's local R2 simulation instead of remote Cloudflare R2.",
@@ -129,10 +134,15 @@ def wrangler_base_args(package: str) -> list[str]:
 
 
 def run_wrangler(args: list[str]) -> None:
-    result = subprocess.run(args, check=False, text=True)
+    env = os.environ.copy()
+    r2_token = env.get("CLOUDFLARE_R2_API_TOKEN")
+    if r2_token:
+        env["CLOUDFLARE_API_TOKEN"] = r2_token
+
+    result = subprocess.run(args, check=False, text=True, env=env)
     if result.returncode != 0:
         raise SystemExit(
-            "Wrangler R2 command failed. Confirm CLOUDFLARE_API_TOKEN has "
+            "Wrangler R2 command failed. Confirm CLOUDFLARE_R2_API_TOKEN has "
             "Workers R2 Storage Write or Workers R2 Storage Bucket Item Write "
             "for dreamgen-gallery, then rerun the command."
         )
@@ -194,13 +204,18 @@ def main() -> None:
         print("Add --execute to upload.")
         return
 
-    if remote and not os.getenv("CLOUDFLARE_API_TOKEN"):
-        raise SystemExit("CLOUDFLARE_API_TOKEN is required for remote R2 publishing.")
+    if remote and not (os.getenv("CLOUDFLARE_R2_API_TOKEN") or os.getenv("CLOUDFLARE_API_TOKEN")):
+        raise SystemExit(
+            "CLOUDFLARE_R2_API_TOKEN or CLOUDFLARE_API_TOKEN is required "
+            "for remote R2 publishing."
+        )
     if remote and not os.getenv("CLOUDFLARE_ACCOUNT_ID"):
         raise SystemExit("CLOUDFLARE_ACCOUNT_ID is required for remote R2 publishing.")
 
     if args.smoke_test:
         smoke_test(args.wrangler_package, args.bucket, remote)
+        if args.smoke_test_only:
+            return
 
     for asset in assets:
         print(f"UPLOAD {asset.key}")


### PR DESCRIPTION
## Summary

- Page through all R2 objects in the gallery API instead of relying on one `GALLERY.list()` page.
- Mark the JSON listing response `no-store` so `/api/images` does not serve stale listings.
- Split R2 publishing credentials from Pages deploy credentials by preferring `CLOUDFLARE_R2_API_TOKEN` for the gallery publisher.
- Make `just publish-gallery-smoke` only run the smoke upload/delete instead of publishing one gallery asset afterward.

## Validation

- `uv run pytest tests/test_publish_gallery.py`
- `uv run pytest tests/` - 65 passed, 1 skipped; pytest exited 0 with the existing post-summary Windows access violation trace while importing `pyarrow` through `diffsynth`
- `uv run python scripts/publish_gallery.py --smoke-test --smoke-test-only --execute --limit 1` with `CLOUDFLARE_R2_API_TOKEN`
- Direct R2 object API confirmed 2026 gallery objects are present in `dreamgen-gallery`

Refs #22