### PR TITLE
Add backend-managed gallery publication catalog

### DIFF
--- a/scripts/publish_gallery.py
+++ b/scripts/publish_gallery.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from src.utils.publication_catalog import catalog_path_for, public_catalog_entries
+
 DEFAULT_BUCKET = "dreamgen-gallery"
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 
@@ -97,15 +99,22 @@ def discover_assets(output_dir: Path, since: float | None, limit: int | None) ->
         raise SystemExit(f"Output directory does not exist: {output_dir}")
 
     assets: list[PublishAsset] = []
-    images = sorted(
-        (
-            path
-            for path in output_dir.rglob("*")
-            if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS
-        ),
-        key=lambda path: path.stat().st_mtime,
-        reverse=True,
-    )
+    if catalog_path_for(output_dir).exists():
+        images = [
+            output_dir / entry["path"]
+            for entry in public_catalog_entries(output_dir)
+            if (output_dir / entry["path"]).exists()
+        ]
+    else:
+        images = sorted(
+            (
+                path
+                for path in output_dir.rglob("*")
+                if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS
+            ),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
 
     included_images = 0
     for image_path in images:

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import aiofiles
-from fastapi import FastAPI, File, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, File, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from PIL import Image
@@ -34,6 +34,15 @@ from src.utils.ollama import (
     list_ollama_models,
     ollama_host,
     resolve_ollama_model,
+)
+from src.utils.publication_catalog import (
+    backfill_catalog,
+    catalog_path_for,
+    load_catalog,
+    public_catalog_entries,
+    register_image,
+    remove_image,
+    set_publication_state,
 )
 from src.utils.storage import (
     StorageManager,
@@ -163,54 +172,48 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 app.mount("/images", StaticFiles(directory=str(OUTPUT_DIR)), name="images")
 
 
-def is_placeholder_artifact(image_file: Path, metadata: Optional[dict[str, Any]] = None) -> bool:
-    """Return True for mock/placeholder artifacts that should stay out of the live gallery."""
-    metadata = metadata or read_image_metadata(image_file)
-    backend = str(metadata.get("backend", "")).lower()
-    if backend == "mock" or metadata.get("is_placeholder") is True:
-        return True
-
-    try:
-        file_size = image_file.stat().st_size
-    except OSError:
-        return False
-
-    if file_size > 8 * 1024:
-        return False
-
-    try:
-        with Image.open(image_file) as img:
-            extrema = img.convert("RGB").getextrema()
-    except Exception:
-        return False
-
-    return all(channel_min == channel_max for channel_min, channel_max in extrema)
-
-
 MAX_GALLERY_SCAN = int(os.getenv("MAX_GALLERY_SCAN", "2000"))
 
 
+def normalize_gallery_key(image_path: str) -> str:
+    """Normalize API image paths into catalog keys."""
+    normalized = image_path.strip().replace("\\", "/").lstrip("/")
+    if normalized.startswith("images/"):
+        normalized = normalized[len("images/") :]
+    return normalized
+
+
 def build_gallery_index(output_dir: Path) -> List[Dict[str, Any]]:
-    """Build gallery metadata without reading prompt files for every stored image."""
+    """Build public gallery metadata from the backend publication catalog."""
+    if not catalog_path_for(output_dir).exists():
+        backfill_catalog(output_dir, default_state="published", include_placeholders=True)
+
     images: List[Dict[str, Any]] = []
     last_image: Optional[Dict[str, Any]] = None
 
-    all_files = list(output_dir.rglob("*.png"))
-    image_files = sorted(all_files, key=lambda path: path.stat().st_mtime, reverse=True)
+    catalog_entries = public_catalog_entries(output_dir)
 
-    for image_file in image_files:
-        metadata = read_image_metadata(image_file)
-        if is_placeholder_artifact(image_file, metadata):
+    for catalog_entry in catalog_entries:
+        image_file = output_dir / catalog_entry["path"]
+        if not image_file.exists():
             continue
 
         stat_result = image_file.stat()
         image_entry = {
             "file": image_file,
             "path": f"/images/{image_file.relative_to(output_dir).as_posix()}",
-            "created_at": datetime.fromtimestamp(stat_result.st_mtime).isoformat(),
+            "created_at": catalog_entry.get(
+                "created_at", datetime.fromtimestamp(stat_result.st_mtime).isoformat()
+            ),
             "size": stat_result.st_size,
             "prompt_hash": image_file.stem.rsplit("_", 1)[-1],
-            "metadata": metadata,
+            "metadata": catalog_entry.get("metadata", {}),
+            "publication": {
+                "id": catalog_entry.get("id"),
+                "state": catalog_entry.get("publication_state"),
+                "publishable": catalog_entry.get("publishable", True),
+                "quality_flags": catalog_entry.get("quality_flags", []),
+            },
         }
 
         if last_image is not None:
@@ -258,6 +261,8 @@ async def hydrate_gallery_entries(images: List[Dict[str, Any]]) -> List[Dict[str
                 "prompt": prompt.strip(),
                 "created_at": image_entry["created_at"],
                 "size": image_entry["size"],
+                "metadata": image_entry.get("metadata", {}),
+                "publication": image_entry.get("publication", {}),
             }
         )
 
@@ -284,6 +289,16 @@ class GenerateResponse(BaseModel):
     image_path: str = Field(..., description="Path to generated image")
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Generation metadata")
     created_at: str = Field(..., description="ISO timestamp")
+
+
+class PublicationUpdateRequest(BaseModel):
+    """Request model for changing gallery publication state."""
+
+    state: str = Field(..., description="Publication state for this image")
+    allow_placeholder_publish: bool = Field(
+        False,
+        description="Allow publishing mock/test placeholder images when explicitly requested",
+    )
 
 
 class EditRequest(BaseModel):
@@ -1114,16 +1129,21 @@ async def generate_image(request: GenerateRequest):
         if resolved_seed is None and request.seed is not None and seed_supported:
             resolved_seed = request.seed
         existing_metadata = read_image_metadata(image_path)
-        write_image_metadata(
+        saved_metadata = {
+            **existing_metadata,
+            **generation_metadata,
+            "backend": backend_name,
+            "configured_backend": config.model.image_backend,
+            "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+            "seed": resolved_seed,
+        }
+        write_image_metadata(image_path, saved_metadata)
+        publication_entry = register_image(
             image_path,
-            {
-                **existing_metadata,
-                **generation_metadata,
-                "backend": backend_name,
-                "configured_backend": config.model.image_backend,
-                "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
-                "seed": resolved_seed,
-            },
+            OUTPUT_DIR,
+            prompt=final_prompt,
+            metadata=saved_metadata,
+            publication_state="draft",
         )
 
         # Create relative path for API response
@@ -1157,6 +1177,12 @@ async def generate_image(request: GenerateRequest):
             metadata={
                 **generation_metadata,
                 "backend": backend_name,
+                "publication": {
+                    "id": publication_entry["id"],
+                    "state": publication_entry["publication_state"],
+                    "publishable": publication_entry["publishable"],
+                    "quality_flags": publication_entry["quality_flags"],
+                },
                 "plugins_used": [
                     name for name, info in plugin_manager.plugins.items() if info.enabled
                 ],
@@ -1196,10 +1222,84 @@ async def get_gallery(limit: int = 50, offset: int = 0):
     }
 
 
+@app.get("/api/gallery/catalog")
+async def get_gallery_catalog(
+    publication_state: Optional[str] = Query(None, alias="state"),
+    limit: int = 100,
+    offset: int = 0,
+):
+    """List backend catalog entries for operator publication review."""
+    if not catalog_path_for(OUTPUT_DIR).exists():
+        await asyncio.to_thread(
+            backfill_catalog, OUTPUT_DIR, default_state="published", include_placeholders=True
+        )
+
+    catalog = await asyncio.to_thread(load_catalog, OUTPUT_DIR)
+    entries = sorted(
+        catalog["assets"].values(),
+        key=lambda entry: str(entry.get("created_at", "")),
+        reverse=True,
+    )
+    if publication_state:
+        normalized_state = publication_state.strip().lower()
+        entries = [entry for entry in entries if entry.get("publication_state") == normalized_state]
+
+    return {
+        "assets": entries[offset : offset + limit],
+        "total": len(entries),
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@app.post("/api/gallery/catalog/backfill")
+async def backfill_gallery_catalog(default_state: str = "published"):
+    """Backfill existing local output images into the backend publication catalog."""
+    try:
+        result = await asyncio.to_thread(
+            backfill_catalog,
+            OUTPUT_DIR,
+            default_state=default_state,
+            include_placeholders=True,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result
+
+
+@app.patch("/api/gallery/publication/{image_path:path}")
+async def update_image_publication(image_path: str, request: PublicationUpdateRequest):
+    """Update publication state for a generated image."""
+    key = normalize_gallery_key(image_path)
+    full_path = (OUTPUT_DIR / key).resolve()
+    output_root = OUTPUT_DIR.resolve()
+
+    if not full_path.is_relative_to(output_root):
+        raise HTTPException(status_code=400, detail="Invalid image path")
+
+    try:
+        entry = await asyncio.to_thread(
+            set_publication_state,
+            OUTPUT_DIR,
+            key,
+            request.state,
+            allow_placeholder_publish=request.allow_placeholder_publish,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (FileNotFoundError, KeyError) as exc:
+        raise HTTPException(status_code=404, detail="Catalog entry not found") from exc
+
+    return entry
+
+
 @app.delete("/api/gallery/{image_path:path}")
 async def delete_image(image_path: str):
     """Delete an image from the gallery"""
-    full_path = (OUTPUT_DIR / image_path).resolve()
+    key = normalize_gallery_key(image_path)
+    full_path = (OUTPUT_DIR / key).resolve()
     output_root = OUTPUT_DIR.resolve()
 
     if not full_path.is_relative_to(output_root):
@@ -1216,6 +1316,7 @@ async def delete_image(image_path: str):
     metadata_path = metadata_path_for(full_path)
     if metadata_path.exists():
         metadata_path.unlink()
+    remove_image(OUTPUT_DIR, key)
 
     return {"message": "Image deleted successfully"}
 
@@ -1292,19 +1393,28 @@ async def edit_image(request: EditRequest, file: UploadFile = File(...)):
         # Save both original and edited images
         import io
 
-        # Save original
-        from PIL import Image
-
-        from src.utils.storage import save_image_and_prompt
-
         original_img = Image.open(io.BytesIO(image_bytes))
         original_path = save_image_and_prompt(
             original_img, f"ORIGINAL: {request.prompt}", str(OUTPUT_DIR)
+        )
+        register_image(
+            original_path,
+            OUTPUT_DIR,
+            prompt=f"ORIGINAL: {request.prompt}",
+            metadata={"operation": "edit_original"},
+            publication_state="draft",
         )
 
         # Save edited
         edited_path = save_image_and_prompt(
             edited_image, f"EDITED: {request.prompt}", str(OUTPUT_DIR)
+        )
+        register_image(
+            edited_path,
+            OUTPUT_DIR,
+            prompt=f"EDITED: {request.prompt}",
+            metadata={"operation": "edit_result"},
+            publication_state="draft",
         )
 
         # Create relative paths for API response

--- a/src/utils/publication_catalog.py
+++ b/src/utils/publication_catalog.py
@@ -1,0 +1,312 @@
+"""Backend-managed publication catalog for generated gallery assets."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+
+from src.utils.storage import read_image_metadata
+
+CATALOG_FILENAME = ".gallery_catalog.json"
+CATALOG_VERSION = 1
+PUBLICATION_STATES = {"draft", "published", "hidden", "featured", "rejected"}
+PUBLIC_GALLERY_STATES = {"published", "featured"}
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+
+
+def utc_now() -> str:
+    """Return the current UTC timestamp in API-friendly ISO format."""
+    return datetime.utcnow().isoformat(timespec="seconds") + "Z"
+
+
+def catalog_path_for(output_dir: Path) -> Path:
+    """Return the catalog path for an output directory."""
+    return output_dir / CATALOG_FILENAME
+
+
+def image_key(image_path: Path, output_dir: Path) -> str:
+    """Return a stable, slash-separated catalog key for an image."""
+    return image_path.resolve().relative_to(output_dir.resolve()).as_posix()
+
+
+def image_id_for(key: str) -> str:
+    """Return a stable short ID for a catalog key."""
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+
+
+def default_catalog() -> dict[str, Any]:
+    """Return a new empty catalog document."""
+    return {"version": CATALOG_VERSION, "updated_at": utc_now(), "assets": {}}
+
+
+def load_catalog(output_dir: Path) -> dict[str, Any]:
+    """Load the publication catalog, returning an empty catalog when absent."""
+    path = catalog_path_for(output_dir)
+    if not path.exists():
+        return default_catalog()
+
+    try:
+        catalog = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default_catalog()
+
+    if not isinstance(catalog, dict):
+        return default_catalog()
+    assets = catalog.get("assets")
+    if not isinstance(assets, dict):
+        catalog["assets"] = {}
+    catalog.setdefault("version", CATALOG_VERSION)
+    catalog.setdefault("updated_at", utc_now())
+    return catalog
+
+
+def save_catalog(output_dir: Path, catalog: dict[str, Any]) -> Path:
+    """Persist the publication catalog atomically enough for local operator use."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    catalog["version"] = CATALOG_VERSION
+    catalog["updated_at"] = utc_now()
+
+    path = catalog_path_for(output_dir)
+    tmp_path = path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(catalog, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(path)
+    return path
+
+
+def is_placeholder_artifact(image_file: Path, metadata: dict[str, Any] | None = None) -> bool:
+    """Return True for mock/test artifacts that should not be public by default."""
+    metadata = metadata or read_image_metadata(image_file)
+    backend = str(metadata.get("backend", "")).lower()
+    if backend == "mock" or metadata.get("is_placeholder") is True:
+        return True
+
+    try:
+        file_size = image_file.stat().st_size
+    except OSError:
+        return False
+
+    if file_size > 8 * 1024:
+        return False
+
+    try:
+        with Image.open(image_file) as img:
+            extrema = img.convert("RGB").getextrema()
+    except Exception:
+        return False
+
+    return all(channel_min == channel_max for channel_min, channel_max in extrema)
+
+
+def prompt_for(image_path: Path) -> str:
+    """Read the prompt sidecar for an image when available."""
+    prompt_path = image_path.with_suffix(".txt")
+    if not prompt_path.exists():
+        return ""
+
+    try:
+        return prompt_path.read_text(encoding="utf-8", errors="ignore").strip()
+    except OSError:
+        return ""
+
+
+def created_at_for(image_path: Path) -> str:
+    """Return an image creation timestamp from file metadata."""
+    try:
+        return datetime.fromtimestamp(image_path.stat().st_mtime).isoformat()
+    except OSError:
+        return utc_now()
+
+
+def build_catalog_entry(
+    image_path: Path,
+    output_dir: Path,
+    *,
+    prompt: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    publication_state: str = "draft",
+    allow_placeholder_publish: bool = False,
+) -> dict[str, Any]:
+    """Build a normalized catalog entry for an image."""
+    key = image_key(image_path, output_dir)
+    metadata = metadata or read_image_metadata(image_path)
+    placeholder = is_placeholder_artifact(image_path, metadata)
+    state = normalize_publication_state(publication_state)
+    if (
+        placeholder
+        and state in (PUBLIC_GALLERY_STATES | {"draft"})
+        and not allow_placeholder_publish
+    ):
+        state = "rejected"
+
+    quality_flags = []
+    if placeholder:
+        quality_flags.append("placeholder")
+
+    return {
+        "id": image_id_for(key),
+        "path": key,
+        "prompt": prompt if prompt is not None else prompt_for(image_path),
+        "metadata": metadata,
+        "created_at": created_at_for(image_path),
+        "updated_at": utc_now(),
+        "publication_state": state,
+        "publishable": not placeholder or allow_placeholder_publish,
+        "quality_flags": quality_flags,
+    }
+
+
+def normalize_publication_state(state: str) -> str:
+    """Validate and normalize a publication state."""
+    normalized = state.strip().lower()
+    if normalized not in PUBLICATION_STATES:
+        raise ValueError(f"Invalid publication state: {state}")
+    return normalized
+
+
+def register_image(
+    image_path: Path,
+    output_dir: Path,
+    *,
+    prompt: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    publication_state: str = "draft",
+    allow_placeholder_publish: bool = False,
+) -> dict[str, Any]:
+    """Add or refresh an image in the catalog."""
+    catalog = load_catalog(output_dir)
+    key = image_key(image_path, output_dir)
+    existing = catalog["assets"].get(key, {})
+    state = existing.get("publication_state", publication_state)
+    entry = build_catalog_entry(
+        image_path,
+        output_dir,
+        prompt=prompt,
+        metadata=metadata,
+        publication_state=state,
+        allow_placeholder_publish=allow_placeholder_publish,
+    )
+    catalog["assets"][key] = entry
+    save_catalog(output_dir, catalog)
+    return entry
+
+
+def remove_image(output_dir: Path, key: str) -> bool:
+    """Remove an image from the catalog."""
+    catalog = load_catalog(output_dir)
+    removed = catalog["assets"].pop(key, None) is not None
+    if removed:
+        save_catalog(output_dir, catalog)
+    return removed
+
+
+def backfill_catalog(
+    output_dir: Path,
+    *,
+    default_state: str = "published",
+    include_placeholders: bool = True,
+) -> dict[str, Any]:
+    """Register existing output images in the catalog."""
+    normalize_publication_state(default_state)
+    catalog = load_catalog(output_dir)
+    added = 0
+    refreshed = 0
+    skipped = 0
+
+    if not output_dir.exists():
+        save_catalog(output_dir, catalog)
+        return {"added": added, "refreshed": refreshed, "skipped": skipped, "total": 0}
+
+    image_files = sorted(
+        (
+            path
+            for path in output_dir.rglob("*")
+            if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS
+        ),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+
+    for image_path in image_files:
+        metadata = read_image_metadata(image_path)
+        placeholder = is_placeholder_artifact(image_path, metadata)
+        if placeholder and not include_placeholders:
+            skipped += 1
+            continue
+
+        key = image_key(image_path, output_dir)
+        existing = catalog["assets"].get(key)
+        state = existing.get("publication_state", default_state) if existing else default_state
+        if placeholder:
+            state = existing.get("publication_state", "rejected") if existing else "rejected"
+
+        catalog["assets"][key] = build_catalog_entry(
+            image_path,
+            output_dir,
+            prompt=prompt_for(image_path),
+            metadata=metadata,
+            publication_state=state,
+        )
+        if existing:
+            refreshed += 1
+        else:
+            added += 1
+
+    save_catalog(output_dir, catalog)
+    return {
+        "added": added,
+        "refreshed": refreshed,
+        "skipped": skipped,
+        "total": len(catalog["assets"]),
+    }
+
+
+def set_publication_state(
+    output_dir: Path,
+    key: str,
+    publication_state: str,
+    *,
+    allow_placeholder_publish: bool = False,
+) -> dict[str, Any]:
+    """Update the publication state for one catalog entry."""
+    state = normalize_publication_state(publication_state)
+    catalog = load_catalog(output_dir)
+    assets = catalog["assets"]
+    entry = assets.get(key)
+    if entry is None:
+        raise KeyError(key)
+
+    image_path = (output_dir / key).resolve()
+    if not image_path.exists():
+        raise FileNotFoundError(key)
+
+    metadata = read_image_metadata(image_path)
+    placeholder = is_placeholder_artifact(image_path, metadata)
+    if placeholder and state in PUBLIC_GALLERY_STATES and not allow_placeholder_publish:
+        raise PermissionError("Placeholder images cannot be published without override.")
+
+    entry["publication_state"] = state
+    entry["updated_at"] = utc_now()
+    entry["publishable"] = not placeholder or allow_placeholder_publish
+    if placeholder:
+        flags = set(entry.get("quality_flags", []))
+        flags.add("placeholder")
+        entry["quality_flags"] = sorted(flags)
+    assets[key] = entry
+    save_catalog(output_dir, catalog)
+    return entry
+
+
+def public_catalog_entries(output_dir: Path) -> list[dict[str, Any]]:
+    """Return catalog entries that should be exposed by the gallery API."""
+    catalog = load_catalog(output_dir)
+    entries = [
+        entry
+        for entry in catalog["assets"].values()
+        if entry.get("publication_state") in PUBLIC_GALLERY_STATES
+    ]
+    return sorted(entries, key=lambda entry: str(entry.get("created_at", "")), reverse=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ from fastapi.testclient import TestClient
 from PIL import Image, ImageDraw
 
 from src.utils.ollama import OllamaModelInfo
+from src.utils.publication_catalog import load_catalog
 from src.utils.storage import metadata_path_for, write_image_metadata
 
 # Redirect OUTPUT_DIR to a temp directory BEFORE any server imports so that test
@@ -333,6 +334,12 @@ def test_image_file_created(client, tmp_path):
     if fs_path.parent.exists():
         assert fs_path.exists() or True  # File may not persist in test mode
 
+    catalog = load_catalog(Path(_TEST_OUTPUT_DIR))
+    relative_key = image_path.replace("/images/", "")
+    assert relative_key in catalog["assets"]
+    assert catalog["assets"][relative_key]["publication_state"] == "rejected"
+    assert catalog["assets"][relative_key]["publishable"] is False
+
 
 def test_gallery_ignores_placeholder_artifacts_beyond_scan_cap(client):
     """Gallery should keep scanning until it finds real images instead of stopping at placeholders."""
@@ -363,11 +370,84 @@ def test_gallery_ignores_placeholder_artifacts_beyond_scan_cap(client):
     valid.with_suffix(".txt").write_text("real image")
     write_image_metadata(valid, {"backend": "small-sd", "is_placeholder": False})
 
+    response = client.post("/api/gallery/catalog/backfill")
+    assert response.status_code == 200
+
     response = client.get("/api/gallery?limit=5&offset=0")
     assert response.status_code == 200
     data = response.json()
     assert data["total"] >= 1
     assert any(item["path"].endswith("deadbeef.png") for item in data["images"])
+
+
+def test_publication_state_controls_gallery_visibility(client):
+    """Operators should be able to publish and unpublish cataloged images."""
+    output_root = Path(_TEST_OUTPUT_DIR)
+    week_dir = output_root / "2099" / "week_03"
+    week_dir.mkdir(parents=True, exist_ok=True)
+
+    image_path = week_dir / "image_20990103_000001_cafefeed.png"
+    image = Image.new("RGB", (64, 64), color=(30, 40, 50))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((5, 5, 32, 32), fill=(200, 80, 40))
+    image.save(image_path)
+    image_path.with_suffix(".txt").write_text("publish me")
+    write_image_metadata(image_path, {"backend": "small-sd", "is_placeholder": False})
+
+    response = client.post("/api/gallery/catalog/backfill?default_state=published")
+    assert response.status_code == 200
+
+    relative_path = image_path.relative_to(output_root).as_posix()
+    response = client.get("/api/gallery?limit=100&offset=0")
+    assert response.status_code == 200
+    assert any(item["path"].endswith("cafefeed.png") for item in response.json()["images"])
+
+    response = client.patch(
+        f"/api/gallery/publication/{relative_path}",
+        json={"state": "hidden"},
+    )
+    assert response.status_code == 200
+    assert response.json()["publication_state"] == "hidden"
+
+    response = client.get("/api/gallery?limit=100&offset=0")
+    assert response.status_code == 200
+    assert not any(item["path"].endswith("cafefeed.png") for item in response.json()["images"])
+
+    response = client.patch(
+        f"/api/gallery/publication/{relative_path}",
+        json={"state": "published"},
+    )
+    assert response.status_code == 200
+    assert response.json()["publication_state"] == "published"
+
+
+def test_placeholder_cannot_be_published_without_override(client):
+    """Mock placeholders should stay unpublished unless the operator explicitly overrides."""
+    output_root = Path(_TEST_OUTPUT_DIR)
+    week_dir = output_root / "2099" / "week_04"
+    week_dir.mkdir(parents=True, exist_ok=True)
+
+    image_path = week_dir / "image_20990104_000001_baddecaf.png"
+    Image.new("RGB", (32, 32), color=(200, 200, 200)).save(image_path)
+    image_path.with_suffix(".txt").write_text("placeholder")
+    write_image_metadata(image_path, {"backend": "mock", "is_placeholder": True})
+
+    response = client.post("/api/gallery/catalog/backfill")
+    assert response.status_code == 200
+
+    relative_path = image_path.relative_to(output_root).as_posix()
+    response = client.patch(
+        f"/api/gallery/publication/{relative_path}",
+        json={"state": "published"},
+    )
+    assert response.status_code == 409
+
+    response = client.patch(
+        f"/api/gallery/publication/{relative_path}",
+        json={"state": "published", "allow_placeholder_publish": True},
+    )
+    assert response.status_code == 200
+    assert response.json()["publication_state"] == "published"
 
 
 def test_delete_image_removes_metadata_sidecar(client):
@@ -387,6 +467,9 @@ def test_delete_image_removes_metadata_sidecar(client):
         image_path, {"backend": "small-sd", "is_placeholder": False}
     )
 
+    response = client.post("/api/gallery/catalog/backfill")
+    assert response.status_code == 200
+
     relative_path = image_path.relative_to(Path(_TEST_OUTPUT_DIR)).as_posix()
     response = client.delete(f"/api/gallery/{relative_path}")
 
@@ -394,3 +477,4 @@ def test_delete_image_removes_metadata_sidecar(client):
     assert not image_path.exists()
     assert not prompt_path.exists()
     assert not metadata_file.exists()
+    assert relative_path not in load_catalog(Path(_TEST_OUTPUT_DIR))["assets"]

--- a/tests/test_publish_gallery.py
+++ b/tests/test_publish_gallery.py
@@ -1,6 +1,7 @@
 import json
 
 from scripts.publish_gallery import discover_assets
+from src.utils.publication_catalog import backfill_catalog, set_publication_state
 
 
 def test_discover_assets_skips_mock_placeholders_and_includes_prompt(tmp_path):
@@ -41,3 +42,27 @@ def test_discover_assets_limit_counts_images_not_prompts(tmp_path):
 
     assert len([asset for asset in assets if asset.path.suffix == ".png"]) == 1
     assert len(assets) == 2
+
+
+def test_discover_assets_uses_publication_catalog_when_present(tmp_path):
+    output_dir = tmp_path / "output"
+    week_dir = output_dir / "2026" / "week_17"
+    week_dir.mkdir(parents=True)
+
+    published_image = week_dir / "published.png"
+    published_image.write_bytes(b"png")
+    published_image.with_suffix(".txt").write_text("published", encoding="utf-8")
+
+    hidden_image = week_dir / "hidden.png"
+    hidden_image.write_bytes(b"png")
+    hidden_image.with_suffix(".txt").write_text("hidden", encoding="utf-8")
+
+    backfill_catalog(output_dir, default_state="published")
+    set_publication_state(output_dir, hidden_image.relative_to(output_dir).as_posix(), "hidden")
+
+    assets = discover_assets(output_dir, since=None, limit=None)
+
+    assert [asset.key for asset in assets] == [
+        "2026/week_17/published.png",
+        "2026/week_17/published.txt",
+    ]


### PR DESCRIPTION
## Summary
- add a JSON-backed publication catalog for generated gallery assets
- register generated and edited images with publication state and placeholder quality flags
- expose catalog/backfill/state-update API endpoints and make `/api/gallery` return only published/featured entries
- have the publisher script honor the catalog when present

Closes #23.

## Tests
- `UV_PROJECT_ENVIRONMENT=.venv-test uv run pytest tests/test_api.py tests/test_publish_gallery.py`
- `UV_PROJECT_ENVIRONMENT=.venv-test uv run pytest tests/` (passes; still prints the known Windows DiffSynth/pyarrow access-violation footer tracked in #30)