### PR TITLE
[codex] Fix Windows DiffSynth pytest access violation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: host-image/package-lock.json
 

--- a/host-image/package-lock.json
+++ b/host-image/package-lock.json
@@ -8,20 +8,20 @@
 			"name": "host-image",
 			"version": "0.0.0",
 			"devDependencies": {
-				"@cloudflare/vitest-pool-workers": "^0.15.0",
+				"@cloudflare/vitest-pool-workers": "^0.16.10",
 				"typescript": "^6.0.3",
 				"vitest": "^4.1.5",
 				"wrangler": "^4.85.0"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
-			"integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+			"integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/@cloudflare/unenv-preset": {
@@ -41,16 +41,16 @@
 			}
 		},
 		"node_modules/@cloudflare/vitest-pool-workers": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.15.0.tgz",
-			"integrity": "sha512-RldzOt2az3mxICTxT7GTSBpm6f61lx4LWSilRHm4pJlYAGmfGu1pyinqJw3UmPZS9N/mrN7XwdZAqFV6hhmWaQ==",
+			"version": "0.16.10",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.10.tgz",
+			"integrity": "sha512-cHYJ67zi+L4o2Ped8DCfRv0kWl/VNaUUicl1JStxoMsw+32WxExAlYYlAjNludTN6F5y0KScLXmXma2WoTLMvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cjs-module-lexer": "^1.2.3",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260424.0",
-				"wrangler": "4.85.0",
+				"miniflare": "4.20260526.0",
+				"wrangler": "4.95.0",
 				"zod": "^3.25.76"
 			},
 			"peerDependencies": {
@@ -60,9 +60,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260424.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260424.1.tgz",
-			"integrity": "sha512-yFR1XaJbSDLg/qbwtrYaU2xwFXatIPKR5nrMQCN1q/m6+Qe/j6r+kCnFEvOJjMZOm9iCKsE6Qly5clgl4u32qw==",
+			"version": "1.20260526.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260526.1.tgz",
+			"integrity": "sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==",
 			"cpu": [
 				"x64"
 			],
@@ -77,9 +77,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260424.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260424.1.tgz",
-			"integrity": "sha512-LqWKcE7x/9KyC2iQvKPeb20hKST3dYXDZlYTvFymgR1DfLS0OFOCzVGTloVNd7WqvK4SkdzBYfxo7QMIAeBK0w==",
+			"version": "1.20260526.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260526.1.tgz",
+			"integrity": "sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==",
 			"cpu": [
 				"arm64"
 			],
@@ -94,9 +94,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260424.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260424.1.tgz",
-			"integrity": "sha512-YlEBFbAYZHe/ylzl8WEYQEU/jr+0XMqXaST2oBk5oVjksdb1NGuJaggluCdZAzuJJ8UqdTmyhY5u/qrasbiFWA==",
+			"version": "1.20260526.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260526.1.tgz",
+			"integrity": "sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==",
 			"cpu": [
 				"x64"
 			],
@@ -111,9 +111,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260424.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260424.1.tgz",
-			"integrity": "sha512-qJ0X0m6cL8fWDUPDg8K4IxYZXNJI6XbeOihqjnqKbAClrjdPDn8VUSd+z2XiCQ5NylMtMrpa/skC9UfaR6mh8g==",
+			"version": "1.20260526.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260526.1.tgz",
+			"integrity": "sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==",
 			"cpu": [
 				"arm64"
 			],
@@ -128,9 +128,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260424.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260424.1.tgz",
-			"integrity": "sha512-tZ7Z9qmYNAP6z1/+8r/zKbk8F8DZmpmwNzMeN+zkde2Wnhfr3FBqOkJXT/5zmli8HPoWrIXxSiyqcNDMy8V2Zg==",
+			"version": "1.20260526.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260526.1.tgz",
+			"integrity": "sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==",
 			"cpu": [
 				"x64"
 			],
@@ -143,15 +143,6 @@
 			"engines": {
 				"node": ">=16"
 			}
-		},
-		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260426.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260426.1.tgz",
-			"integrity": "sha512-cBYeQaWwv/jFV8ualmwp6wIxmAf0rDe2DPPQwPbslKmPHqgv861YpAvm45r05K40QboZgxNQVIPgNkmtHqZeJQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -2117,24 +2108,24 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260424.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260424.0.tgz",
-			"integrity": "sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw==",
+			"version": "4.20260526.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260526.0.tgz",
+			"integrity": "sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "^0.34.5",
 				"undici": "7.24.8",
-				"workerd": "1.20260424.1",
-				"ws": "8.18.0",
+				"workerd": "1.20260526.1",
+				"ws": "8.20.1",
 				"youch": "4.1.0-beta.10"
 			},
 			"bin": {
 				"miniflare": "bootstrap.js"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/nanoid": {
@@ -2264,10 +2255,70 @@
 				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
 			}
 		},
+		"node_modules/rosie-skills": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/rosie-skills/-/rosie-skills-0.6.4.tgz",
+			"integrity": "sha512-ojfhSiQRdZ2QyWbmKAHOSAUbaLYrTc5zIH7mS1jKoP8KCFSQddwVhMyFqldckTeybTfW3zNcsZzyOTzGTN1SBA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"bin": {
+				"rosie-skills": "dist/bin.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"rosie-skills-darwin-arm64": "0.6.4",
+				"rosie-skills-freebsd-x64": "0.6.4",
+				"rosie-skills-linux-x64": "0.6.4"
+			}
+		},
+		"node_modules/rosie-skills-darwin-arm64": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/rosie-skills-darwin-arm64/-/rosie-skills-darwin-arm64-0.6.4.tgz",
+			"integrity": "sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/rosie-skills-freebsd-x64": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/rosie-skills-freebsd-x64/-/rosie-skills-freebsd-x64-0.6.4.tgz",
+			"integrity": "sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/rosie-skills-linux-x64": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/rosie-skills-linux-x64/-/rosie-skills-linux-x64-0.6.4.tgz",
+			"integrity": "sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -2638,9 +2689,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260424.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260424.1.tgz",
-			"integrity": "sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ==",
+			"version": "1.20260526.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260526.1.tgz",
+			"integrity": "sha512-IHzymht98p10JH1zzwdCpbViAqw97HrwKl7+KfZeASFMsYSrIsAULWdPn0LRC5FTUzBpamLNyKCCKxbgXHgRHQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -2651,41 +2702,42 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260424.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260424.1",
-				"@cloudflare/workerd-linux-64": "1.20260424.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260424.1",
-				"@cloudflare/workerd-windows-64": "1.20260424.1"
+				"@cloudflare/workerd-darwin-64": "1.20260526.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260526.1",
+				"@cloudflare/workerd-linux-64": "1.20260526.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260526.1",
+				"@cloudflare/workerd-windows-64": "1.20260526.1"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.85.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.85.0.tgz",
-			"integrity": "sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg==",
+			"version": "4.95.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.95.0.tgz",
+			"integrity": "sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
-				"@cloudflare/kv-asset-handler": "0.4.2",
+				"@cloudflare/kv-asset-handler": "0.5.0",
 				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260424.0",
+				"miniflare": "4.20260526.0",
 				"path-to-regexp": "6.3.0",
+				"rosie-skills": "^0.6.3",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260424.1"
+				"workerd": "1.20260526.1"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
 				"wrangler2": "bin/wrangler.js"
 			},
 			"engines": {
-				"node": ">=20.3.0"
+				"node": ">=22.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260424.1"
+				"@cloudflare/workers-types": "^4.20260526.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -2694,9 +2746,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"version": "8.20.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/host-image/package.json
+++ b/host-image/package.json
@@ -10,7 +10,7 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.15.0",
+		"@cloudflare/vitest-pool-workers": "^0.16.10",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.5",
 		"wrangler": "^4.85.0"

--- a/src/generators/zimage_generator.py
+++ b/src/generators/zimage_generator.py
@@ -4,6 +4,7 @@ import asyncio
 import gc
 import hashlib
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -14,6 +15,13 @@ from loguru import logger
 from ..plugins import plugin_manager, register_lora_plugin
 from ..plugins.lora import get_lora_path
 from .base_generator import GenerationResult, ImageGenerator
+
+
+@dataclass(frozen=True)
+class DiffSynthModelConfigSpec:
+    """Import-free description of local checkpoint files for DiffSynth."""
+
+    path: list[str]
 
 
 class ZImageGenerator(ImageGenerator):
@@ -77,10 +85,8 @@ class ZImageGenerator(ImageGenerator):
         self.selected_lora_name = None
         return None
 
-    def _build_diffsynth_model_configs(self):
-        """Build local-path model configs for DiffSynth Z-Image loading."""
-        from diffsynth.pipelines.z_image import ModelConfig
-
+    def _build_diffsynth_model_configs(self) -> list[DiffSynthModelConfigSpec]:
+        """Build local-path model configs without importing DiffSynth."""
         transformer_paths = sorted(
             str(path) for path in (self.model_path / "transformer").glob("*.safetensors")
         )
@@ -108,9 +114,9 @@ class ZImageGenerator(ImageGenerator):
             )
 
         return [
-            ModelConfig(path=transformer_paths),
-            ModelConfig(path=text_encoder_paths),
-            ModelConfig(path=vae_paths),
+            DiffSynthModelConfigSpec(path=transformer_paths),
+            DiffSynthModelConfigSpec(path=text_encoder_paths),
+            DiffSynthModelConfigSpec(path=vae_paths),
         ]
 
     def _load_diffsynth_pipe(self, lora_path: Path):
@@ -130,10 +136,13 @@ class ZImageGenerator(ImageGenerator):
             )
 
         logger.info(f"Loading Z-Image via DiffSynth for LoRA support from: {self.model_path}")
+        model_configs = [
+            ModelConfig(path=config.path) for config in self._build_diffsynth_model_configs()
+        ]
         self.pipe = ZImagePipeline.from_pretrained(
             torch_dtype=torch.bfloat16,
             device=self.device,
-            model_configs=self._build_diffsynth_model_configs(),
+            model_configs=model_configs,
             tokenizer_config=ModelConfig(path=str(self.model_path / "tokenizer")),
         )
         self.pipe.load_lora(self.pipe.dit, str(lora_path))

--- a/tests/test_zimage_generator.py
+++ b/tests/test_zimage_generator.py
@@ -1,5 +1,6 @@
 """Tests for Z-Image generator."""
 
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -161,7 +162,8 @@ class TestZImageGeneratorWithMockZImage:
         with patch("torch.cuda.is_available", return_value=False):
             gen = ZImageGenerator(mock_config)
 
-        configs = gen._build_diffsynth_model_configs()
+        with patch.dict("sys.modules", {"diffsynth": None}):
+            configs = gen._build_diffsynth_model_configs()
 
         assert configs[0].path == sorted(str(path) for path in transformer_shards)
         assert configs[1].path == sorted(str(path) for path in text_encoder_shards)


### PR DESCRIPTION
## Summary

Fixes #30 by keeping the Z-Image DiffSynth model-config path builder import-free.

## What changed

- Added a lightweight `DiffSynthModelConfigSpec` for local checkpoint path discovery.
- Moved conversion to DiffSynth `ModelConfig` objects into the actual LoRA pipeline load path.
- Added a regression test that verifies `_build_diffsynth_model_configs()` works even when `diffsynth` is unavailable.
- Updated `host-image` Worker test tooling to clear the CI `npm audit --audit-level=moderate` failure from the current `ws` advisory, and moved that CI job to Node 22 to match the updated Cloudflare tooling engine requirement.

## Root cause

A unit test called `_build_diffsynth_model_configs()`, which imported `diffsynth.pipelines.z_image.ModelConfig`. On Windows that pulled in `diffsynth -> pandas -> pyarrow` and printed a fatal access-violation trace even though pytest exited successfully.

## Validation

- `UV_PROJECT_ENVIRONMENT=.venv-test uv run black --check src/generators/zimage_generator.py tests/test_zimage_generator.py`
- `UV_PROJECT_ENVIRONMENT=.venv-test uv run isort --check src/generators/zimage_generator.py tests/test_zimage_generator.py`
- `git diff --check --cached`
- `UV_PROJECT_ENVIRONMENT=.venv-test uv run pytest tests/` -> 69 passed, 2 skipped, 2 warnings; no Windows access-violation footer
- `npm ci` in `host-image`
- `npx tsc --noEmit` in `host-image`
- `npm test -- --run` in `host-image`
- `npm audit --audit-level=moderate` in `host-image`
- `UV_PROJECT_ENVIRONMENT=.venv-test uv run pre-commit run check-yaml --files .github/workflows/ci.yml`