### PR TITLE
[codex] Add ImageGenService boundary and mypy green zone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
           uv run pylint src/ --errors-only --disable=import-error
         continue-on-error: true
 
+      - name: Type check typed green zone (mypy)
+        run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          uv run mypy
+
   python-tests:
     name: Python Tests
     runs-on: ubuntu-latest

--- a/docs/CODE_QUALITY.md
+++ b/docs/CODE_QUALITY.md
@@ -264,14 +264,15 @@ just web-lint-fix
 # Type check Python code
 just typecheck
 
-# Specific file
-uv run mypy src/main.py
+# The default mypy command checks the current typed green zone from mypy.ini.
+uv run mypy
 ```
 
 ### Configuration
 
 **mypy** (`mypy.ini`):
 - Python 3.11+
+- Uses an explicit `files` allowlist for typed green-zone modules while legacy debt is tracked in GitHub
 - Ignore missing imports (ML libraries)
 - No strict optional
 - Excludes: venv, node_modules, output, tests

--- a/justfile
+++ b/justfile
@@ -76,7 +76,7 @@ lint-errors:
 
 # Type check Python code
 typecheck:
-    uv run mypy src/
+    uv run mypy
 
 # Lint web UI
 web-lint:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,9 @@
 [mypy]
 python_version = 3.11
+files =
+    src/services,
+    src/utils/storage.py,
+    src/utils/publication_catalog.py
 warn_return_any = False
 warn_unused_configs = True
 disallow_untyped_defs = False

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -19,15 +19,11 @@ from fastapi.staticfiles import StaticFiles
 from PIL import Image
 from pydantic import BaseModel, Field
 
-from src.generators.factory import (
-    backend_label,
-    create_image_generator,
-    is_model_cached,
-    resolve_image_backend,
-)
+from src.generators.factory import backend_label, is_model_cached, resolve_image_backend
 from src.generators.prompt_generator import PromptGenerator
 from src.plugins import plugin_manager, register_lora_plugin
 from src.plugins.lora import get_available_loras
+from src.services import GenerationProgressEvent, GenerationServiceRequest, ImageGenService
 from src.utils.config import Config
 from src.utils.ollama import (
     get_ollama_version,
@@ -44,13 +40,7 @@ from src.utils.publication_catalog import (
     remove_image,
     set_publication_state,
 )
-from src.utils.storage import (
-    StorageManager,
-    metadata_path_for,
-    read_image_metadata,
-    save_image_and_prompt,
-    write_image_metadata,
-)
+from src.utils.storage import StorageManager, metadata_path_for, save_image_and_prompt
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -974,8 +964,53 @@ async def generate_image(request: GenerateRequest):
     """Generate a single image"""
     generation_id = str(uuid.uuid4())
 
+    async def emit_generation_event(event: GenerationProgressEvent) -> None:
+        if event.progress is not None:
+            await broadcast_task_progress(
+                task="image_generation",
+                task_id=generation_id,
+                client_request_id=request.client_request_id,
+                progress=event.progress,
+                label=event.label or event.name,
+                detail=event.detail or "",
+            )
+
+        if event.name == "prompt_generated":
+            await manager.broadcast(
+                json.dumps(
+                    {
+                        "type": "prompt_generated",
+                        "id": generation_id,
+                        "client_request_id": request.client_request_id,
+                        "prompt": event.payload.get("prompt", ""),
+                    }
+                )
+            )
+        elif event.name == "model_loading":
+            await manager.broadcast(
+                json.dumps(
+                    {
+                        "type": "model_loading",
+                        "id": generation_id,
+                        "client_request_id": request.client_request_id,
+                        "message": event.payload.get("message", event.detail or ""),
+                    }
+                )
+            )
+        elif event.name == "generation_completed":
+            await manager.broadcast(
+                json.dumps(
+                    {
+                        "type": "generation_completed",
+                        "id": generation_id,
+                        "client_request_id": request.client_request_id,
+                        "image_path": event.payload.get("image_path", ""),
+                        "prompt": event.payload.get("prompt", ""),
+                    }
+                )
+            )
+
     try:
-        # Broadcast start event
         await manager.broadcast(
             json.dumps(
                 {
@@ -986,211 +1021,34 @@ async def generate_image(request: GenerateRequest):
                 }
             )
         )
-        await broadcast_task_progress(
-            task="image_generation",
-            task_id=generation_id,
-            client_request_id=request.client_request_id,
-            progress=8,
-            label="Preparing image request",
-            detail="Collecting the prompt, active plugins, and runtime settings.",
-        )
-
-        # Generate prompt if not provided
-        if request.prompt:
-            final_prompt = request.prompt
-            await broadcast_task_progress(
-                task="image_generation",
-                task_id=generation_id,
-                client_request_id=request.client_request_id,
-                progress=24,
-                label="Prompt ready",
-                detail="Using the prompt you provided directly.",
-            )
-        else:
-            prompt_gen = PromptGenerator(config)
-            await broadcast_task_progress(
-                task="image_generation",
-                task_id=generation_id,
-                client_request_id=request.client_request_id,
-                progress=24,
-                label="Generating prompt",
-                detail="Building a fresh prompt from Ollama and the active plugins.",
-            )
-            final_prompt = await prompt_gen.generate_prompt()
-
-            # Broadcast prompt generated event
-            await manager.broadcast(
-                json.dumps(
-                    {
-                        "type": "prompt_generated",
-                        "id": generation_id,
-                        "client_request_id": request.client_request_id,
-                        "prompt": final_prompt,
-                    }
-                )
-            )
-            await broadcast_task_progress(
-                task="image_generation",
-                task_id=generation_id,
-                client_request_id=request.client_request_id,
-                progress=40,
-                label="Prompt ready",
-                detail="The prompt is assembled. Preparing the image backend next.",
-            )
-
-        try:
-            image_gen, backend_name = create_image_generator(config)
-            logger.info("Using image backend: %s", backend_name)
-            await broadcast_task_progress(
-                task="image_generation",
-                task_id=generation_id,
-                client_request_id=request.client_request_id,
-                progress=55,
-                label="Backend ready",
-                detail="The selected image backend is loaded and ready to render.",
-            )
-        except MemoryError as e:
-            error_msg = "Insufficient memory to load the configured image backend."
-            logger.error(f"Memory error loading Flux model: {str(e)}")
-            await manager.broadcast(
-                json.dumps(
-                    {
-                        "type": "generation_error",
-                        "id": generation_id,
-                        "client_request_id": request.client_request_id,
-                        "error": error_msg,
-                    }
-                )
-            )
-            raise HTTPException(status_code=507, detail=error_msg)
-        except Exception as e:
-            error_msg = f"Failed to load image backend: {str(e)}"
-            logger.error(error_msg)
-            await manager.broadcast(
-                json.dumps(
-                    {
-                        "type": "generation_error",
-                        "id": generation_id,
-                        "client_request_id": request.client_request_id,
-                        "error": error_msg,
-                    }
-                )
-            )
-            raise HTTPException(status_code=500, detail=error_msg)
-
-        backend_name = backend_label(config, resolve_image_backend(config))
-        loading_message = {
-            "mock": "Using mock image generator.",
-            "smoke-test": "Loading smoke-test image model.",
-            "small-sd": "Loading small Stable Diffusion fallback model.",
-            "sd-turbo": "Loading turbo image model.",
-            "ollama": "Requesting an image from the configured Ollama host.",
-        }.get(backend_name, "Loading Flux model (this may take several minutes on first run)...")
-
-        await manager.broadcast(
-            json.dumps(
-                {
-                    "type": "model_loading",
-                    "id": generation_id,
-                    "client_request_id": request.client_request_id,
-                    "message": loading_message,
-                }
-            )
-        )
-        await broadcast_task_progress(
-            task="image_generation",
-            task_id=generation_id,
-            client_request_id=request.client_request_id,
-            progress=68,
-            label="Rendering image",
-            detail=loading_message,
-        )
-
-        # Generate and save the image through the active backend.
-        storage = StorageManager(str(OUTPUT_DIR))
-        requested_output_path = storage.get_output_path(final_prompt)
-        image_path, _, _ = await image_gen.generate_image(
-            final_prompt,
-            requested_output_path,
-            force_reinit=False,
-            seed=request.seed,
-        )
-        await broadcast_task_progress(
-            task="image_generation",
-            task_id=generation_id,
-            client_request_id=request.client_request_id,
-            progress=92,
-            label="Finalizing output",
-            detail="Saving metadata and writing the finished image to the gallery.",
-        )
-        generation_metadata = getattr(image_gen, "last_generation_metadata", {}) or {}
-        seed_supported = generation_metadata.get("seed_supported", True)
-        resolved_seed = generation_metadata.get("seed")
-        if resolved_seed is None and request.seed is not None and seed_supported:
-            resolved_seed = request.seed
-        existing_metadata = read_image_metadata(image_path)
-        saved_metadata = {
-            **existing_metadata,
-            **generation_metadata,
-            "backend": backend_name,
-            "configured_backend": config.model.image_backend,
-            "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
-            "seed": resolved_seed,
-        }
-        write_image_metadata(image_path, saved_metadata)
-        publication_entry = register_image(
-            image_path,
-            OUTPUT_DIR,
-            prompt=final_prompt,
-            metadata=saved_metadata,
-            publication_state="draft",
-        )
-
-        # Create relative path for API response
-        relative_path = f"/images/{image_path.relative_to(OUTPUT_DIR).as_posix()}"
-
-        # Broadcast completion event
-        await manager.broadcast(
-            json.dumps(
-                {
-                    "type": "generation_completed",
-                    "id": generation_id,
-                    "client_request_id": request.client_request_id,
-                    "image_path": relative_path,
-                    "prompt": final_prompt,
-                }
-            )
-        )
-        await broadcast_task_progress(
-            task="image_generation",
-            task_id=generation_id,
-            client_request_id=request.client_request_id,
-            progress=100,
-            label="Image ready",
-            detail="The generated image is saved and ready to review.",
+        service = ImageGenService(config, output_dir=OUTPUT_DIR)
+        result = await service.generate(
+            GenerationServiceRequest(prompt=request.prompt, seed=request.seed),
+            callback=emit_generation_event,
         )
 
         return GenerateResponse(
             id=generation_id,
-            prompt=final_prompt,
-            image_path=relative_path,
-            metadata={
-                **generation_metadata,
-                "backend": backend_name,
-                "publication": {
-                    "id": publication_entry["id"],
-                    "state": publication_entry["publication_state"],
-                    "publishable": publication_entry["publishable"],
-                    "quality_flags": publication_entry["quality_flags"],
-                },
-                "plugins_used": [
-                    name for name, info in plugin_manager.plugins.items() if info.enabled
-                ],
-                "seed": resolved_seed,
-            },
-            created_at=datetime.now().isoformat(),
+            prompt=result.prompt,
+            image_path=result.relative_image_path,
+            metadata=result.metadata,
+            created_at=result.created_at,
         )
 
+    except MemoryError as e:
+        error_msg = "Insufficient memory to load the configured image backend."
+        logger.error(f"Memory error loading image backend: {str(e)}")
+        await manager.broadcast(
+            json.dumps(
+                {
+                    "type": "generation_error",
+                    "id": generation_id,
+                    "client_request_id": request.client_request_id,
+                    "error": error_msg,
+                }
+            )
+        )
+        raise HTTPException(status_code=507, detail=error_msg)
     except Exception as e:
         logger.error(f"Generation failed: {str(e)}")
 

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,15 @@
+"""Application service boundaries for DreamGen workflows."""
+
+from .image_generation import (
+    GenerationProgressEvent,
+    GenerationServiceRequest,
+    GenerationServiceResult,
+    ImageGenService,
+)
+
+__all__ = [
+    "GenerationProgressEvent",
+    "GenerationServiceRequest",
+    "GenerationServiceResult",
+    "ImageGenService",
+]

--- a/src/services/image_generation.py
+++ b/src/services/image_generation.py
@@ -1,0 +1,279 @@
+"""Core image generation service boundary shared by API, CLI, and jobs."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+from src.generators.factory import create_image_generator
+from src.generators.prompt_generator import PromptGenerator
+from src.plugins import plugin_manager
+from src.utils.config import Config
+from src.utils.publication_catalog import register_image
+from src.utils.storage import StorageManager, read_image_metadata, write_image_metadata
+
+
+class ImageBackend(Protocol):
+    """Generation backend interface used by the service."""
+
+    last_generation_metadata: dict[str, Any]
+
+    async def generate_image(
+        self,
+        prompt: str,
+        output_path: Path,
+        force_reinit: bool = False,
+        seed: int | None = None,
+    ) -> tuple[Path, float, str]:
+        """Generate and save an image."""
+
+    def cleanup(self) -> None:
+        """Release backend resources."""
+
+
+@dataclass(frozen=True)
+class GenerationServiceRequest:
+    """Input for a single image generation workflow."""
+
+    prompt: str | None = None
+    meta_prompt: str | None = None
+    seed: int | None = None
+    force_reinit: bool = False
+    publication_state: str = "draft"
+    cleanup: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GenerationProgressEvent:
+    """Structured progress event emitted during generation."""
+
+    name: str
+    progress: int | None = None
+    label: str | None = None
+    detail: str | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GenerationServiceResult:
+    """Result from a completed generation workflow."""
+
+    prompt: str
+    image_path: Path
+    relative_image_path: str
+    backend: str
+    model_name: str
+    generation_time: float
+    metadata: dict[str, Any]
+    publication: dict[str, Any]
+    created_at: str
+
+
+ProgressCallback = Callable[[GenerationProgressEvent], Awaitable[None] | None]
+
+
+def loading_message_for_backend(backend_name: str) -> str:
+    """Return a user-facing lifecycle message for a backend label."""
+    return {
+        "mock": "Using mock image generator.",
+        "smoke-test": "Loading smoke-test image model.",
+        "small-sd": "Loading small Stable Diffusion fallback model.",
+        "sd-turbo": "Loading turbo image model.",
+        "ollama": "Requesting an image from the configured Ollama host.",
+    }.get(backend_name, "Loading Flux model (this may take several minutes on first run)...")
+
+
+class ImageGenService:
+    """Coordinates prompt resolution, backend generation, metadata, and catalog state."""
+
+    def __init__(self, config: Config, output_dir: Path | None = None):
+        self.config = config
+        self.output_dir = output_dir or config.system.output_dir
+
+    async def _emit(
+        self,
+        callback: ProgressCallback | None,
+        event: GenerationProgressEvent,
+    ) -> None:
+        if callback is None:
+            return
+        result = callback(event)
+        if inspect.isawaitable(result):
+            await result
+
+    async def _resolve_prompt(
+        self,
+        request: GenerationServiceRequest,
+        callback: ProgressCallback | None,
+    ) -> str:
+        if request.prompt:
+            await self._emit(
+                callback,
+                GenerationProgressEvent(
+                    name="prompt_ready",
+                    progress=24,
+                    label="Prompt ready",
+                    detail="Using the prompt you provided directly.",
+                    payload={"prompt": request.prompt},
+                ),
+            )
+            return request.prompt
+
+        await self._emit(
+            callback,
+            GenerationProgressEvent(
+                name="prompt_generation_started",
+                progress=24,
+                label="Generating prompt",
+                detail="Building a fresh prompt from Ollama and the active plugins.",
+            ),
+        )
+        prompt = await PromptGenerator(self.config).generate_prompt(meta_prompt=request.meta_prompt)
+        await self._emit(
+            callback,
+            GenerationProgressEvent(
+                name="prompt_generated",
+                progress=40,
+                label="Prompt ready",
+                detail="The prompt is assembled. Preparing the image backend next.",
+                payload={"prompt": prompt},
+            ),
+        )
+        return prompt
+
+    async def generate(
+        self,
+        request: GenerationServiceRequest,
+        callback: ProgressCallback | None = None,
+    ) -> GenerationServiceResult:
+        """Run one generation workflow and return persisted artifact details."""
+        await self._emit(
+            callback,
+            GenerationProgressEvent(
+                name="generation_preparing",
+                progress=8,
+                label="Preparing image request",
+                detail="Collecting the prompt, active plugins, and runtime settings.",
+            ),
+        )
+
+        final_prompt = await self._resolve_prompt(request, callback)
+        image_gen_raw, backend_name = create_image_generator(self.config)
+        image_gen = cast(ImageBackend, image_gen_raw)
+        await self._emit(
+            callback,
+            GenerationProgressEvent(
+                name="backend_ready",
+                progress=55,
+                label="Backend ready",
+                detail="The selected image backend is loaded and ready to render.",
+                payload={"backend": backend_name},
+            ),
+        )
+
+        loading_message = loading_message_for_backend(backend_name)
+        await self._emit(
+            callback,
+            GenerationProgressEvent(
+                name="model_loading",
+                progress=68,
+                label="Rendering image",
+                detail=loading_message,
+                payload={"backend": backend_name, "message": loading_message},
+            ),
+        )
+
+        storage = StorageManager(str(self.output_dir))
+        requested_output_path = storage.get_output_path(final_prompt)
+        try:
+            image_path, generation_time, model_name = await image_gen.generate_image(
+                final_prompt,
+                requested_output_path,
+                force_reinit=request.force_reinit,
+                seed=request.seed,
+            )
+        finally:
+            if request.cleanup:
+                image_gen.cleanup()
+
+        await self._emit(
+            callback,
+            GenerationProgressEvent(
+                name="finalizing_output",
+                progress=92,
+                label="Finalizing output",
+                detail="Saving metadata and writing the finished image to the gallery.",
+            ),
+        )
+
+        generation_metadata = getattr(image_gen, "last_generation_metadata", {}) or {}
+        seed_supported = generation_metadata.get("seed_supported", True)
+        resolved_seed = generation_metadata.get("seed")
+        if resolved_seed is None and request.seed is not None and seed_supported:
+            resolved_seed = request.seed
+
+        existing_metadata = read_image_metadata(image_path)
+        saved_metadata = {
+            **existing_metadata,
+            **request.metadata,
+            **generation_metadata,
+            "backend": backend_name,
+            "configured_backend": self.config.model.image_backend,
+            "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+            "seed": resolved_seed,
+        }
+        write_image_metadata(image_path, saved_metadata)
+        publication_entry = register_image(
+            image_path,
+            self.output_dir,
+            prompt=final_prompt,
+            metadata=saved_metadata,
+            publication_state=request.publication_state,
+        )
+        relative_image_path = f"/images/{image_path.relative_to(self.output_dir).as_posix()}"
+        active_plugins = [name for name, info in plugin_manager.plugins.items() if info.enabled]
+        response_metadata = {
+            **generation_metadata,
+            "backend": backend_name,
+            "publication": {
+                "id": publication_entry["id"],
+                "state": publication_entry["publication_state"],
+                "publishable": publication_entry["publishable"],
+                "quality_flags": publication_entry["quality_flags"],
+            },
+            "plugins_used": active_plugins,
+            "seed": resolved_seed,
+        }
+        created_at = datetime.now().isoformat()
+
+        await self._emit(
+            callback,
+            GenerationProgressEvent(
+                name="generation_completed",
+                progress=100,
+                label="Image ready",
+                detail="The generated image is saved and ready to review.",
+                payload={
+                    "image_path": relative_image_path,
+                    "prompt": final_prompt,
+                    "backend": backend_name,
+                },
+            ),
+        )
+
+        return GenerationServiceResult(
+            prompt=final_prompt,
+            image_path=image_path,
+            relative_image_path=relative_image_path,
+            backend=backend_name,
+            model_name=model_name,
+            generation_time=generation_time,
+            metadata=response_metadata,
+            publication=response_metadata["publication"],
+            created_at=created_at,
+        )

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -1,0 +1,77 @@
+"""Tests for the core ImageGenService boundary."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services import GenerationServiceRequest, ImageGenService
+from src.utils.publication_catalog import load_catalog
+from src.utils.storage import read_image_metadata
+
+
+@pytest.fixture
+def mock_service_config(tmp_path):
+    """Create the minimal config shape used by mock generation."""
+    config = MagicMock()
+    config.model.image_backend = "mock"
+    config.model.flux_model = "black-forest-labs/FLUX.1-schnell"
+    config.model.small_sd_model = "segmind/tiny-sd"
+    config.image.width = 64
+    config.image.height = 64
+    config.system.output_dir = tmp_path
+    config.system.cpu_only = True
+    return config
+
+
+@pytest.mark.asyncio
+async def test_service_generates_image_metadata_and_catalog_entry(mock_service_config, tmp_path):
+    service = ImageGenService(mock_service_config, output_dir=tmp_path)
+
+    result = await service.generate(
+        GenerationServiceRequest(prompt="service boundary test", seed=123)
+    )
+
+    assert result.image_path.exists()
+    assert result.relative_image_path.startswith("/images/")
+    assert result.backend == "mock"
+    assert result.metadata["backend"] == "mock"
+    assert result.metadata["seed"] == 123
+    assert result.metadata["publication"]["state"] == "rejected"
+    assert result.metadata["publication"]["quality_flags"] == ["placeholder"]
+
+    metadata = read_image_metadata(result.image_path)
+    assert metadata["backend"] == "mock"
+    assert metadata["configured_backend"] == "mock"
+    assert metadata["seed"] == 123
+
+    catalog = load_catalog(tmp_path)
+    relative_key = result.image_path.relative_to(tmp_path).as_posix()
+    assert catalog["assets"][relative_key]["prompt"] == "service boundary test"
+    assert catalog["assets"][relative_key]["publication_state"] == "rejected"
+    assert catalog["assets"][relative_key]["quality_flags"] == ["placeholder"]
+
+
+@pytest.mark.asyncio
+async def test_service_emits_generation_lifecycle_events(mock_service_config, tmp_path):
+    service = ImageGenService(mock_service_config, output_dir=tmp_path)
+    events = []
+
+    async def collect(event):
+        events.append(event)
+
+    await service.generate(
+        GenerationServiceRequest(prompt="event test", seed=7),
+        callback=collect,
+    )
+
+    event_names = [event.name for event in events]
+    assert event_names == [
+        "generation_preparing",
+        "prompt_ready",
+        "backend_ready",
+        "model_loading",
+        "finalizing_output",
+        "generation_completed",
+    ]
+    assert events[-1].payload["image_path"].startswith("/images/")


### PR DESCRIPTION
## Summary
- add a typed ImageGenService boundary that owns prompt resolution, backend generation, metadata persistence, publication catalog registration, and progress events
- refactor the API generation endpoint to delegate orchestration to the service while preserving websocket/task progress events
- add a focused mypy green zone, CI type-check step, justfile command, and code quality docs

## Validation
- UV_PROJECT_ENVIRONMENT=.venv-test uv run pytest tests/
- UV_PROJECT_ENVIRONMENT=.venv-test uv run mypy
- UV_PROJECT_ENVIRONMENT=.venv-test uv run black --check src tests
- UV_PROJECT_ENVIRONMENT=.venv-test uv run isort --check src tests
- UV_PROJECT_ENVIRONMENT=.venv-test uv run pylint src/ --errors-only --disable=import-error
- UV_PROJECT_ENVIRONMENT=.venv-test uv run pre-commit run check-yaml --files .github/workflows/ci.yml
- git diff --check

Refs #29
Refs #38