### PR TITLE
[codex] Route CLI generation through ImageGenService

### DIFF
--- a/src/services/image_generation.py
+++ b/src/services/image_generation.py
@@ -150,6 +150,8 @@ class ImageGenService:
         self,
         request: GenerationServiceRequest,
         callback: ProgressCallback | None = None,
+        backend: ImageBackend | None = None,
+        backend_name: str | None = None,
     ) -> GenerationServiceResult:
         """Run one generation workflow and return persisted artifact details."""
         await self._emit(
@@ -163,8 +165,13 @@ class ImageGenService:
         )
 
         final_prompt = await self._resolve_prompt(request, callback)
-        image_gen_raw, backend_name = create_image_generator(self.config)
-        image_gen = cast(ImageBackend, image_gen_raw)
+        if backend is None:
+            image_gen_raw, backend_name = create_image_generator(self.config)
+            image_gen = cast(ImageBackend, image_gen_raw)
+        else:
+            if backend_name is None:
+                raise ValueError("backend_name is required when passing a reusable backend")
+            image_gen = backend
         await self._emit(
             callback,
             GenerationProgressEvent(
@@ -190,6 +197,13 @@ class ImageGenService:
 
         storage = StorageManager(str(self.output_dir))
         requested_output_path = storage.get_output_path(final_prompt)
+        await self._emit(
+            callback,
+            GenerationProgressEvent(
+                name="output_path_ready",
+                payload={"output_path": requested_output_path},
+            ),
+        )
         try:
             image_path, generation_time, model_name = await image_gen.generate_image(
                 final_prompt,

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -7,8 +7,9 @@ import os
 import sys
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Awaitable, Optional, TypeVar
+from typing import Awaitable, Iterator, Optional, TypeVar
 
 # Fix Windows Unicode handling
 if sys.platform == "win32":
@@ -35,10 +36,10 @@ from .. import __version__
 from ..generators.factory import create_image_generator, is_model_cached, resolve_image_backend
 from ..generators.prompt_generator import PromptGenerator
 from ..plugins import ensure_initialized, plugin_manager
+from ..services import GenerationProgressEvent, GenerationServiceRequest, ImageGenService
 from .config import Config
 from .logging_config import setup_logging
 from .metrics import MetricsCollector
-from .storage import StorageManager
 from .troubleshoot import SystemDiagnostics
 
 # Initialize rich console for better output
@@ -71,20 +72,31 @@ def get_runtime_config() -> Config:
     return app.state.config
 
 
+@contextmanager
+def temporary_backend_override(
+    config: Config,
+    backend_override: Optional[str] = None,
+    mock: bool = False,
+) -> Iterator[None]:
+    """Temporarily apply a one-shot generation backend override."""
+    original_backend = config.model.image_backend
+    effective_backend = "mock" if mock else backend_override
+
+    try:
+        if effective_backend:
+            config.model.image_backend = effective_backend.lower()
+        yield
+    finally:
+        config.model.image_backend = original_backend
+
+
 def create_generator_with_overrides(
     backend_override: Optional[str] = None,
     mock: bool = False,
 ):
     """Create an image generator while temporarily overriding the configured backend."""
-    original_backend = app.state.config.model.image_backend
-    effective_backend = "mock" if mock else backend_override
-
-    try:
-        if effective_backend:
-            app.state.config.model.image_backend = effective_backend.lower()
+    with temporary_backend_override(app.state.config, backend_override, mock):
         return create_image_generator(app.state.config)
-    finally:
-        app.state.config.model.image_backend = original_backend
 
 
 def resolve_backend_with_overrides(
@@ -92,15 +104,8 @@ def resolve_backend_with_overrides(
     mock: bool = False,
 ) -> str:
     """Resolve the effective backend while honoring one-shot CLI overrides."""
-    original_backend = app.state.config.model.image_backend
-    effective_backend = "mock" if mock else backend_override
-
-    try:
-        if effective_backend:
-            app.state.config.model.image_backend = effective_backend.lower()
+    with temporary_backend_override(app.state.config, backend_override, mock):
         return resolve_image_backend(app.state.config)
-    finally:
-        app.state.config.model.image_backend = original_backend
 
 
 def _valid_hf_token() -> bool:
@@ -182,17 +187,15 @@ async def await_with_generation_status(
     *,
     backend_name: str,
     phase: str,
-    output_path: Path,
+    output_path: Path | None,
     heartbeat_seconds: int = HEARTBEAT_SECONDS,
 ) -> T:
     """Await generation work while a thread emits visible lifecycle status."""
     started_at = time.monotonic()
     stop_event = threading.Event()
 
-    console.print(
-        f"[cyan]{phase}:[/cyan] request submitted to {backend_name}; "
-        f"output target: {output_path}"
-    )
+    output_detail = f"; output target: {output_path}" if output_path else ""
+    console.print(f"[cyan]{phase}:[/cyan] request submitted to {backend_name}{output_detail}")
 
     def heartbeat() -> None:
         while not stop_event.wait(heartbeat_seconds):
@@ -209,6 +212,30 @@ async def await_with_generation_status(
     finally:
         stop_event.set()
         heartbeat_thread.join(timeout=1)
+
+
+def print_generation_service_event(event: GenerationProgressEvent) -> None:
+    """Render service lifecycle events that matter to CLI users."""
+    if event.name == "prompt_ready":
+        console.print(
+            Panel(
+                f"[bold]Using provided prompt:[/bold]\n\n{event.payload.get('prompt', '')}",
+                title="Custom Prompt",
+                border_style="blue",
+            )
+        )
+    elif event.name == "prompt_generated":
+        console.print(
+            Panel(
+                f"[bold]Generated prompt:[/bold]\n\n{event.payload.get('prompt', '')}",
+                title="AI Prompt",
+                border_style="green",
+            )
+        )
+    elif event.name == "output_path_ready":
+        output_path = event.payload.get("output_path")
+        if output_path:
+            console.print(f"[cyan]Saving output to:[/cyan] {output_path}")
 
 
 @plugins_app.command("list")
@@ -366,96 +393,85 @@ def generate(
                         raise typer.Exit(1)
 
                     # Initialize components
-                    init_task = progress.add_task("[cyan]Initializing components...", total=None)
-                    prompt_gen = PromptGenerator(app.state.config)
+                    init_task = progress.add_task(
+                        "[cyan]Initializing generation service...", total=None
+                    )
                     if mock:
                         console.print(
                             "[yellow]Using mock image generator (no GPU required)[/yellow]"
                         )
-                        image_gen, backend_name = create_generator_with_overrides(mock=True)
-                    else:
-                        image_gen, backend_name = create_generator_with_overrides(
-                            backend_override=backend
-                        )
-                    storage = StorageManager()
+                    service = ImageGenService(
+                        app.state.config, output_dir=app.state.config.system.output_dir
+                    )
                     metrics = MetricsCollector(app.state.config.system.log_dir / "metrics")
                     progress.remove_task(init_task)
 
                     console.print(
-                        f"[cyan]Using image backend:[/cyan] {backend_name} "
+                        f"[cyan]Using image backend:[/cyan] {resolved_backend} "
                         f"(resolved: {resolved_backend}, "
                         f"requested: {_requested_backend_name(app.state.config, backend, mock)})"
-                    )
-                    console.print(
-                        f"[cyan]Model/provider:[/cyan] {_format_model_detail(image_gen)}; "
-                        f"device: {_format_device_detail(image_gen)}"
                     )
 
                     # Start metrics collection
                     metrics.start_batch()
 
-                    # Use provided prompt or generate one
-                    if prompt:
-                        generated_prompt = prompt
-                        console.print(
-                            Panel(
-                                f"[bold]Using provided prompt:[/bold]\n\n{generated_prompt}",
-                                title="Custom Prompt",
-                                border_style="blue",
-                            )
-                        )
-                    else:
+                    generation_prompt = prompt
+                    if not prompt and interactive:
+                        prompt_gen = PromptGenerator(app.state.config)
                         prompt_task = progress.add_task(
                             "[cyan]Generating creative prompt...", total=None
                         )
-                        if interactive:
-                            generated_prompt = await prompt_gen.get_prompt_with_feedback()
-                        else:
-                            generated_prompt = await prompt_gen.generate_prompt()
-                        progress.remove_task(prompt_task)
-                        console.print(
-                            Panel(
-                                f"[bold]Generated prompt:[/bold]\n\n{generated_prompt}",
-                                title="AI Prompt",
-                                border_style="green",
-                            )
-                        )
-
-                    # Get output path
-                    output_path = storage.get_output_path(generated_prompt)
-                    console.print(f"[cyan]Saving output to:[/cyan] {output_path}")
+                        try:
+                            generation_prompt = await prompt_gen.get_prompt_with_feedback()
+                        finally:
+                            progress.remove_task(prompt_task)
+                            prompt_gen.cleanup()
 
                     # Generate image
                     image_task = progress.add_task("[cyan]Generating image...", total=None)
                     try:
-                        output_path, gen_time, model_name = await await_with_generation_status(
-                            image_gen.generate_image(generated_prompt, output_path),
-                            backend_name=backend_name,
-                            phase="Image generation",
-                            output_path=output_path,
-                        )
+                        with temporary_backend_override(app.state.config, backend, mock):
+                            result = await await_with_generation_status(
+                                service.generate(
+                                    GenerationServiceRequest(
+                                        prompt=generation_prompt,
+                                        cleanup=True,
+                                    ),
+                                    callback=print_generation_service_event,
+                                ),
+                                backend_name=resolved_backend,
+                                phase="Image generation",
+                                output_path=None,
+                            )
                     except Exception as e:
                         console.print(
                             f"[red]Generation failed[/red]\n"
-                            f"Backend: {backend_name}\n"
-                            f"Phase: image generation\n"
+                            f"Backend: {resolved_backend}\n"
+                            "Phase: image generation\n"
                             f"Error: {str(e)}"
                         )
                         raise typer.Exit(1) from e
                     finally:
                         progress.remove_task(image_task)
 
-                    console.print(f"[green]Image received and saved[/green] ({gen_time:.1f}s)")
+                    console.print(
+                        f"[cyan]Model/provider:[/cyan] {result.model_name}; "
+                        f"backend: {result.backend}"
+                    )
+                    console.print(
+                        f"[green]Image received and saved[/green] ({result.generation_time:.1f}s)"
+                    )
 
                     # Show success message with details
                     console.print(
                         Panel(
                             f"[bold green]Image generated successfully![/bold green]\n\n"
-                            f"📁 Saved to: {output_path}\n"
-                            f"📝 Prompt saved to: {output_path.with_suffix('.txt')}\n\n"
-                            f"[dim]Model: {model_name}\n"
-                            f"Time: {gen_time:.1f}s\n"
-                            f"Prompt: {generated_prompt}[/dim]",
+                            f"Saved to: {result.image_path}\n"
+                            f"Prompt saved to: {result.image_path.with_suffix('.txt')}\n\n"
+                            f"[dim]Model: {result.model_name}\n"
+                            f"Backend: {result.backend}\n"
+                            f"Time: {result.generation_time:.1f}s\n"
+                            f"Prompt: {result.prompt}[/dim]",
                             title="Success",
                             border_style="green",
                         )
@@ -463,10 +479,6 @@ def generate(
 
                     # End metrics collection
                     metrics.end_batch()
-
-                    # Cleanup
-                    prompt_gen.cleanup()
-                    image_gen.cleanup()
 
                 except typer.Exit:
                     raise
@@ -673,7 +685,9 @@ def loop(
                         image_gen, backend_name = create_generator_with_overrides(
                             backend_override=backend
                         )
-                    storage = StorageManager()
+                    service = ImageGenService(
+                        app.state.config, output_dir=app.state.config.system.output_dir
+                    )
                     metrics = MetricsCollector(app.state.config.system.log_dir / "metrics")
                     progress.remove_task(init_task)
 
@@ -708,24 +722,37 @@ def loop(
                                 )
                             )
 
-                            # Get output path and generate
-                            output_path = storage.get_output_path(prompt)
-                            console.print(
-                                f"[cyan]Image {i+1}/{batch_size} output target:[/cyan] {output_path}"
-                            )
+                            def print_loop_event(event: GenerationProgressEvent) -> None:
+                                if event.name == "output_path_ready":
+                                    output_path = event.payload.get("output_path")
+                                    if output_path:
+                                        console.print(
+                                            f"[cyan]Image {i+1}/{batch_size} output target:[/cyan] "
+                                            f"{output_path}"
+                                        )
+
                             force_reinit = i > 0 and i % 5 == 0  # Reinit every 5 images
-                            output_path, gen_time, model_name = await await_with_generation_status(
-                                image_gen.generate_image(
-                                    prompt, output_path, force_reinit=force_reinit
-                                ),
-                                backend_name=backend_name,
-                                phase=f"Image {i+1}/{batch_size} generation",
-                                output_path=output_path,
-                            )
+                            with temporary_backend_override(app.state.config, backend, mock):
+                                result = await await_with_generation_status(
+                                    service.generate(
+                                        GenerationServiceRequest(
+                                            prompt=prompt,
+                                            force_reinit=force_reinit,
+                                        ),
+                                        callback=print_loop_event,
+                                        backend=image_gen,
+                                        backend_name=backend_name,
+                                    ),
+                                    backend_name=backend_name,
+                                    phase=f"Image {i+1}/{batch_size} generation",
+                                    output_path=None,
+                                )
+                            model_name = result.model_name
 
                             console.print(
-                                f"[green]✓[/green] Image {i+1} generated in {gen_time:.1f}s using {model_name}\n"
-                                f"   📁 {output_path}"
+                                f"[green]✓[/green] Image {i+1} generated in "
+                                f"{result.generation_time:.1f}s using {result.model_name}\n"
+                                f"   {result.image_path}"
                             )
 
                             progress.update(batch_task, advance=1)

--- a/tests/test_cli_generation_progress.py
+++ b/tests/test_cli_generation_progress.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 
 from src.utils import cli
 from src.utils.cli import app
+from src.utils.publication_catalog import load_catalog
 
 runner = CliRunner()
 
@@ -27,6 +28,9 @@ def test_generate_mock_prints_lifecycle_status(tmp_path, monkeypatch):
     assert "request submitted" in result.stdout
     assert "Image received and saved" in result.stdout
     assert "Saved to:" in result.stdout
+
+    catalog = load_catalog(tmp_path)
+    assert len(catalog["assets"]) == 1
 
 
 def test_generate_accepts_model_alias_for_backend(tmp_path, monkeypatch):

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from PIL import Image
 
 from src.services import GenerationServiceRequest, ImageGenService
 from src.utils.publication_catalog import load_catalog
@@ -22,6 +23,31 @@ def mock_service_config(tmp_path):
     config.system.output_dir = tmp_path
     config.system.cpu_only = True
     return config
+
+
+class ReusableBackend:
+    """Small backend double that proves the service can use caller-owned backends."""
+
+    def __init__(self):
+        self.calls = 0
+        self.cleaned = False
+        self.last_generation_metadata = {"seed_supported": True, "backend_double": True}
+
+    async def generate_image(
+        self,
+        prompt: str,
+        output_path: Path,
+        force_reinit: bool = False,
+        seed: int | None = None,
+    ) -> tuple[Path, float, str]:
+        self.calls += 1
+        self.last_generation_metadata["force_reinit"] = force_reinit
+        self.last_generation_metadata["seed"] = seed
+        Image.new("RGB", (8, 8), color=(20, 40, 60)).save(output_path)
+        return output_path, 0.25, "reusable-test-backend"
+
+    def cleanup(self) -> None:
+        self.cleaned = True
 
 
 @pytest.mark.asyncio
@@ -71,7 +97,33 @@ async def test_service_emits_generation_lifecycle_events(mock_service_config, tm
         "prompt_ready",
         "backend_ready",
         "model_loading",
+        "output_path_ready",
         "finalizing_output",
         "generation_completed",
     ]
+    assert events[4].payload["output_path"].suffix == ".png"
     assert events[-1].payload["image_path"].startswith("/images/")
+
+
+@pytest.mark.asyncio
+async def test_service_can_reuse_caller_owned_backend(mock_service_config, tmp_path):
+    service = ImageGenService(mock_service_config, output_dir=tmp_path)
+    backend = ReusableBackend()
+
+    result = await service.generate(
+        GenerationServiceRequest(
+            prompt="reused backend test",
+            seed=99,
+            force_reinit=True,
+        ),
+        backend=backend,
+        backend_name="reusable",
+    )
+
+    assert backend.calls == 1
+    assert backend.cleaned is False
+    assert result.backend == "reusable"
+    assert result.model_name == "reusable-test-backend"
+    assert result.metadata["backend_double"] is True
+    assert result.metadata["force_reinit"] is True
+    assert result.metadata["seed"] == 99


### PR DESCRIPTION
﻿## Summary
- route single-image CLI generation through ImageGenService so CLI and API share artifact persistence, metadata, catalog registration, and lifecycle events
- add reusable-backend support to ImageGenService so batch loop can keep one loaded model while still using the service boundary
- emit service output-path events for cleaner CLI status and add regression coverage for CLI catalog registration and reusable backends

## Validation
- UV_PROJECT_ENVIRONMENT=.venv-test uv run pytest tests/
- UV_PROJECT_ENVIRONMENT=.venv-test uv run mypy
- UV_PROJECT_ENVIRONMENT=.venv-test uv run black --check src tests
- UV_PROJECT_ENVIRONMENT=.venv-test uv run isort --check src tests
- UV_PROJECT_ENVIRONMENT=.venv-test uv run pylint src/ --errors-only --disable=import-error
- git diff --check
- uv run dreamgen generate --mock --prompt "polished service cli smoke" with temporary required env vars

Refs #38
