### PR TITLE
[codex] Polish operator surfaces

### DIFF
--- a/host-image/src/index.ts
+++ b/host-image/src/index.ts
@@ -2,6 +2,19 @@ export interface Env {
 	DREAM_BUCKET: R2Bucket;
 }
 
+const IMAGE_CACHE_SECONDS = 300;
+
+function jsonResponse(payload: unknown, init: ResponseInit = {}) {
+	const headers = new Headers(init.headers);
+	headers.set('Content-Type', 'application/json');
+	headers.set('Access-Control-Allow-Origin', '*');
+
+	return new Response(JSON.stringify(payload, null, 2), {
+		...init,
+		headers,
+	});
+}
+
 export default {
 	async fetch(request: Request, env: Env) {
 		// Only allow GET requests
@@ -10,10 +23,22 @@ export default {
 		}
 
 		try {
+			const url = new URL(request.url);
+
+			if (url.pathname === '/health') {
+				return jsonResponse({
+					status: 'ok',
+					service: 'host-image',
+					cache_seconds: IMAGE_CACHE_SECONDS,
+				});
+			}
+
 			// List all images and get the most recent one
 			const list = await env.DREAM_BUCKET.list();
-
 			if (!list.objects || list.objects.length === 0) {
+				if (url.pathname === '/metadata') {
+					return jsonResponse({ error: 'No PNG images found', image_count: 0 }, { status: 404 });
+				}
 				return new Response('No images found', { status: 404 });
 			}
 
@@ -21,13 +46,24 @@ export default {
 			const images = list.objects
 				.filter((obj) => obj.key.endsWith('.png'))
 				.sort((a, b) => new Date(b.uploaded).getTime() - new Date(a.uploaded).getTime());
-
 			if (images.length === 0) {
+				if (url.pathname === '/metadata') {
+					return jsonResponse({ error: 'No PNG images found', image_count: 0 }, { status: 404 });
+				}
 				return new Response('No PNG images found', { status: 404 });
 			}
 
 			// Get the most recent image
 			const latestImage = images[0];
+			if (url.pathname === '/metadata') {
+				return jsonResponse({
+					latest_key: latestImage.key,
+					latest_uploaded: latestImage.uploaded,
+					image_count: images.length,
+					cache_seconds: IMAGE_CACHE_SECONDS,
+				});
+			}
+
 			const object = await env.DREAM_BUCKET.get(latestImage.key);
 
 			if (!object) {
@@ -37,7 +73,7 @@ export default {
 			// Set up headers
 			const headers = new Headers();
 			headers.set('Content-Type', 'image/png');
-			headers.set('Cache-Control', 'public, max-age=300'); // Cache for 5 minutes to show updates faster
+			headers.set('Cache-Control', `public, max-age=${IMAGE_CACHE_SECONDS}`); // Cache briefly to show updates faster
 			headers.set('Access-Control-Allow-Origin', '*'); // Allow CORS
 			headers.set('X-Image-Name', latestImage.key); // Show which image is being served
 

--- a/host-image/test/index.spec.ts
+++ b/host-image/test/index.spec.ts
@@ -46,6 +46,49 @@ describe('host-image worker', () => {
 		expect(await response.text()).toBe('No images found');
 	});
 
+	it('returns health metadata without reading the bucket', async () => {
+		const response = await worker.fetch(new Request('https://example.com/health'), createEnv([]));
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Content-Type')).toBe('application/json');
+		await expect(response.json()).resolves.toMatchObject({
+			status: 'ok',
+			service: 'host-image',
+			cache_seconds: 300,
+		});
+	});
+
+	it('returns latest image metadata without streaming the image', async () => {
+		const response = await worker.fetch(
+			new Request('https://example.com/metadata'),
+			createEnv([
+				{ key: 'older.png', uploaded: new Date('2026-04-01T00:00:00Z'), body: 'older' },
+				{ key: 'newer.png', uploaded: new Date('2026-04-02T00:00:00Z'), body: 'newer' },
+				{ key: 'newer.txt', uploaded: new Date('2026-04-03T00:00:00Z'), body: 'prompt' },
+			]),
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			latest_key: 'newer.png',
+			image_count: 2,
+			cache_seconds: 300,
+		});
+	});
+
+	it('returns JSON 404 metadata when no PNGs are available', async () => {
+		const response = await worker.fetch(
+			new Request('https://example.com/metadata'),
+			createEnv([{ key: 'prompt.txt', uploaded: new Date('2026-04-03T00:00:00Z') }]),
+		);
+
+		expect(response.status).toBe(404);
+		await expect(response.json()).resolves.toMatchObject({
+			error: 'No PNG images found',
+			image_count: 0,
+		});
+	});
+
 	it('serves the most recently uploaded PNG image', async () => {
 		const response = await worker.fetch(
 			new Request('https://example.com'),

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import uuid
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -48,6 +49,7 @@ logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 ALLOWED_IMAGE_BACKENDS = {"auto", "flux", "ollama", "zimage", "small", "turbo", "smoke", "mock"}
+MAX_RECENT_GENERATION_EVENTS = 100
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -378,6 +380,17 @@ class ConnectionManager:
 
 
 manager = ConnectionManager()
+recent_generation_events: deque[Dict[str, Any]] = deque(maxlen=MAX_RECENT_GENERATION_EVENTS)
+
+
+def record_generation_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Record a lightweight lifecycle event for recent operator diagnostics."""
+    payload = {
+        "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        **event,
+    }
+    recent_generation_events.appendleft(payload)
+    return payload
 
 
 async def broadcast_task_progress(
@@ -390,19 +403,18 @@ async def broadcast_task_progress(
     detail: str,
 ) -> None:
     """Broadcast a normalized task progress event for frontend progress UIs."""
-    await manager.broadcast(
-        json.dumps(
-            {
-                "type": "task_progress",
-                "task": task,
-                "id": task_id,
-                "client_request_id": client_request_id,
-                "progress": progress,
-                "label": label,
-                "detail": detail,
-            }
-        )
+    payload = record_generation_event(
+        {
+            "type": "task_progress",
+            "task": task,
+            "id": task_id,
+            "client_request_id": client_request_id,
+            "progress": progress,
+            "label": label,
+            "detail": detail,
+        }
     )
+    await manager.broadcast(json.dumps(payload))
 
 
 async def prefetch_default_fallback_model() -> None:
@@ -965,6 +977,18 @@ async def generate_image(request: GenerateRequest):
     generation_id = str(uuid.uuid4())
 
     async def emit_generation_event(event: GenerationProgressEvent) -> None:
+        record_generation_event(
+            {
+                "type": "generation_lifecycle",
+                "name": event.name,
+                "id": generation_id,
+                "client_request_id": request.client_request_id,
+                "progress": event.progress,
+                "label": event.label,
+                "detail": event.detail,
+                "payload": event.payload,
+            }
+        )
         if event.progress is not None:
             await broadcast_task_progress(
                 task="image_generation",
@@ -1013,12 +1037,13 @@ async def generate_image(request: GenerateRequest):
     try:
         await manager.broadcast(
             json.dumps(
-                {
-                    "type": "generation_started",
-                    "id": generation_id,
-                    "client_request_id": request.client_request_id,
-                    "timestamp": datetime.now().isoformat(),
-                }
+                record_generation_event(
+                    {
+                        "type": "generation_started",
+                        "id": generation_id,
+                        "client_request_id": request.client_request_id,
+                    }
+                )
             )
         )
         service = ImageGenService(config, output_dir=OUTPUT_DIR)
@@ -1040,12 +1065,14 @@ async def generate_image(request: GenerateRequest):
         logger.error(f"Memory error loading image backend: {str(e)}")
         await manager.broadcast(
             json.dumps(
-                {
-                    "type": "generation_error",
-                    "id": generation_id,
-                    "client_request_id": request.client_request_id,
-                    "error": error_msg,
-                }
+                record_generation_event(
+                    {
+                        "type": "generation_error",
+                        "id": generation_id,
+                        "client_request_id": request.client_request_id,
+                        "error": error_msg,
+                    }
+                )
             )
         )
         raise HTTPException(status_code=507, detail=error_msg)
@@ -1055,16 +1082,25 @@ async def generate_image(request: GenerateRequest):
         # Broadcast error event
         await manager.broadcast(
             json.dumps(
-                {
-                    "type": "generation_error",
-                    "id": generation_id,
-                    "client_request_id": request.client_request_id,
-                    "error": str(e),
-                }
+                record_generation_event(
+                    {
+                        "type": "generation_error",
+                        "id": generation_id,
+                        "client_request_id": request.client_request_id,
+                        "error": str(e),
+                    }
+                )
             )
         )
 
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/api/generation/events")
+async def get_generation_events(limit: int = Query(25, ge=1, le=100)):
+    """Return recent generation lifecycle events for operator dashboards."""
+    events = list(recent_generation_events)[:limit]
+    return {"events": events, "total": len(recent_generation_events), "limit": limit}
 
 
 @app.get("/api/gallery")

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -3,6 +3,7 @@ Command-line interface for the continuous image generation system.
 """
 
 import asyncio
+import json
 import os
 import sys
 import threading
@@ -365,6 +366,11 @@ def generate(
         "--mps-use-fp16",
         help="Use float16 precision on Apple Silicon (may improve performance)",
     ),
+    summary_json: bool = typer.Option(
+        False,
+        "--summary-json",
+        help="Print a machine-readable generation summary after success",
+    ),
 ) -> None:
     """Generate a single image using AI-generated prompts or a custom prompt."""
 
@@ -476,6 +482,23 @@ def generate(
                             border_style="green",
                         )
                     )
+                    if summary_json:
+                        print(
+                            json.dumps(
+                                {
+                                    "image_path": str(result.image_path),
+                                    "prompt_path": str(result.image_path.with_suffix(".txt")),
+                                    "relative_image_path": result.relative_image_path,
+                                    "prompt": result.prompt,
+                                    "backend": result.backend,
+                                    "model": result.model_name,
+                                    "generation_time": result.generation_time,
+                                    "metadata": result.metadata,
+                                    "created_at": result.created_at,
+                                },
+                                sort_keys=True,
+                            )
+                        )
 
                     # End metrics collection
                     metrics.end_batch()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -161,6 +161,29 @@ def test_generate_with_seed(client):
     assert data["metadata"].get("seed") == 42
 
 
+def test_generation_events_endpoint_records_recent_lifecycle(client):
+    """Generation lifecycle events should be inspectable after the request completes."""
+    payload = {"prompt": "observable test image", "client_request_id": "req-events-123"}
+
+    response = client.post("/api/generate", json=payload)
+    assert response.status_code == 200
+    generation_id = response.json()["id"]
+
+    events_response = client.get("/api/generation/events?limit=20")
+    assert events_response.status_code == 200
+    data = events_response.json()
+    assert data["limit"] == 20
+    assert data["total"] >= 1
+
+    matching = [event for event in data["events"] if event.get("id") == generation_id]
+    assert matching
+    assert any(event["type"] == "generation_started" for event in matching)
+    assert any(
+        event["type"] == "task_progress" and event["label"] == "Image ready" for event in matching
+    )
+    assert all("timestamp" in event for event in matching)
+
+
 def test_generation_config_endpoint(client):
     """The generation config endpoint should expose backend and LoRA settings."""
     response = client.get("/api/config/generation")

--- a/tests/test_cli_generation_progress.py
+++ b/tests/test_cli_generation_progress.py
@@ -1,6 +1,7 @@
 """Tests for CLI generation progress and diagnostics."""
 
 import asyncio
+import json
 from io import StringIO
 from pathlib import Path
 
@@ -45,6 +46,27 @@ def test_generate_accepts_model_alias_for_backend(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.stdout
     assert "requested: mock" in result.stdout
     assert "resolved: mock" in result.stdout
+
+
+def test_generate_summary_json_prints_machine_readable_result(tmp_path, monkeypatch):
+    """Automation can consume a stable summary after human-readable output."""
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+
+    result = runner.invoke(
+        app,
+        ["generate", "--mock", "--prompt", "json summary prompt", "--summary-json"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    summary_line = next(
+        line for line in reversed(result.stdout.splitlines()) if line.startswith("{")
+    )
+    summary = json.loads(summary_line)
+    assert summary["backend"] == "mock"
+    assert summary["prompt"] == "json summary prompt"
+    assert summary["image_path"].endswith(".png")
+    assert summary["prompt_path"].endswith(".txt")
+    assert summary["relative_image_path"].startswith("/images/")
 
 
 @pytest.mark.asyncio

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -8,6 +8,7 @@ import {
   Image as ImageIcon,
   Loader2,
   Play,
+  RotateCcw,
   Settings as SettingsIcon,
   Sparkles,
   Square,
@@ -21,6 +22,7 @@ import TaskProgress from "@/components/TaskProgress";
 import {
   API_BASE,
   api,
+  GenerationEvent,
   GenerateResponse,
   GenerationConfig,
   PluginInfo,
@@ -111,6 +113,15 @@ const formatCountdown = (target: Date | null) => {
 const truncatePrompt = (prompt: string, max = 88) =>
   prompt.length > max ? `${prompt.slice(0, max).trim()}...` : prompt;
 
+const describeGenerationEvent = (event: GenerationEvent) => {
+  if (event.type === "generation_error") return `Error: ${event.error ?? "unknown"}`;
+  if (event.type === "generation_started") return "Generation started";
+  if (event.type === "generation_completed") return "Generation completed";
+  if (event.label) return event.label;
+  if (event.name) return event.name.replaceAll("_", " ");
+  return event.type.replaceAll("_", " ");
+};
+
 export default function Home() {
   const [activeTab, setActiveTab] = useState<TabId>("generate");
   const [promptSeed, setPromptSeed] = useState("");
@@ -123,6 +134,7 @@ export default function Home() {
   const [status, setStatus] = useState<SystemStatus | null>(null);
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
   const [generationConfig, setGenerationConfig] = useState<GenerationConfig | null>(null);
+  const [generationEvents, setGenerationEvents] = useState<GenerationEvent[]>([]);
   const [nextRunAt, setNextRunAt] = useState<Date | null>(null);
   const [, setClockTick] = useState(Date.now());
   const [sessionCount, setSessionCount] = useState(0);
@@ -205,6 +217,17 @@ export default function Home() {
     }
   }, []);
 
+  const loadGenerationEvents = useCallback(async () => {
+    try {
+      const response = await api.getGenerationEvents(8);
+      startTransition(() => {
+        setGenerationEvents(response.events);
+      });
+    } catch (error) {
+      console.error("Failed to load generation events:", error);
+    }
+  }, []);
+
   runGenerationRef.current = async (source: "manual" | "loop") => {
     if (isGeneratingRef.current) return;
 
@@ -251,7 +274,12 @@ export default function Home() {
         setGenerationProgress(null);
       }, 1200);
       await galleryCache.clear();
-      await Promise.all([loadRecentImages(), loadDashboardControls(), api.getStatus().then(setStatus)]);
+      await Promise.all([
+        loadRecentImages(),
+        loadDashboardControls(),
+        loadGenerationEvents(),
+        api.getStatus().then(setStatus),
+      ]);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : "Unknown error";
       addLog(`Generation failed: ${errorMsg}`, "error");
@@ -298,6 +326,7 @@ export default function Home() {
     api.getStatus().then(setStatus).catch(console.error);
     loadRecentImages();
     loadDashboardControls();
+    loadGenerationEvents();
 
     const unsubscribe = api.subscribeWebSocket((data) => {
       const nextProgress = getTaskProgressUpdate(
@@ -318,8 +347,10 @@ export default function Home() {
         addLog(String(msg.message ?? "Loading model..."));
       } else if (msg.type === "generation_completed") {
         addLog(`Saved ${String(msg.image_path ?? "image")}.`);
+        void loadGenerationEvents();
       } else if (msg.type === "generation_error") {
         addLog(`Backend error: ${String(msg.error ?? "unknown")}`, "error");
+        void loadGenerationEvents();
       }
     });
 
@@ -329,7 +360,7 @@ export default function Home() {
         clearTimeout(generationResetTimeoutRef.current);
       }
     };
-  }, [loadDashboardControls, loadRecentImages]);
+  }, [loadDashboardControls, loadGenerationEvents, loadRecentImages]);
 
   useEffect(() => {
     if (!isGenerating || !generationProgress || generationProgress.progress >= 96) return;
@@ -799,6 +830,33 @@ export default function Home() {
                           </div>
                           <div className="mt-2 text-sm leading-6 text-foreground">{lastActivity}</div>
                         </div>
+
+                        <div className="rounded-2xl border border-border/60 bg-background/78 px-4 py-3">
+                          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                            Lifecycle
+                          </div>
+                          {generationEvents.length > 0 ? (
+                            <div className="mt-3 space-y-2">
+                              {generationEvents.slice(0, 4).map((event, index) => (
+                                <div
+                                  key={`${event.timestamp}-${event.id ?? index}-${event.type}`}
+                                  className="flex items-start justify-between gap-3 text-xs"
+                                >
+                                  <span className="min-w-0 capitalize text-foreground">
+                                    {describeGenerationEvent(event)}
+                                  </span>
+                                  <span className="shrink-0 text-muted-foreground">
+                                    {new Date(event.timestamp).toLocaleTimeString()}
+                                  </span>
+                                </div>
+                              ))}
+                            </div>
+                          ) : (
+                            <div className="mt-2 text-sm leading-6 text-muted-foreground">
+                              No recorded lifecycle events yet.
+                            </div>
+                          )}
+                        </div>
                       </div>
 
                     </div>
@@ -818,38 +876,63 @@ export default function Home() {
                       {recentImages.length > 0 ? (
                         <div className="space-y-3">
                           {recentImages.slice(0, 3).map((image) => (
-                            <button
+                            <div
                               key={image.path}
-                              onClick={() => {
-                                setCurrentImage({
-                                  id: image.path,
-                                  prompt: image.prompt,
-                                  image_path: image.path,
-                                  metadata: {
-                                    backend: status?.backend ?? "unknown",
-                                    plugins_used: status?.active_plugins ?? [],
-                                  },
-                                  created_at: image.created_at,
-                                });
-                              }}
-                              className="flex w-full items-center gap-3 rounded-2xl border border-border/60 bg-background/78 p-3 text-left transition hover:border-primary/35 hover:bg-background/90"
+                              className="rounded-2xl border border-border/60 bg-background/78 p-3 transition hover:border-primary/35 hover:bg-background/90"
                             >
-                              {/* Backend-served generated files are not routed through Next image optimization. */}
-                              {/* eslint-disable-next-line @next/next/no-img-element */}
-                              <img
-                                src={`${API_BASE}${image.path}`}
-                                alt="Recent generation"
-                                className="h-16 w-16 rounded-xl object-cover"
-                              />
-                              <div className="min-w-0">
-                                <p className="text-xs text-muted-foreground">
-                                  {new Date(image.created_at).toLocaleString()}
-                                </p>
-                                <p className="mt-1 text-sm leading-6 text-foreground">
-                                  {truncatePrompt(image.prompt, 58)}
-                                </p>
+                              <button
+                                onClick={() => {
+                                  setCurrentImage({
+                                    id: image.path,
+                                    prompt: image.prompt,
+                                    image_path: image.path,
+                                    metadata: {
+                                      backend: status?.backend ?? "unknown",
+                                      plugins_used: status?.active_plugins ?? [],
+                                    },
+                                    created_at: image.created_at,
+                                  });
+                                }}
+                                className="flex w-full items-center gap-3 text-left"
+                              >
+                                {/* Backend-served generated files are not routed through Next image optimization. */}
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                  src={`${API_BASE}${image.path}`}
+                                  alt="Recent generation"
+                                  className="h-16 w-16 rounded-xl object-cover"
+                                />
+                                <div className="min-w-0">
+                                  <p className="text-xs text-muted-foreground">
+                                    {new Date(image.created_at).toLocaleString()}
+                                  </p>
+                                  <p className="mt-1 text-sm leading-6 text-foreground">
+                                    {truncatePrompt(image.prompt, 58)}
+                                  </p>
+                                </div>
+                              </button>
+                              <div className="mt-3 flex gap-2">
+                                <button
+                                  onClick={() => setPromptSeed(image.prompt)}
+                                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl border border-border/70 px-3 py-2 text-xs text-muted-foreground transition hover:border-primary/40 hover:text-foreground"
+                                >
+                                  <Play className="h-3.5 w-3.5" />
+                                  Use prompt
+                                </button>
+                                <button
+                                  onClick={() => {
+                                    setPromptSeed(image.prompt);
+                                    promptSeedRef.current = image.prompt;
+                                    void runGenerationRef.current("manual");
+                                  }}
+                                  disabled={isGenerating}
+                                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl bg-primary px-3 py-2 text-xs text-primary-foreground transition hover:opacity-95 disabled:opacity-60"
+                                >
+                                  <RotateCcw className="h-3.5 w-3.5" />
+                                  Rerun
+                                </button>
                               </div>
-                            </button>
+                            </div>
                           ))}
                         </div>
                       ) : (

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -136,6 +136,26 @@ export interface GenerationConfig {
   zimage_native_available?: boolean;
 }
 
+export interface GenerationEvent {
+  timestamp: string;
+  type: string;
+  id?: string;
+  task?: string;
+  client_request_id?: string | null;
+  progress?: number | null;
+  label?: string | null;
+  detail?: string | null;
+  error?: string;
+  name?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface GenerationEventsResponse {
+  events: GenerationEvent[];
+  total: number;
+  limit: number;
+}
+
 const extractErrorMessage = async (response: Response, fallback: string) => {
   try {
     const data = await response.json();
@@ -204,6 +224,12 @@ export class ImageGenAPI {
       body: JSON.stringify(request),
     });
     if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to generate image'));
+    return response.json();
+  }
+
+  async getGenerationEvents(limit: number = 25): Promise<GenerationEventsResponse> {
+    const response = await fetch(`${this.baseUrl}/api/generation/events?limit=${limit}`);
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get generation events'));
     return response.json();
   }
 


### PR DESCRIPTION
﻿## Summary
- API/service: add a recent generation lifecycle event buffer plus `GET /api/generation/events` for operator diagnostics (#45)
- Web UI: add lifecycle visibility plus recent-output `Use prompt` and `Rerun` controls on the Create surface (#41)
- CLI: add `dreamgen generate --summary-json` for automation-friendly generation summaries (#50)
- Edge worker: add host-image `GET /health` and `GET /metadata` endpoints for deployment and dashboard checks (#49)

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-test uv run pytest tests/`
- `UV_PROJECT_ENVIRONMENT=.venv-test uv run mypy`
- `UV_PROJECT_ENVIRONMENT=.venv-test uv run black --check src tests`
- `UV_PROJECT_ENVIRONMENT=.venv-test uv run isort --check src tests`
- `UV_PROJECT_ENVIRONMENT=.venv-test uv run pylint src/ --errors-only --disable=import-error`
- `npm run lint` in `web-ui/`
- `npm run build` in `web-ui/`
- `npm test -- --run` in `host-image/`
- `npx wrangler deploy --dry-run` in `host-image/`
- `git diff --check`
- local smoke: backend `http://127.0.0.1:25800`, web UI `http://127.0.0.1:7860`, `POST /api/generate`, `GET /api/generation/events`, and `dreamgen generate --mock --summary-json`

Refs #41
Refs #45
Closes #49
Closes #50
