### PR TITLE
Add gallery sync status and featured controls

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -26,6 +26,7 @@ from src.plugins import plugin_manager, register_lora_plugin
 from src.plugins.lora import get_available_loras
 from src.services import GenerationProgressEvent, GenerationServiceRequest, ImageGenService
 from src.utils.config import Config
+from src.utils.gallery_publisher import DEFAULT_BUCKET, build_publish_status
 from src.utils.ollama import (
     get_ollama_version,
     list_ollama_models,
@@ -1138,12 +1139,42 @@ async def get_gallery_catalog(
         normalized_state = publication_state.strip().lower()
         entries = [entry for entry in entries if entry.get("publication_state") == normalized_state]
 
+    page_entries = []
+    for entry in entries[offset : offset + limit]:
+        payload = dict(entry)
+        image_file = OUTPUT_DIR / str(entry.get("path", ""))
+        if image_file.exists():
+            payload["size"] = image_file.stat().st_size
+            payload["image_url"] = f"/images/{image_file.relative_to(OUTPUT_DIR).as_posix()}"
+        page_entries.append(payload)
+
     return {
-        "assets": entries[offset : offset + limit],
+        "assets": page_entries,
         "total": len(entries),
         "limit": limit,
         "offset": offset,
     }
+
+
+@app.get("/api/gallery/sync/status")
+async def get_gallery_sync_status(
+    bucket: str = DEFAULT_BUCKET,
+    since: Optional[str] = None,
+    limit: Optional[int] = Query(None, ge=1, le=500),
+    include_featured: bool = True,
+):
+    """Return the local catalog-driven R2 publish plan status."""
+    try:
+        return await asyncio.to_thread(
+            build_publish_status,
+            OUTPUT_DIR,
+            bucket=bucket,
+            since=since,
+            limit=limit,
+            include_featured=include_featured,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @app.post("/api/gallery/catalog/backfill")

--- a/src/utils/gallery_publisher.py
+++ b/src/utils/gallery_publisher.py
@@ -194,6 +194,89 @@ def build_publish_plan(
     return PublishPlan(assets=assets, skipped=skipped, image_count=included_images, delete_count=0)
 
 
+def build_publish_status(
+    output_dir: Path,
+    *,
+    bucket: str = DEFAULT_BUCKET,
+    since: str | None = None,
+    limit: int | None = None,
+    include_featured: bool = True,
+    prune: bool = False,
+    preview_limit: int = 10,
+) -> dict[str, object]:
+    """Return a non-mutating local status snapshot for the R2 publish workflow."""
+    approved_states = sorted(_approved_states(include_featured))
+    command = "uv run dreamgen publish --execute"
+    if bucket != DEFAULT_BUCKET:
+        command += f" --bucket {bucket}"
+    if since:
+        command += f" --since {since}"
+    if limit is not None:
+        command += f" --limit {limit}"
+    if not include_featured:
+        command += " --no-include-featured"
+    if prune:
+        command += " --prune"
+
+    status: dict[str, object] = {
+        "bucket": bucket,
+        "approved_states": approved_states,
+        "catalog_present": catalog_path_for(output_dir).exists(),
+        "output_present": output_dir.exists(),
+        "ready": False,
+        "needs_publish": False,
+        "upload_images": 0,
+        "upload_files": 0,
+        "skipped_assets": 0,
+        "delete_objects": 0,
+        "preview_assets": [],
+        "skipped_preview": [],
+        "command": command,
+        "message": "",
+    }
+
+    if not output_dir.exists():
+        status["message"] = f"Output directory does not exist: {output_dir}"
+        return status
+    if not catalog_path_for(output_dir).exists():
+        status["message"] = (
+            "Publication catalog is missing. Backfill or generate through the backend first."
+        )
+        return status
+
+    plan = build_publish_plan(
+        output_dir,
+        parse_since(since),
+        limit,
+        include_featured=include_featured,
+        prune=prune,
+    )
+
+    status.update(
+        {
+            "ready": True,
+            "needs_publish": plan.file_count > 0 or (prune and plan.delete_count > 0),
+            "upload_images": plan.image_count,
+            "upload_files": plan.file_count,
+            "skipped_assets": len(plan.skipped),
+            "delete_objects": plan.delete_count if prune else 0,
+            "preview_assets": [
+                {"key": asset.key, "reason": asset.reason} for asset in plan.assets[:preview_limit]
+            ],
+            "skipped_preview": [
+                {"key": skipped.key, "reason": skipped.reason}
+                for skipped in plan.skipped[:preview_limit]
+            ],
+            "message": (
+                "Approved local assets are ready for R2 publishing."
+                if plan.file_count
+                else "No approved local assets are currently in the publish plan."
+            ),
+        }
+    )
+    return status
+
+
 def discover_assets(output_dir: Path, since: float | None, limit: int | None) -> list[PublishAsset]:
     """Compatibility wrapper used by tests and older callers."""
     return build_publish_plan(output_dir, since, limit).assets

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -443,6 +443,51 @@ def test_publication_state_controls_gallery_visibility(client):
     assert response.status_code == 200
     assert response.json()["publication_state"] == "published"
 
+    response = client.patch(
+        f"/api/gallery/publication/{relative_path}",
+        json={"state": "featured"},
+    )
+    assert response.status_code == 200
+    assert response.json()["publication_state"] == "featured"
+
+    response = client.get("/api/gallery?limit=100&offset=0")
+    assert response.status_code == 200
+    featured_item = next(
+        item for item in response.json()["images"] if item["path"].endswith("cafefeed.png")
+    )
+    assert featured_item["publication"]["state"] == "featured"
+
+
+def test_gallery_sync_status_reports_catalog_publish_plan(client):
+    """Operators should be able to see what the R2 publish step would upload."""
+    output_root = Path(_TEST_OUTPUT_DIR)
+    week_dir = output_root / "2099" / "week_05"
+    week_dir.mkdir(parents=True, exist_ok=True)
+
+    image_path = week_dir / "image_20990105_000001_syncfeed.png"
+    image = Image.new("RGB", (64, 64), color=(20, 60, 90))
+    draw = ImageDraw.Draw(image)
+    draw.ellipse((8, 8, 48, 48), fill=(220, 180, 60))
+    image.save(image_path)
+    image_path.with_suffix(".txt").write_text("sync me")
+    write_image_metadata(image_path, {"backend": "small-sd", "is_placeholder": False})
+
+    response = client.post("/api/gallery/catalog/backfill?default_state=published")
+    assert response.status_code == 200
+
+    response = client.get("/api/gallery/sync/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["bucket"] == "dreamgen-gallery"
+    assert data["catalog_present"] is True
+    assert data["ready"] is True
+    assert data["needs_publish"] is True
+    assert data["upload_images"] >= 1
+    assert data["upload_files"] >= 1
+    assert "published" in data["approved_states"]
+    assert "featured" in data["approved_states"]
+    assert any(asset["key"].endswith("syncfeed.png") for asset in data["preview_assets"])
+
 
 def test_placeholder_cannot_be_published_without_override(client):
     """Mock placeholders should stay unpublished unless the operator explicitly overrides."""

--- a/web-ui/components/Gallery.tsx
+++ b/web-ui/components/Gallery.tsx
@@ -4,18 +4,33 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Trash2, Download, X, Loader2, Clock, FileText,
-  Calendar, Grid, ChevronRight, Folder
+  Calendar, Grid, ChevronRight, Folder, Star, Eye, EyeOff, Archive,
+  UploadCloud
 } from "lucide-react";
-import { api, API_BASE } from "@/lib/api";
+import {
+  api,
+  API_BASE,
+  type GalleryCatalogEntry,
+  type GallerySyncStatus,
+  type PublicationState,
+} from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { motion, AnimatePresence } from "framer-motion";
 import galleryCache from "@/lib/cache";
 
 interface GalleryImage {
   path: string;
+  catalog_path: string;
   prompt: string;
   created_at: string;
   size: number;
+  metadata: Record<string, unknown>;
+  publication: {
+    id: string;
+    state: PublicationState;
+    publishable: boolean;
+    quality_flags: string[];
+  };
 }
 
 interface GalleryResponse {
@@ -34,11 +49,46 @@ interface WeekGroup {
 }
 
 type ViewMode = "week" | "all";
+type CatalogFilter = PublicationState | "all";
 
 const ALL_PAGE_SIZE = 20;
 const WEEK_PAGE_SIZE = 200;
 const CACHE_TIMEOUT_MS = 800;
 const GALLERY_TIMEOUT_MS = 30000;
+const PUBLICATION_OPTIONS: Array<{
+  state: PublicationState;
+  label: string;
+  icon: typeof Star;
+}> = [
+  { state: "featured", label: "Featured", icon: Star },
+  { state: "published", label: "Published", icon: Eye },
+  { state: "draft", label: "Draft", icon: FileText },
+  { state: "hidden", label: "Hidden", icon: EyeOff },
+  { state: "rejected", label: "Rejected", icon: Archive },
+];
+
+const stateStyles: Record<PublicationState, string> = {
+  featured: "bg-amber-500 text-black",
+  published: "bg-emerald-600 text-white",
+  draft: "bg-slate-500 text-white",
+  hidden: "bg-zinc-700 text-white",
+  rejected: "bg-rose-700 text-white",
+};
+
+const toGalleryImage = (entry: GalleryCatalogEntry): GalleryImage => ({
+  path: entry.image_url || `/images/${entry.path}`,
+  catalog_path: entry.path,
+  prompt: entry.prompt || "",
+  created_at: entry.created_at,
+  size: entry.size || 0,
+  metadata: entry.metadata || {},
+  publication: {
+    id: entry.id,
+    state: entry.publication_state,
+    publishable: entry.publishable,
+    quality_flags: entry.quality_flags || [],
+  },
+});
 
 const withTimeout = async <T,>(
   promise: Promise<T>,
@@ -78,8 +128,11 @@ export default function Gallery() {
   const [page, setPage] = useState(0);
   const [total, setTotal] = useState(0);
   const [deleting, setDeleting] = useState<string | null>(null);
+  const [publicationUpdating, setPublicationUpdating] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>("week");
+  const [catalogFilter, setCatalogFilter] = useState<CatalogFilter>("all");
+  const [syncStatus, setSyncStatus] = useState<GallerySyncStatus | null>(null);
   const loadRequestRef = useRef(0);
 
   const imagesPerPage = viewMode === "all" ? ALL_PAGE_SIZE : WEEK_PAGE_SIZE;
@@ -127,16 +180,25 @@ export default function Gallery() {
     loadRequestRef.current = requestId;
     const limit = viewMode === "all" ? ALL_PAGE_SIZE : WEEK_PAGE_SIZE;
     const offset = viewMode === "all" ? page * ALL_PAGE_SIZE : 0;
-    const cacheKey = `gallery_${viewMode}_${page}_${limit}`;
+    const cacheKey = `gallery_catalog_${viewMode}_${catalogFilter}_${page}_${limit}`;
 
     setLoading(true);
     setError(null);
 
     try {
-      console.log('Fetching gallery from API');
-      const response: GalleryResponse = await api.getGallery(limit, offset, GALLERY_TIMEOUT_MS);
+      console.log('Fetching gallery catalog from API');
+      const [catalogResponse, publishStatus] = await Promise.all([
+        api.getGalleryCatalog(limit, offset, catalogFilter, GALLERY_TIMEOUT_MS),
+        api.getGallerySyncStatus(10),
+      ]);
 
       if (loadRequestRef.current !== requestId) return;
+      const response: GalleryResponse = {
+        images: catalogResponse.assets.map(toGalleryImage),
+        total: catalogResponse.total,
+        limit: catalogResponse.limit,
+        offset: catalogResponse.offset,
+      };
 
       void withTimeout(galleryCache.set(cacheKey, {
         images: response.images,
@@ -147,6 +209,7 @@ export default function Gallery() {
 
       setImages(response.images);
       setTotal(response.total);
+      setSyncStatus(publishStatus);
 
       if (viewMode === "week") {
         organizeByWeek(response.images);
@@ -173,14 +236,14 @@ export default function Gallery() {
         setError(null);
       } else {
         const message = err instanceof Error ? err.message : "Unknown error";
-        setError(`Failed to load gallery. ${message}`);
+        setError(`Failed to load gallery catalog. ${message}`);
       }
     } finally {
       if (loadRequestRef.current === requestId) {
         setLoading(false);
       }
     }
-  }, [organizeByWeek, page, viewMode]);
+  }, [catalogFilter, organizeByWeek, page, viewMode]);
 
   const getWeekNumber = (date: Date): number => {
     const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
@@ -218,6 +281,10 @@ export default function Gallery() {
     void loadImages();
   }, [loadImages]);
 
+  useEffect(() => {
+    setPage(0);
+  }, [catalogFilter, viewMode]);
+
   const handleDelete = async (imagePath: string, event: React.MouseEvent) => {
     event.stopPropagation();
     if (!confirm("Are you sure you want to delete this image?")) return;
@@ -240,6 +307,36 @@ export default function Gallery() {
       alert("Failed to delete image");
     } finally {
       setDeleting(null);
+    }
+  };
+
+  const handlePublicationChange = async (
+    image: GalleryImage,
+    state: PublicationState,
+    event?: React.MouseEvent
+  ) => {
+    event?.stopPropagation();
+    const updateKey = `${image.catalog_path}:${state}`;
+    setPublicationUpdating(updateKey);
+    try {
+      const updatedEntry = await api.updatePublicationState(image.catalog_path, state);
+      const updatedImage = toGalleryImage(updatedEntry);
+
+      setImages((currentImages) => currentImages.map((item) => (
+        item.catalog_path === image.catalog_path ? updatedImage : item
+      )));
+      setSelectedImage((currentImage) => (
+        currentImage?.catalog_path === image.catalog_path ? updatedImage : currentImage
+      ));
+
+      await withTimeout(galleryCache.clear(), CACHE_TIMEOUT_MS, undefined);
+      await loadImages();
+    } catch (err) {
+      console.error("Failed to update publication state:", err);
+      const message = err instanceof Error ? err.message : "Failed to update publication state";
+      alert(message);
+    } finally {
+      setPublicationUpdating(null);
     }
   };
 
@@ -271,10 +368,23 @@ export default function Gallery() {
   };
 
   const formatSize = (bytes: number) => {
+    if (bytes <= 0) return "Unknown size";
     if (bytes < 1024) return `${bytes} B`;
     if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   };
+
+  const renderStateBadge = (state: PublicationState, className?: string) => (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-2 py-0.5 text-[11px] font-medium capitalize",
+        stateStyles[state],
+        className
+      )}
+    >
+      {state}
+    </span>
+  );
 
   const renderImageGrid = (images: GalleryImage[]) => (
     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2 sm:gap-3 lg:gap-4">
@@ -292,6 +402,9 @@ export default function Gallery() {
             className="w-full h-full object-cover"
             loading="lazy"
           />
+          <div className="absolute left-2 top-2">
+            {renderStateBadge(image.publication.state, "shadow-sm")}
+          </div>
 
           <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
             <div className="absolute bottom-0 left-0 right-0 p-3">
@@ -311,8 +424,24 @@ export default function Gallery() {
                 <button
                   onClick={(e) => handleDownload(image.path, image.prompt, e)}
                   className="p-1.5 bg-primary/80 hover:bg-primary rounded text-primary-foreground"
+                  title="Download image"
                 >
                   <Download className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  onClick={(e) => handlePublicationChange(image, "featured", e)}
+                  className="p-1.5 bg-amber-500/90 hover:bg-amber-500 rounded text-black disabled:opacity-50"
+                  disabled={
+                    image.publication.state === "featured"
+                    || publicationUpdating === `${image.catalog_path}:featured`
+                  }
+                  title="Mark featured"
+                >
+                  {publicationUpdating === `${image.catalog_path}:featured` ? (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  ) : (
+                    <Star className="w-3.5 h-3.5" />
+                  )}
                 </button>
               </div>
             </div>
@@ -372,12 +501,36 @@ export default function Gallery() {
       <div className="h-full flex flex-col">
         {/* Header */}
         <div className="px-4 sm:px-6 py-4 border-b border-border">
-          <div className="flex items-center justify-between">
-            <div>
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="min-w-0">
               <h2 className="text-lg font-semibold">Gallery</h2>
-              <p className="text-sm text-muted-foreground">{total} images generated</p>
+              <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                <span>{total} cataloged images</span>
+                {syncStatus && (
+                  <span className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-xs">
+                    <UploadCloud className="h-3.5 w-3.5" />
+                    {syncStatus.ready
+                      ? `${syncStatus.upload_images} approved / ${syncStatus.upload_files} files ready`
+                      : syncStatus.message}
+                  </span>
+                )}
+              </div>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <select
+                value={catalogFilter}
+                onChange={(event) => setCatalogFilter(event.target.value as CatalogFilter)}
+                className="h-8 rounded-md border border-border bg-background px-2 text-sm"
+                title="Filter by publication state"
+              >
+                <option value="all">All states</option>
+                {PUBLICATION_OPTIONS.map((option) => (
+                  <option key={option.state} value={option.state}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+
               {/* View Mode Toggle */}
               <div className="flex bg-muted rounded-md p-1">
                 <button
@@ -558,6 +711,7 @@ export default function Gallery() {
                       {formatDate(selectedImage.created_at)}
                     </span>
                     <span>{formatSize(selectedImage.size)}</span>
+                    {renderStateBadge(selectedImage.publication.state)}
                   </div>
                 </div>
                 <button
@@ -580,28 +734,70 @@ export default function Gallery() {
 
             {/* Modal Footer */}
             <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-background via-background/80 to-transparent p-4">
-              <div className="flex gap-2 justify-end">
-                <button
-                  onClick={(e) => handleDownload(selectedImage.path, selectedImage.prompt, e)}
-                  className="px-4 py-2 bg-primary text-primary-foreground rounded hover:opacity-90 flex items-center gap-2"
-                >
-                  <Download className="w-4 h-4" />
-                  Download
-                </button>
-                <button
-                  onClick={(e) => {
-                    handleDelete(selectedImage.path, e);
-                  }}
-                  className="px-4 py-2 bg-destructive text-destructive-foreground rounded hover:opacity-90 flex items-center gap-2"
-                  disabled={deleting === selectedImage.path}
-                >
-                  {deleting === selectedImage.path ? (
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                  ) : (
-                    <Trash2 className="w-4 h-4" />
-                  )}
-                  Delete
-                </button>
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                <div className="min-w-0">
+                  <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span>Publish state</span>
+                    {!selectedImage.publication.publishable && (
+                      <span className="rounded border border-border px-2 py-0.5">not publishable</span>
+                    )}
+                    {selectedImage.publication.quality_flags.map((flag) => (
+                      <span key={flag} className="rounded border border-border px-2 py-0.5">
+                        {flag}
+                      </span>
+                    ))}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {PUBLICATION_OPTIONS.map((option) => {
+                      const Icon = option.icon;
+                      const updateKey = `${selectedImage.catalog_path}:${option.state}`;
+                      const isCurrent = selectedImage.publication.state === option.state;
+                      return (
+                        <button
+                          key={option.state}
+                          onClick={(event) => handlePublicationChange(selectedImage, option.state, event)}
+                          className={cn(
+                            "flex h-9 items-center gap-2 rounded border border-border px-3 text-sm transition-colors",
+                            isCurrent
+                              ? "bg-primary text-primary-foreground"
+                              : "bg-background/80 hover:bg-muted"
+                          )}
+                          disabled={isCurrent || publicationUpdating === updateKey}
+                        >
+                          {publicationUpdating === updateKey ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Icon className="h-4 w-4" />
+                          )}
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div className="flex gap-2 justify-end">
+                  <button
+                    onClick={(e) => handleDownload(selectedImage.path, selectedImage.prompt, e)}
+                    className="px-4 py-2 bg-primary text-primary-foreground rounded hover:opacity-90 flex items-center gap-2"
+                  >
+                    <Download className="w-4 h-4" />
+                    Download
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      handleDelete(selectedImage.path, e);
+                    }}
+                    className="px-4 py-2 bg-destructive text-destructive-foreground rounded hover:opacity-90 flex items-center gap-2"
+                    disabled={deleting === selectedImage.path}
+                  >
+                    {deleting === selectedImage.path ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Trash2 className="w-4 h-4" />
+                    )}
+                    Delete
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -156,6 +156,53 @@ export interface GenerationEventsResponse {
   limit: number;
 }
 
+export type PublicationState = 'draft' | 'published' | 'hidden' | 'featured' | 'rejected';
+
+export interface GalleryPublication {
+  id: string;
+  state: PublicationState;
+  publishable: boolean;
+  quality_flags: string[];
+}
+
+export interface GalleryCatalogEntry {
+  id: string;
+  path: string;
+  image_url?: string;
+  prompt: string;
+  created_at: string;
+  updated_at: string;
+  publication_state: PublicationState;
+  publishable: boolean;
+  quality_flags: string[];
+  metadata: Record<string, unknown>;
+  size?: number;
+}
+
+export interface GalleryCatalogResponse {
+  assets: GalleryCatalogEntry[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface GallerySyncStatus {
+  bucket: string;
+  approved_states: string[];
+  catalog_present: boolean;
+  output_present: boolean;
+  ready: boolean;
+  needs_publish: boolean;
+  upload_images: number;
+  upload_files: number;
+  skipped_assets: number;
+  delete_objects: number;
+  preview_assets: Array<{ key: string; reason: string }>;
+  skipped_preview: Array<{ key: string; reason: string }>;
+  command: string;
+  message: string;
+}
+
 const extractErrorMessage = async (response: Response, fallback: string) => {
   try {
     const data = await response.json();
@@ -253,6 +300,59 @@ export class ImageGenAPI {
       }
       throw error;
     }
+  }
+
+  async getGalleryCatalog(
+    limit: number = 100,
+    offset: number = 0,
+    state?: PublicationState | 'all',
+    timeoutMs: number = 20000
+  ): Promise<GalleryCatalogResponse> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+    if (state && state !== 'all') params.set('state', state);
+
+    try {
+      const response = await fetch(`${this.baseUrl}/api/gallery/catalog?${params.toString()}`, {
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+
+      if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get gallery catalog'));
+      return response.json();
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(`Gallery catalog request timed out after ${Math.round(timeoutMs / 1000)}s`);
+      }
+      throw error;
+    }
+  }
+
+  async getGallerySyncStatus(limit: number = 10): Promise<GallerySyncStatus> {
+    const response = await fetch(`${this.baseUrl}/api/gallery/sync/status?limit=${limit}`);
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get gallery sync status'));
+    return response.json();
+  }
+
+  async updatePublicationState(
+    imagePath: string,
+    state: PublicationState,
+    allowPlaceholderPublish: boolean = false
+  ): Promise<GalleryCatalogEntry> {
+    const response = await fetch(`${this.baseUrl}/api/gallery/publication/${encodeURIComponent(imagePath)}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ state, allow_placeholder_publish: allowPlaceholderPublish }),
+    });
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to update publication state'));
+    return response.json();
   }
 
   async deleteImage(imagePath: string) {


### PR DESCRIPTION
Closes #52.

## Summary
- Add a non-mutating R2 publish status helper and expose it at `/api/gallery/sync/status`.
- Enrich `/api/gallery/catalog` entries with `image_url` and `size` for operator gallery rendering.
- Move the web gallery onto the operator catalog, add state filters, status badges, quick feature action, and modal publication controls for draft/published/hidden/featured/rejected.

## Verification
- `uv run pytest tests/`
- `uv run black --check src tests`
- `uv run isort --check-only src tests`
- `uv run mypy`
- `uv run pylint src/ --errors-only --disable=import-error`
- `npm run lint`
- `npm run build`
- Local smoke: backend `http://127.0.0.1:25800`, UI `http://127.0.0.1:7860`, sync status/catalog HTTP checks, encoded publication PATCH