### PR TITLE
[codex] Add durable generation jobs

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -14,7 +14,16 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import aiofiles
-from fastapi import FastAPI, File, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect
+from fastapi import (
+    BackgroundTasks,
+    FastAPI,
+    File,
+    HTTPException,
+    Query,
+    UploadFile,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from PIL import Image
@@ -24,7 +33,12 @@ from src.generators.factory import backend_label, is_model_cached, resolve_image
 from src.generators.prompt_generator import PromptGenerator
 from src.plugins import plugin_manager, register_lora_plugin
 from src.plugins.lora import get_available_loras
-from src.services import GenerationProgressEvent, GenerationServiceRequest, ImageGenService
+from src.services import (
+    GenerationJobCreate,
+    GenerationProgressEvent,
+    ImageGenService,
+    SQLiteGenerationJobStore,
+)
 from src.utils.config import Config
 from src.utils.gallery_publisher import DEFAULT_BUCKET, build_publish_status
 from src.utils.ollama import (
@@ -284,6 +298,19 @@ class GenerateResponse(BaseModel):
     created_at: str = Field(..., description="ISO timestamp")
 
 
+class JobCreateRequest(BaseModel):
+    """Request model for durable image generation jobs."""
+
+    prompt: Optional[str] = Field(None, description="Optional custom prompt")
+    meta_prompt: Optional[str] = Field(None, description="Optional prompt-generation steering text")
+    seed: Optional[int] = Field(None, description="Random seed for reproducibility")
+    publication_state: str = Field("draft", description="Initial publication state")
+    client_request_id: Optional[str] = Field(
+        None, description="Client-provided request ID used to correlate progress events"
+    )
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Extra job metadata")
+
+
 class PublicationUpdateRequest(BaseModel):
     """Request model for changing gallery publication state."""
 
@@ -382,6 +409,8 @@ class ConnectionManager:
 
 manager = ConnectionManager()
 recent_generation_events: deque[Dict[str, Any]] = deque(maxlen=MAX_RECENT_GENERATION_EVENTS)
+generation_job_store = SQLiteGenerationJobStore(OUTPUT_DIR / ".generation_jobs.sqlite3")
+generation_worker_lock = asyncio.Lock()
 
 
 def record_generation_event(event: Dict[str, Any]) -> Dict[str, Any]:
@@ -418,6 +447,149 @@ async def broadcast_task_progress(
     await manager.broadcast(json.dumps(payload))
 
 
+async def emit_generation_service_event(
+    *,
+    job_id: str,
+    client_request_id: Optional[str],
+    event: GenerationProgressEvent,
+) -> None:
+    """Persist and broadcast a service lifecycle event for a durable job."""
+    generation_job_store.record_event(job_id, event)
+    record_generation_event(
+        {
+            "type": "generation_lifecycle",
+            "name": event.name,
+            "id": job_id,
+            "client_request_id": client_request_id,
+            "progress": event.progress,
+            "label": event.label,
+            "detail": event.detail,
+            "payload": event.payload,
+        }
+    )
+    if event.progress is not None:
+        await broadcast_task_progress(
+            task="image_generation",
+            task_id=job_id,
+            client_request_id=client_request_id,
+            progress=event.progress,
+            label=event.label or event.name,
+            detail=event.detail or "",
+        )
+
+    if event.name == "prompt_generated":
+        await manager.broadcast(
+            json.dumps(
+                {
+                    "type": "prompt_generated",
+                    "id": job_id,
+                    "client_request_id": client_request_id,
+                    "prompt": event.payload.get("prompt", ""),
+                }
+            )
+        )
+    elif event.name == "model_loading":
+        await manager.broadcast(
+            json.dumps(
+                {
+                    "type": "model_loading",
+                    "id": job_id,
+                    "client_request_id": client_request_id,
+                    "message": event.payload.get("message", event.detail or ""),
+                }
+            )
+        )
+    elif event.name == "generation_completed":
+        await manager.broadcast(
+            json.dumps(
+                {
+                    "type": "generation_completed",
+                    "id": job_id,
+                    "client_request_id": client_request_id,
+                    "image_path": event.payload.get("image_path", ""),
+                    "prompt": event.payload.get("prompt", ""),
+                }
+            )
+        )
+
+
+async def run_generation_job(job_id: str):
+    """Run one queued generation job through the shared service boundary."""
+    job_payload = generation_job_store.request_for_job(job_id)
+    if job_payload is None:
+        raise KeyError(f"Unknown generation job: {job_id}")
+
+    async with generation_worker_lock:
+        current = generation_job_store.get_job(job_id)
+        if current is None:
+            raise KeyError(f"Unknown generation job: {job_id}")
+        if current["status"] in {"succeeded", "failed", "cancelled"}:
+            return None
+
+        generation_job_store.start_job(job_id)
+        await manager.broadcast(
+            json.dumps(
+                record_generation_event(
+                    {
+                        "type": "generation_started",
+                        "id": job_id,
+                        "client_request_id": job_payload.client_request_id,
+                    }
+                )
+            )
+        )
+
+        async def emit(event: GenerationProgressEvent) -> None:
+            await emit_generation_service_event(
+                job_id=job_id,
+                client_request_id=job_payload.client_request_id,
+                event=event,
+            )
+
+        try:
+            service = ImageGenService(config, output_dir=OUTPUT_DIR)
+            result = await service.generate(job_payload.to_service_request(job_id), callback=emit)
+            generation_job_store.complete_job(
+                job_id,
+                prompt=result.prompt,
+                image_path=result.image_path,
+                relative_image_path=result.relative_image_path,
+                backend=result.backend,
+                model_name=result.model_name,
+                generation_time=result.generation_time,
+                metadata=result.metadata,
+            )
+            return result
+        except Exception as exc:
+            error_msg = (
+                "Insufficient memory to load the configured image backend."
+                if isinstance(exc, MemoryError)
+                else str(exc)
+            )
+            generation_job_store.fail_job(job_id, error_msg)
+            await manager.broadcast(
+                json.dumps(
+                    record_generation_event(
+                        {
+                            "type": "generation_error",
+                            "id": job_id,
+                            "client_request_id": job_payload.client_request_id,
+                            "error": error_msg,
+                        }
+                    )
+                )
+            )
+            raise
+
+
+async def run_generation_job_safely(job_id: str) -> None:
+    """Background-task wrapper that records failures without crashing the server."""
+    try:
+        await run_generation_job(job_id)
+    except Exception as exc:
+        logger.error("Generation job %s failed: %s", job_id, exc)
+
+
 async def prefetch_default_fallback_model() -> None:
     """Fetch the default public fallback model in the background when needed."""
     if resolve_image_backend(config) != "small":
@@ -438,6 +610,7 @@ async def prefetch_default_fallback_model() -> None:
 
 @app.on_event("startup")
 async def startup_event() -> None:
+    generation_job_store.initialize()
     asyncio.create_task(prefetch_default_fallback_model())
 
 
@@ -975,83 +1148,18 @@ async def generate_prompt(request: PromptRequest):
 @app.post("/api/generate", response_model=GenerateResponse)
 async def generate_image(request: GenerateRequest):
     """Generate a single image"""
-    generation_id = str(uuid.uuid4())
-
-    async def emit_generation_event(event: GenerationProgressEvent) -> None:
-        record_generation_event(
-            {
-                "type": "generation_lifecycle",
-                "name": event.name,
-                "id": generation_id,
-                "client_request_id": request.client_request_id,
-                "progress": event.progress,
-                "label": event.label,
-                "detail": event.detail,
-                "payload": event.payload,
-            }
+    job = generation_job_store.create_job(
+        GenerationJobCreate(
+            prompt=request.prompt,
+            seed=request.seed,
+            client_request_id=request.client_request_id,
         )
-        if event.progress is not None:
-            await broadcast_task_progress(
-                task="image_generation",
-                task_id=generation_id,
-                client_request_id=request.client_request_id,
-                progress=event.progress,
-                label=event.label or event.name,
-                detail=event.detail or "",
-            )
-
-        if event.name == "prompt_generated":
-            await manager.broadcast(
-                json.dumps(
-                    {
-                        "type": "prompt_generated",
-                        "id": generation_id,
-                        "client_request_id": request.client_request_id,
-                        "prompt": event.payload.get("prompt", ""),
-                    }
-                )
-            )
-        elif event.name == "model_loading":
-            await manager.broadcast(
-                json.dumps(
-                    {
-                        "type": "model_loading",
-                        "id": generation_id,
-                        "client_request_id": request.client_request_id,
-                        "message": event.payload.get("message", event.detail or ""),
-                    }
-                )
-            )
-        elif event.name == "generation_completed":
-            await manager.broadcast(
-                json.dumps(
-                    {
-                        "type": "generation_completed",
-                        "id": generation_id,
-                        "client_request_id": request.client_request_id,
-                        "image_path": event.payload.get("image_path", ""),
-                        "prompt": event.payload.get("prompt", ""),
-                    }
-                )
-            )
-
+    )
+    generation_id = job["id"]
     try:
-        await manager.broadcast(
-            json.dumps(
-                record_generation_event(
-                    {
-                        "type": "generation_started",
-                        "id": generation_id,
-                        "client_request_id": request.client_request_id,
-                    }
-                )
-            )
-        )
-        service = ImageGenService(config, output_dir=OUTPUT_DIR)
-        result = await service.generate(
-            GenerationServiceRequest(prompt=request.prompt, seed=request.seed),
-            callback=emit_generation_event,
-        )
+        result = await run_generation_job(generation_id)
+        if result is None:
+            raise RuntimeError(f"Generation job {generation_id} did not produce a result")
 
         return GenerateResponse(
             id=generation_id,
@@ -1064,37 +1172,58 @@ async def generate_image(request: GenerateRequest):
     except MemoryError as e:
         error_msg = "Insufficient memory to load the configured image backend."
         logger.error(f"Memory error loading image backend: {str(e)}")
-        await manager.broadcast(
-            json.dumps(
-                record_generation_event(
-                    {
-                        "type": "generation_error",
-                        "id": generation_id,
-                        "client_request_id": request.client_request_id,
-                        "error": error_msg,
-                    }
-                )
-            )
-        )
         raise HTTPException(status_code=507, detail=error_msg)
     except Exception as e:
         logger.error(f"Generation failed: {str(e)}")
-
-        # Broadcast error event
-        await manager.broadcast(
-            json.dumps(
-                record_generation_event(
-                    {
-                        "type": "generation_error",
-                        "id": generation_id,
-                        "client_request_id": request.client_request_id,
-                        "error": str(e),
-                    }
-                )
-            )
-        )
-
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/api/jobs")
+async def create_generation_job(request: JobCreateRequest, background_tasks: BackgroundTasks):
+    """Create a durable generation job and schedule it on the local worker."""
+    job = generation_job_store.create_job(
+        GenerationJobCreate(
+            prompt=request.prompt,
+            meta_prompt=request.meta_prompt,
+            seed=request.seed,
+            publication_state=request.publication_state,
+            client_request_id=request.client_request_id,
+            metadata=request.metadata,
+        )
+    )
+    background_tasks.add_task(run_generation_job_safely, job["id"])
+    return job
+
+
+@app.get("/api/jobs")
+async def list_generation_jobs(
+    status: Optional[str] = Query(None),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    """List recent durable generation jobs."""
+    return {
+        "jobs": generation_job_store.list_jobs(status=status, limit=limit, offset=offset),
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@app.get("/api/jobs/{job_id}")
+async def get_generation_job(job_id: str):
+    """Return one durable generation job with its progress events."""
+    job = generation_job_store.get_job(job_id, include_events=True)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Generation job not found")
+    return job
+
+
+@app.get("/api/jobs/{job_id}/events")
+async def get_generation_job_events(job_id: str):
+    """Return persisted lifecycle events for one generation job."""
+    if generation_job_store.get_job(job_id) is None:
+        raise HTTPException(status_code=404, detail="Generation job not found")
+    return {"events": generation_job_store.get_events(job_id)}
 
 
 @app.get("/api/generation/events")

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,5 +1,10 @@
 """Application service boundaries for DreamGen workflows."""
 
+from .generation_jobs import (
+    GenerationJobCreate,
+    SQLiteGenerationJobStore,
+    job_payload_from_service_request,
+)
 from .image_generation import (
     GenerationProgressEvent,
     GenerationServiceRequest,
@@ -8,8 +13,11 @@ from .image_generation import (
 )
 
 __all__ = [
+    "GenerationJobCreate",
     "GenerationProgressEvent",
     "GenerationServiceRequest",
     "GenerationServiceResult",
     "ImageGenService",
+    "SQLiteGenerationJobStore",
+    "job_payload_from_service_request",
 ]

--- a/src/services/generation_jobs.py
+++ b/src/services/generation_jobs.py
@@ -1,0 +1,464 @@
+"""SQLite-backed durable generation job state."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .image_generation import GenerationProgressEvent, GenerationServiceRequest
+
+TERMINAL_STATUSES = {"succeeded", "failed", "cancelled"}
+
+
+def utc_now() -> str:
+    """Return an ISO-8601 UTC timestamp."""
+    return datetime.utcnow().isoformat(timespec="seconds") + "Z"
+
+
+@dataclass(frozen=True)
+class GenerationJobCreate:
+    """Durable job creation payload."""
+
+    prompt: str | None = None
+    meta_prompt: str | None = None
+    seed: int | None = None
+    publication_state: str = "draft"
+    client_request_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_service_request(self, job_id: str) -> GenerationServiceRequest:
+        """Convert a persisted job payload to the service request boundary."""
+        return GenerationServiceRequest(
+            prompt=self.prompt,
+            meta_prompt=self.meta_prompt,
+            seed=self.seed,
+            publication_state=self.publication_state,
+            metadata={**self.metadata, "job_id": job_id},
+        )
+
+
+class SQLiteGenerationJobStore:
+    """Persist generation jobs and progress events in a local SQLite database."""
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self._initialized = False
+
+    def initialize(self) -> None:
+        """Create the database schema if it does not already exist."""
+        if self._initialized:
+            return
+
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as connection:
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS generation_jobs (
+                    id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    request_json TEXT NOT NULL,
+                    client_request_id TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    started_at TEXT,
+                    completed_at TEXT,
+                    progress INTEGER NOT NULL DEFAULT 0,
+                    prompt TEXT,
+                    backend TEXT,
+                    model_name TEXT,
+                    image_path TEXT,
+                    relative_image_path TEXT,
+                    generation_time REAL,
+                    error TEXT,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    metadata_json TEXT NOT NULL DEFAULT '{}'
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS generation_job_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    job_id TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    progress INTEGER,
+                    label TEXT,
+                    detail TEXT,
+                    payload_json TEXT NOT NULL DEFAULT '{}',
+                    FOREIGN KEY(job_id) REFERENCES generation_jobs(id)
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_generation_jobs_status_updated
+                ON generation_jobs(status, updated_at DESC)
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_generation_events_job
+                ON generation_job_events(job_id, id)
+                """
+            )
+        self._initialized = True
+
+    def create_job(self, payload: GenerationJobCreate, job_id: str | None = None) -> dict[str, Any]:
+        """Create a queued generation job and return its snapshot."""
+        self.initialize()
+        resolved_job_id = job_id or str(uuid.uuid4())
+        now = utc_now()
+        request_payload = {
+            "prompt": payload.prompt,
+            "meta_prompt": payload.meta_prompt,
+            "seed": payload.seed,
+            "publication_state": payload.publication_state,
+            "metadata": payload.metadata,
+        }
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO generation_jobs (
+                    id, status, request_json, client_request_id, created_at, updated_at
+                )
+                VALUES (?, 'queued', ?, ?, ?, ?)
+                """,
+                (
+                    resolved_job_id,
+                    json.dumps(request_payload, sort_keys=True),
+                    payload.client_request_id,
+                    now,
+                    now,
+                ),
+            )
+            self._append_event(
+                connection,
+                resolved_job_id,
+                GenerationProgressEvent(
+                    name="queued",
+                    progress=0,
+                    label="Queued",
+                    detail="Generation job is waiting for the local worker.",
+                ),
+            )
+        return self.get_job(resolved_job_id) or {}
+
+    def start_job(self, job_id: str) -> dict[str, Any]:
+        """Mark a queued job as running."""
+        self.initialize()
+        now = utc_now()
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE generation_jobs
+                SET status = 'running',
+                    started_at = COALESCE(started_at, ?),
+                    updated_at = ?,
+                    attempts = attempts + 1,
+                    progress = MAX(progress, 1),
+                    error = NULL
+                WHERE id = ? AND status NOT IN ('succeeded', 'failed', 'cancelled')
+                """,
+                (now, now, job_id),
+            )
+            self._append_event(
+                connection,
+                job_id,
+                GenerationProgressEvent(
+                    name="running",
+                    progress=1,
+                    label="Running",
+                    detail="The local generation worker started this job.",
+                ),
+            )
+        return self.get_job(job_id) or {}
+
+    def record_event(self, job_id: str, event: GenerationProgressEvent) -> dict[str, Any]:
+        """Persist a generation lifecycle event for a job."""
+        self.initialize()
+        with self._connect() as connection:
+            self._append_event(connection, job_id, event)
+            if event.progress is not None:
+                connection.execute(
+                    """
+                    UPDATE generation_jobs
+                    SET progress = ?, updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (event.progress, utc_now(), job_id),
+                )
+        return self.get_job(job_id) or {}
+
+    def complete_job(
+        self,
+        job_id: str,
+        *,
+        prompt: str,
+        image_path: Path,
+        relative_image_path: str,
+        backend: str,
+        model_name: str,
+        generation_time: float,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Mark a job as succeeded with generated artifact details."""
+        self.initialize()
+        now = utc_now()
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE generation_jobs
+                SET status = 'succeeded',
+                    updated_at = ?,
+                    completed_at = ?,
+                    progress = 100,
+                    prompt = ?,
+                    backend = ?,
+                    model_name = ?,
+                    image_path = ?,
+                    relative_image_path = ?,
+                    generation_time = ?,
+                    error = NULL,
+                    metadata_json = ?
+                WHERE id = ?
+                """,
+                (
+                    now,
+                    now,
+                    prompt,
+                    backend,
+                    model_name,
+                    str(image_path),
+                    relative_image_path,
+                    generation_time,
+                    json.dumps(metadata, sort_keys=True),
+                    job_id,
+                ),
+            )
+            self._append_event(
+                connection,
+                job_id,
+                GenerationProgressEvent(
+                    name="succeeded",
+                    progress=100,
+                    label="Succeeded",
+                    detail="Generation job completed successfully.",
+                    payload={"image_path": relative_image_path},
+                ),
+            )
+        return self.get_job(job_id) or {}
+
+    def fail_job(self, job_id: str, error: str) -> dict[str, Any]:
+        """Mark a job as failed and persist the error."""
+        self.initialize()
+        now = utc_now()
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE generation_jobs
+                SET status = 'failed',
+                    updated_at = ?,
+                    completed_at = ?,
+                    error = ?
+                WHERE id = ? AND status NOT IN ('succeeded', 'cancelled')
+                """,
+                (now, now, error, job_id),
+            )
+            self._append_event(
+                connection,
+                job_id,
+                GenerationProgressEvent(
+                    name="failed",
+                    label="Failed",
+                    detail=error,
+                    payload={"error": error},
+                ),
+            )
+        return self.get_job(job_id) or {}
+
+    def cancel_job(self, job_id: str) -> dict[str, Any]:
+        """Cancel a queued job."""
+        self.initialize()
+        now = utc_now()
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE generation_jobs
+                SET status = 'cancelled',
+                    updated_at = ?,
+                    completed_at = ?,
+                    error = 'cancelled'
+                WHERE id = ? AND status = 'queued'
+                """,
+                (now, now, job_id),
+            )
+            self._append_event(
+                connection,
+                job_id,
+                GenerationProgressEvent(
+                    name="cancelled",
+                    label="Cancelled",
+                    detail="Generation job was cancelled before it started.",
+                ),
+            )
+        return self.get_job(job_id) or {}
+
+    def get_job(self, job_id: str, *, include_events: bool = False) -> dict[str, Any] | None:
+        """Return a job snapshot by ID."""
+        self.initialize()
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM generation_jobs WHERE id = ?",
+                (job_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            job = self._row_to_job(row)
+            if include_events:
+                job["events"] = self.get_events(job_id)
+            return job
+
+    def list_jobs(
+        self,
+        *,
+        status: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List recent jobs, optionally filtered by status."""
+        self.initialize()
+        params: list[Any] = []
+        where = ""
+        if status:
+            where = "WHERE status = ?"
+            params.append(status)
+        params.extend([limit, offset])
+        with self._connect() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT * FROM generation_jobs
+                {where}
+                ORDER BY created_at DESC, id DESC
+                LIMIT ? OFFSET ?
+                """,
+                params,
+            ).fetchall()
+            return [self._row_to_job(row) for row in rows]
+
+    def get_events(self, job_id: str) -> list[dict[str, Any]]:
+        """Return persisted lifecycle events for a job."""
+        self.initialize()
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM generation_job_events
+                WHERE job_id = ?
+                ORDER BY id ASC
+                """,
+                (job_id,),
+            ).fetchall()
+            return [self._row_to_event(row) for row in rows]
+
+    def request_for_job(self, job_id: str) -> GenerationJobCreate | None:
+        """Return the original creation payload for a job."""
+        job = self.get_job(job_id)
+        if job is None:
+            return None
+        request = job["request"]
+        return GenerationJobCreate(
+            prompt=request.get("prompt"),
+            meta_prompt=request.get("meta_prompt"),
+            seed=request.get("seed"),
+            publication_state=request.get("publication_state", "draft"),
+            client_request_id=job.get("client_request_id"),
+            metadata=request.get("metadata") or {},
+        )
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _append_event(
+        self,
+        connection: sqlite3.Connection,
+        job_id: str,
+        event: GenerationProgressEvent,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO generation_job_events (
+                job_id, timestamp, name, progress, label, detail, payload_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                job_id,
+                utc_now(),
+                event.name,
+                event.progress,
+                event.label,
+                event.detail,
+                json.dumps(event.payload, sort_keys=True, default=str),
+            ),
+        )
+
+    def _row_to_job(self, row: sqlite3.Row) -> dict[str, Any]:
+        request = json.loads(row["request_json"] or "{}")
+        metadata = json.loads(row["metadata_json"] or "{}")
+        return {
+            "id": row["id"],
+            "status": row["status"],
+            "request": request,
+            "client_request_id": row["client_request_id"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "started_at": row["started_at"],
+            "completed_at": row["completed_at"],
+            "progress": row["progress"],
+            "prompt": row["prompt"],
+            "backend": row["backend"],
+            "model_name": row["model_name"],
+            "image_path": row["image_path"],
+            "relative_image_path": row["relative_image_path"],
+            "generation_time": row["generation_time"],
+            "error": row["error"],
+            "attempts": row["attempts"],
+            "metadata": metadata,
+        }
+
+    def _row_to_event(self, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "job_id": row["job_id"],
+            "timestamp": row["timestamp"],
+            "name": row["name"],
+            "progress": row["progress"],
+            "label": row["label"],
+            "detail": row["detail"],
+            "payload": json.loads(row["payload_json"] or "{}"),
+        }
+
+
+def job_payload_from_service_request(
+    request: GenerationServiceRequest,
+    *,
+    client_request_id: str | None = None,
+) -> GenerationJobCreate:
+    """Build a durable job payload from the service request model."""
+    data = asdict(request)
+    return GenerationJobCreate(
+        prompt=data.get("prompt"),
+        meta_prompt=data.get("meta_prompt"),
+        seed=data.get("seed"),
+        publication_state=data.get("publication_state", "draft"),
+        client_request_id=client_request_id,
+        metadata=data.get("metadata") or {},
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -161,6 +161,53 @@ def test_generate_with_seed(client):
     assert data["metadata"].get("seed") == 42
 
 
+def test_generate_endpoint_records_durable_job(client):
+    """The compatibility generate endpoint should also persist durable job state."""
+    response = client.post(
+        "/api/generate",
+        json={"prompt": "Durable compatibility image", "seed": 24},
+    )
+    assert response.status_code == 200
+    generation = response.json()
+
+    job_response = client.get(f"/api/jobs/{generation['id']}")
+    assert job_response.status_code == 200
+    job = job_response.json()
+    assert job["status"] == "succeeded"
+    assert job["request"]["prompt"] == "Durable compatibility image"
+    assert job["metadata"]["seed"] == 24
+    assert job["relative_image_path"] == generation["image_path"]
+    assert any(event["name"] == "generation_completed" for event in job["events"])
+
+
+def test_jobs_endpoint_creates_and_lists_generation_job(client):
+    """Durable job endpoints should create, run, fetch, and list jobs."""
+    response = client.post(
+        "/api/jobs",
+        json={
+            "prompt": "Queued durable image",
+            "seed": 31,
+            "client_request_id": "req-job-api-1",
+        },
+    )
+    assert response.status_code == 200
+    created = response.json()
+    assert created["request"]["prompt"] == "Queued durable image"
+
+    job_response = client.get(f"/api/jobs/{created['id']}")
+    assert job_response.status_code == 200
+    job = job_response.json()
+    assert job["status"] == "succeeded"
+    assert job["client_request_id"] == "req-job-api-1"
+    assert job["relative_image_path"].startswith("/images/")
+    assert any(event["name"] == "succeeded" for event in job["events"])
+
+    list_response = client.get("/api/jobs?status=succeeded&limit=10")
+    assert list_response.status_code == 200
+    listed_ids = [item["id"] for item in list_response.json()["jobs"]]
+    assert created["id"] in listed_ids
+
+
 def test_generation_events_endpoint_records_recent_lifecycle(client):
     """Generation lifecycle events should be inspectable after the request completes."""
     payload = {"prompt": "observable test image", "client_request_id": "req-events-123"}

--- a/tests/test_generation_jobs.py
+++ b/tests/test_generation_jobs.py
@@ -1,0 +1,77 @@
+"""Tests for durable generation job persistence."""
+
+from pathlib import Path
+
+from src.services import GenerationJobCreate, GenerationProgressEvent, SQLiteGenerationJobStore
+
+
+def test_generation_job_store_persists_state_transitions(tmp_path):
+    store = SQLiteGenerationJobStore(tmp_path / "jobs.sqlite3")
+
+    queued = store.create_job(
+        GenerationJobCreate(
+            prompt="durable job prompt",
+            seed=17,
+            client_request_id="req-job-1",
+            metadata={"source": "test"},
+        ),
+        job_id="job-1",
+    )
+
+    assert queued["status"] == "queued"
+    assert queued["request"]["prompt"] == "durable job prompt"
+    assert queued["client_request_id"] == "req-job-1"
+
+    running = store.start_job("job-1")
+    assert running["status"] == "running"
+    assert running["attempts"] == 1
+
+    store.record_event(
+        "job-1",
+        GenerationProgressEvent(
+            name="rendering",
+            progress=50,
+            label="Rendering",
+            detail="Halfway there",
+            payload={"phase": "image"},
+        ),
+    )
+    completed = store.complete_job(
+        "job-1",
+        prompt="durable job prompt",
+        image_path=Path("output/test.png"),
+        relative_image_path="/images/test.png",
+        backend="mock",
+        model_name="mock-generator",
+        generation_time=0.1,
+        metadata={"backend": "mock", "seed": 17},
+    )
+
+    assert completed["status"] == "succeeded"
+    assert completed["progress"] == 100
+    assert completed["relative_image_path"] == "/images/test.png"
+    assert completed["metadata"]["seed"] == 17
+
+    reloaded = SQLiteGenerationJobStore(tmp_path / "jobs.sqlite3")
+    job = reloaded.get_job("job-1", include_events=True)
+    assert job is not None
+    assert job["status"] == "succeeded"
+    assert [event["name"] for event in job["events"]] == [
+        "queued",
+        "running",
+        "rendering",
+        "succeeded",
+    ]
+
+
+def test_generation_job_store_lists_and_records_failures(tmp_path):
+    store = SQLiteGenerationJobStore(tmp_path / "jobs.sqlite3")
+    store.create_job(GenerationJobCreate(prompt="will fail"), job_id="job-fail")
+    store.start_job("job-fail")
+
+    failed = store.fail_job("job-fail", "backend unavailable")
+
+    assert failed["status"] == "failed"
+    assert failed["error"] == "backend unavailable"
+    assert store.list_jobs(status="failed")[0]["id"] == "job-fail"
+    assert store.request_for_job("job-fail").prompt == "will fail"


### PR DESCRIPTION
## Summary

Adds the first local durable generation job slice for #39.

- Introduces a SQLite-backed generation job store with queued/running/succeeded/failed/cancelled state, request payloads, timestamps, attempts, artifact paths, metadata, and lifecycle events.
- Adds `/api/jobs`, `/api/jobs/{id}`, and `/api/jobs/{id}/events` for creating, listing, fetching, and inspecting durable jobs.
- Keeps `/api/generate` compatible while routing it through the same durable job path so existing clients receive the same response shape with a durable job ID.
- Adds focused persistence and API tests for state transitions, failure recording, job listing, and compatibility generation.

## Context

Issue #38 appears already satisfied on `main`: the `ImageGenService` boundary, typed request/result objects, CLI/API usage, metadata sidecars, catalog registration, and service tests are already present. This PR targets the next unblocked foundation issue, #39.

## Validation

- `uv run pytest tests/test_generation_jobs.py tests/test_image_generation_service.py tests/test_api.py` -> `29 passed`
- `uv run pytest tests/` -> `79 passed, 2 skipped`

FastAPI still emits existing `on_event` deprecation warnings during tests.