### PR TITLE
[codex] Add workflow recipes

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -38,6 +38,10 @@ from src.services import (
     GenerationProgressEvent,
     ImageGenService,
     SQLiteGenerationJobStore,
+    apply_config_overrides,
+    get_workflow_recipe,
+    list_workflow_recipes,
+    resolve_workflow_recipe,
 )
 from src.utils.config import Config
 from src.utils.gallery_publisher import DEFAULT_BUCKET, build_publish_status
@@ -306,6 +310,7 @@ class GenerateRequest(BaseModel):
     prompt: Optional[str] = Field(None, description="Optional custom prompt")
     enable_plugins: bool = Field(True, description="Enable plugin enhancements")
     seed: Optional[int] = Field(None, description="Random seed for reproducibility")
+    recipe_id: Optional[str] = Field(None, description="Optional workflow recipe ID")
     client_request_id: Optional[str] = Field(
         None, description="Client-provided request ID used to correlate progress events"
     )
@@ -327,6 +332,7 @@ class JobCreateRequest(BaseModel):
     prompt: Optional[str] = Field(None, description="Optional custom prompt")
     meta_prompt: Optional[str] = Field(None, description="Optional prompt-generation steering text")
     seed: Optional[int] = Field(None, description="Random seed for reproducibility")
+    recipe_id: Optional[str] = Field(None, description="Optional workflow recipe ID")
     publication_state: str = Field("draft", description="Initial publication state")
     client_request_id: Optional[str] = Field(
         None, description="Client-provided request ID used to correlate progress events"
@@ -392,6 +398,18 @@ class PromptResponse(BaseModel):
     """Response model for prompt generation."""
 
     prompt: str = Field(..., description="Generated prompt text")
+
+
+class RecipeResolveRequest(BaseModel):
+    """Request model for resolving a workflow recipe into a job payload."""
+
+    prompt: Optional[str] = Field(None, description="Optional prompt override")
+    meta_prompt: Optional[str] = Field(None, description="Optional meta-prompt override")
+    seed: Optional[int] = Field(None, description="Optional seed override")
+    client_request_id: Optional[str] = Field(
+        None, description="Client-provided request ID used to correlate progress events"
+    )
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Extra request metadata")
 
 
 class SystemStatus(BaseModel):
@@ -571,7 +589,11 @@ async def run_generation_job(job_id: str):
 
         try:
             service = ImageGenService(config, output_dir=OUTPUT_DIR)
-            result = await service.generate(job_payload.to_service_request(job_id), callback=emit)
+            with apply_config_overrides(config, job_payload.config_overrides):
+                result = await service.generate(
+                    job_payload.to_service_request(job_id),
+                    callback=emit,
+                )
             generation_job_store.complete_job(
                 job_id,
                 prompt=result.prompt,
@@ -611,6 +633,38 @@ async def run_generation_job_safely(job_id: str) -> None:
         await run_generation_job(job_id)
     except Exception as exc:
         logger.error("Generation job %s failed: %s", job_id, exc)
+
+
+def generation_job_from_request(
+    *,
+    prompt: Optional[str],
+    meta_prompt: Optional[str],
+    seed: Optional[int],
+    publication_state: str,
+    client_request_id: Optional[str],
+    metadata: Dict[str, Any] | None = None,
+    recipe_id: Optional[str] = None,
+) -> GenerationJobCreate:
+    """Build a job creation payload, resolving a workflow recipe when requested."""
+    if not recipe_id:
+        return GenerationJobCreate(
+            prompt=prompt,
+            meta_prompt=meta_prompt,
+            seed=seed,
+            publication_state=publication_state,
+            client_request_id=client_request_id,
+            metadata=metadata or {},
+        )
+
+    resolution = resolve_workflow_recipe(
+        recipe_id,
+        prompt=prompt,
+        meta_prompt=meta_prompt,
+        seed=seed,
+        metadata=metadata,
+    )
+    payload = resolution.to_job_payload(client_request_id=client_request_id)
+    return GenerationJobCreate(**payload)
 
 
 async def prefetch_default_fallback_model() -> None:
@@ -1141,6 +1195,43 @@ async def set_generation_config(data: dict):
         raise HTTPException(status_code=500, detail=f"Failed to update configuration: {str(e)}")
 
 
+@app.get("/api/recipes")
+async def get_workflow_recipes():
+    """List built-in workflow recipes."""
+    return {"recipes": [recipe.summary() for recipe in list_workflow_recipes()]}
+
+
+@app.get("/api/recipes/{recipe_id}")
+async def get_workflow_recipe_detail(recipe_id: str):
+    """Return a built-in workflow recipe definition."""
+    try:
+        return get_workflow_recipe(recipe_id).to_dict()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.post("/api/recipes/{recipe_id}/resolve")
+async def resolve_workflow_recipe_endpoint(recipe_id: str, request: RecipeResolveRequest):
+    """Resolve a workflow recipe into a generation job payload."""
+    try:
+        resolution = resolve_workflow_recipe(
+            recipe_id,
+            prompt=request.prompt,
+            meta_prompt=request.meta_prompt,
+            seed=request.seed,
+            metadata=request.metadata,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "recipe": resolution.recipe.to_dict(),
+        "job_request": resolution.to_job_payload(client_request_id=request.client_request_id),
+    }
+
+
 @app.post("/api/prompt", response_model=PromptResponse)
 async def generate_prompt(request: PromptRequest):
     """Generate a prompt without creating an image."""
@@ -1181,13 +1272,22 @@ async def generate_prompt(request: PromptRequest):
 @app.post("/api/generate", response_model=GenerateResponse)
 async def generate_image(request: GenerateRequest):
     """Generate a single image"""
-    job = generation_job_store.create_job(
-        GenerationJobCreate(
-            prompt=request.prompt,
-            seed=request.seed,
-            client_request_id=request.client_request_id,
+    try:
+        job = generation_job_store.create_job(
+            generation_job_from_request(
+                prompt=request.prompt,
+                meta_prompt=None,
+                seed=request.seed,
+                publication_state="draft",
+                client_request_id=request.client_request_id,
+                recipe_id=request.recipe_id,
+            )
         )
-    )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     generation_id = job["id"]
     try:
         result = await run_generation_job(generation_id)
@@ -1214,16 +1314,23 @@ async def generate_image(request: GenerateRequest):
 @app.post("/api/jobs")
 async def create_generation_job(request: JobCreateRequest, background_tasks: BackgroundTasks):
     """Create a durable generation job and schedule it on the local worker."""
-    job = generation_job_store.create_job(
-        GenerationJobCreate(
-            prompt=request.prompt,
-            meta_prompt=request.meta_prompt,
-            seed=request.seed,
-            publication_state=request.publication_state,
-            client_request_id=request.client_request_id,
-            metadata=request.metadata,
+    try:
+        job = generation_job_store.create_job(
+            generation_job_from_request(
+                prompt=request.prompt,
+                meta_prompt=request.meta_prompt,
+                seed=request.seed,
+                publication_state=request.publication_state,
+                client_request_id=request.client_request_id,
+                metadata=request.metadata,
+                recipe_id=request.recipe_id,
+            )
         )
-    )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     background_tasks.add_task(run_generation_job_safely, job["id"])
     return job
 

--- a/src/recipes/__init__.py
+++ b/src/recipes/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in workflow recipe assets."""

--- a/src/recipes/mock-smoke.json
+++ b/src/recipes/mock-smoke.json
@@ -1,0 +1,27 @@
+{
+  "id": "mock-smoke",
+  "version": 1,
+  "name": "Mock Smoke",
+  "description": "Generate a deterministic placeholder image for API, CLI, and job smoke tests.",
+  "mode": "text2img",
+  "backend_preference": "mock",
+  "prompt_strategy": {
+    "type": "fixed",
+    "prompt": "DreamGen mock smoke test image"
+  },
+  "image": {
+    "width": 512,
+    "height": 512
+  },
+  "plugins": {
+    "enabled": []
+  },
+  "lora": {
+    "enabled_loras": [],
+    "application_probability": 0.0
+  },
+  "publication": {
+    "state": "draft"
+  },
+  "post_processing": []
+}

--- a/src/recipes/publish-candidate.json
+++ b/src/recipes/publish-candidate.json
@@ -1,0 +1,23 @@
+{
+  "id": "publish-candidate",
+  "version": 1,
+  "name": "Publish Candidate",
+  "description": "Generate a review-ready candidate with default backend settings and draft publication state.",
+  "mode": "text2img",
+  "backend_preference": "auto",
+  "prompt_strategy": {
+    "type": "generated",
+    "meta_prompt": "Create a polished, publication-ready image prompt with strong composition and clear subject detail."
+  },
+  "image": {},
+  "plugins": {},
+  "lora": {},
+  "publication": {
+    "state": "draft"
+  },
+  "post_processing": [
+    {
+      "type": "catalog-review"
+    }
+  ]
+}

--- a/src/recipes/text2img-default.json
+++ b/src/recipes/text2img-default.json
@@ -1,0 +1,18 @@
+{
+  "id": "text2img-default",
+  "version": 1,
+  "name": "Text to Image Default",
+  "description": "Use the configured default backend and prompt plugins for a standard text-to-image run.",
+  "mode": "text2img",
+  "backend_preference": "auto",
+  "prompt_strategy": {
+    "type": "generated"
+  },
+  "image": {},
+  "plugins": {},
+  "lora": {},
+  "publication": {
+    "state": "draft"
+  },
+  "post_processing": []
+}

--- a/src/recipes/zimage-lora.json
+++ b/src/recipes/zimage-lora.json
@@ -1,0 +1,21 @@
+{
+  "id": "zimage-lora",
+  "version": 1,
+  "name": "Z-Image LoRA",
+  "description": "Prefer the local Z-Image backend while allowing configured LoRA selection.",
+  "mode": "text2img",
+  "backend_preference": "zimage",
+  "prompt_strategy": {
+    "type": "generated",
+    "meta_prompt": "Create a detailed image prompt that can benefit from active LoRA style modifiers."
+  },
+  "image": {},
+  "plugins": {},
+  "lora": {
+    "application_probability": 1.0
+  },
+  "publication": {
+    "state": "draft"
+  },
+  "post_processing": []
+}

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -11,6 +11,14 @@ from .image_generation import (
     GenerationServiceResult,
     ImageGenService,
 )
+from .workflow_recipes import (
+    ResolvedWorkflowRecipe,
+    WorkflowRecipe,
+    apply_config_overrides,
+    get_workflow_recipe,
+    list_workflow_recipes,
+    resolve_workflow_recipe,
+)
 
 __all__ = [
     "GenerationJobCreate",
@@ -18,6 +26,12 @@ __all__ = [
     "GenerationServiceRequest",
     "GenerationServiceResult",
     "ImageGenService",
+    "ResolvedWorkflowRecipe",
     "SQLiteGenerationJobStore",
+    "WorkflowRecipe",
+    "apply_config_overrides",
+    "get_workflow_recipe",
     "job_payload_from_service_request",
+    "list_workflow_recipes",
+    "resolve_workflow_recipe",
 ]

--- a/src/services/generation_jobs.py
+++ b/src/services/generation_jobs.py
@@ -30,15 +30,25 @@ class GenerationJobCreate:
     publication_state: str = "draft"
     client_request_id: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    recipe_id: str | None = None
+    recipe_version: int | None = None
+    config_overrides: dict[str, Any] = field(default_factory=dict)
 
     def to_service_request(self, job_id: str) -> GenerationServiceRequest:
         """Convert a persisted job payload to the service request boundary."""
+        metadata = {**self.metadata, "job_id": job_id}
+        if self.recipe_id:
+            metadata["recipe"] = {
+                **metadata.get("recipe", {}),
+                "id": self.recipe_id,
+                "version": self.recipe_version,
+            }
         return GenerationServiceRequest(
             prompt=self.prompt,
             meta_prompt=self.meta_prompt,
             seed=self.seed,
             publication_state=self.publication_state,
-            metadata={**self.metadata, "job_id": job_id},
+            metadata=metadata,
         )
 
 
@@ -121,6 +131,9 @@ class SQLiteGenerationJobStore:
             "seed": payload.seed,
             "publication_state": payload.publication_state,
             "metadata": payload.metadata,
+            "recipe_id": payload.recipe_id,
+            "recipe_version": payload.recipe_version,
+            "config_overrides": payload.config_overrides,
         }
         with self._connect() as connection:
             connection.execute(
@@ -379,6 +392,9 @@ class SQLiteGenerationJobStore:
             publication_state=request.get("publication_state", "draft"),
             client_request_id=job.get("client_request_id"),
             metadata=request.get("metadata") or {},
+            recipe_id=request.get("recipe_id"),
+            recipe_version=request.get("recipe_version"),
+            config_overrides=request.get("config_overrides") or {},
         )
 
     def _connect(self) -> sqlite3.Connection:
@@ -461,4 +477,7 @@ def job_payload_from_service_request(
         publication_state=data.get("publication_state", "draft"),
         client_request_id=client_request_id,
         metadata=data.get("metadata") or {},
+        recipe_id=data.get("recipe_id"),
+        recipe_version=data.get("recipe_version"),
+        config_overrides=data.get("config_overrides") or {},
     )

--- a/src/services/image_generation.py
+++ b/src/services/image_generation.py
@@ -253,6 +253,7 @@ class ImageGenService:
         relative_image_path = f"/images/{image_path.relative_to(self.output_dir).as_posix()}"
         active_plugins = [name for name, info in plugin_manager.plugins.items() if info.enabled]
         response_metadata = {
+            **request.metadata,
             **generation_metadata,
             "backend": backend_name,
             "publication": {

--- a/src/services/workflow_recipes.py
+++ b/src/services/workflow_recipes.py
@@ -1,0 +1,324 @@
+"""Versioned workflow recipes for repeatable generation requests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from src.plugins import plugin_manager
+from src.utils.config import Config
+
+RECIPE_SCHEMA_VERSION = 1
+BUILTIN_RECIPE_DIR = Path(__file__).resolve().parents[1] / "recipes"
+ALLOWED_RECIPE_MODES = {"text2img"}
+ALLOWED_PROMPT_STRATEGIES = {"fixed", "generated"}
+CONFIG_IMAGE_KEYS = {
+    "width",
+    "height",
+    "num_inference_steps",
+    "guidance_scale",
+    "true_cfg_scale",
+}
+
+
+@dataclass(frozen=True)
+class WorkflowRecipe:
+    """Validated workflow recipe definition."""
+
+    id: str
+    version: int
+    name: str
+    description: str
+    mode: str
+    backend_preference: str
+    prompt_strategy: dict[str, Any]
+    image: dict[str, Any] = field(default_factory=dict)
+    plugins: dict[str, Any] = field(default_factory=dict)
+    lora: dict[str, Any] = field(default_factory=dict)
+    publication: dict[str, Any] = field(default_factory=dict)
+    post_processing: list[dict[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "WorkflowRecipe":
+        """Validate and build a recipe from a JSON-compatible dictionary."""
+        required = {
+            "id",
+            "version",
+            "name",
+            "description",
+            "mode",
+            "backend_preference",
+            "prompt_strategy",
+            "publication",
+        }
+        missing = sorted(required - set(payload))
+        if missing:
+            raise ValueError(f"Recipe is missing required fields: {', '.join(missing)}")
+
+        recipe_id = str(payload["id"]).strip()
+        if not recipe_id:
+            raise ValueError("Recipe id must not be empty")
+
+        version = int(payload["version"])
+        if version < 1:
+            raise ValueError(f"Recipe {recipe_id} version must be >= 1")
+
+        mode = str(payload["mode"]).strip()
+        if mode not in ALLOWED_RECIPE_MODES:
+            raise ValueError(f"Recipe {recipe_id} has unsupported mode: {mode}")
+
+        prompt_strategy = payload["prompt_strategy"]
+        if not isinstance(prompt_strategy, dict):
+            raise ValueError(f"Recipe {recipe_id} prompt_strategy must be an object")
+        strategy_type = str(prompt_strategy.get("type", "")).strip()
+        if strategy_type not in ALLOWED_PROMPT_STRATEGIES:
+            raise ValueError(f"Recipe {recipe_id} has unsupported prompt strategy: {strategy_type}")
+        if strategy_type == "fixed" and not str(prompt_strategy.get("prompt", "")).strip():
+            raise ValueError(f"Recipe {recipe_id} fixed prompt strategy requires prompt")
+
+        image = _object_payload(payload, "image", recipe_id)
+        unknown_image_keys = sorted(set(image) - CONFIG_IMAGE_KEYS)
+        if unknown_image_keys:
+            raise ValueError(
+                f"Recipe {recipe_id} has unsupported image keys: {', '.join(unknown_image_keys)}"
+            )
+
+        return cls(
+            id=recipe_id,
+            version=version,
+            name=str(payload["name"]).strip(),
+            description=str(payload["description"]).strip(),
+            mode=mode,
+            backend_preference=str(payload["backend_preference"]).strip().lower(),
+            prompt_strategy=prompt_strategy,
+            image=image,
+            plugins=_object_payload(payload, "plugins", recipe_id),
+            lora=_object_payload(payload, "lora", recipe_id),
+            publication=_object_payload(payload, "publication", recipe_id),
+            post_processing=_post_processing_payload(payload, recipe_id),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible recipe payload."""
+        return {
+            "id": self.id,
+            "version": self.version,
+            "name": self.name,
+            "description": self.description,
+            "mode": self.mode,
+            "backend_preference": self.backend_preference,
+            "prompt_strategy": self.prompt_strategy,
+            "image": self.image,
+            "plugins": self.plugins,
+            "lora": self.lora,
+            "publication": self.publication,
+            "post_processing": self.post_processing,
+        }
+
+    def summary(self) -> dict[str, Any]:
+        """Return a compact recipe listing payload."""
+        return {
+            "id": self.id,
+            "version": self.version,
+            "name": self.name,
+            "description": self.description,
+            "mode": self.mode,
+            "backend_preference": self.backend_preference,
+        }
+
+    def config_overrides(self) -> dict[str, Any]:
+        """Return runtime config overrides expressed by this recipe."""
+        overrides: dict[str, Any] = {
+            "model": {"image_backend": self.backend_preference},
+            "image": dict(self.image),
+        }
+
+        if self.plugins:
+            overrides["plugins"] = dict(self.plugins)
+
+        if self.lora:
+            overrides["lora"] = dict(self.lora)
+
+        return overrides
+
+
+@dataclass(frozen=True)
+class ResolvedWorkflowRecipe:
+    """Recipe resolved into a concrete generation request shape."""
+
+    recipe: WorkflowRecipe
+    prompt: str | None
+    meta_prompt: str | None
+    seed: int | None
+    publication_state: str
+    metadata: dict[str, Any]
+    config_overrides: dict[str, Any]
+
+    def to_job_payload(self, client_request_id: str | None = None) -> dict[str, Any]:
+        """Return a JSON-compatible job creation payload."""
+        return {
+            "prompt": self.prompt,
+            "meta_prompt": self.meta_prompt,
+            "seed": self.seed,
+            "publication_state": self.publication_state,
+            "client_request_id": client_request_id,
+            "metadata": self.metadata,
+            "recipe_id": self.recipe.id,
+            "recipe_version": self.recipe.version,
+            "config_overrides": self.config_overrides,
+        }
+
+
+def list_workflow_recipes(recipe_dir: Path = BUILTIN_RECIPE_DIR) -> list[WorkflowRecipe]:
+    """Load all built-in workflow recipes."""
+    recipes = [load_workflow_recipe(path) for path in sorted(recipe_dir.glob("*.json"))]
+    return sorted(recipes, key=lambda item: item.id)
+
+
+def get_workflow_recipe(recipe_id: str, recipe_dir: Path = BUILTIN_RECIPE_DIR) -> WorkflowRecipe:
+    """Load one built-in workflow recipe by ID."""
+    normalized_id = recipe_id.strip()
+    for recipe in list_workflow_recipes(recipe_dir):
+        if recipe.id == normalized_id:
+            return recipe
+    raise KeyError(f"Unknown workflow recipe: {recipe_id}")
+
+
+def load_workflow_recipe(path: Path) -> WorkflowRecipe:
+    """Load and validate one recipe JSON file."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Recipe file {path} must contain a JSON object")
+    return WorkflowRecipe.from_dict(payload)
+
+
+def resolve_workflow_recipe(
+    recipe_id: str,
+    *,
+    prompt: str | None = None,
+    meta_prompt: str | None = None,
+    seed: int | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> ResolvedWorkflowRecipe:
+    """Resolve a recipe plus caller overrides into a generation request."""
+    recipe = get_workflow_recipe(recipe_id)
+    strategy = recipe.prompt_strategy
+    strategy_type = strategy["type"]
+
+    resolved_prompt = prompt
+    resolved_meta_prompt = meta_prompt
+    if resolved_prompt is None and strategy_type == "fixed":
+        resolved_prompt = str(strategy.get("prompt", "")).strip()
+    if resolved_prompt is None and resolved_meta_prompt is None:
+        recipe_meta_prompt = strategy.get("meta_prompt")
+        if recipe_meta_prompt:
+            resolved_meta_prompt = str(recipe_meta_prompt)
+
+    recipe_metadata = {
+        **(metadata or {}),
+        "recipe": {
+            "id": recipe.id,
+            "version": recipe.version,
+            "mode": recipe.mode,
+        },
+    }
+
+    return ResolvedWorkflowRecipe(
+        recipe=recipe,
+        prompt=resolved_prompt,
+        meta_prompt=resolved_meta_prompt,
+        seed=seed,
+        publication_state=str(recipe.publication.get("state", "draft")).strip() or "draft",
+        metadata=recipe_metadata,
+        config_overrides=recipe.config_overrides(),
+    )
+
+
+@contextmanager
+def apply_config_overrides(config: Config, overrides: dict[str, Any] | None) -> Iterator[None]:
+    """Temporarily apply recipe runtime overrides to a Config object and plugins."""
+    overrides = overrides or {}
+    if not overrides:
+        yield
+        return
+
+    image_values = {key: getattr(config.image, key) for key in CONFIG_IMAGE_KEYS}
+    model_values = {
+        "image_backend": config.model.image_backend,
+        "ollama_image_model": config.model.ollama_image_model,
+    }
+    lora_values = {
+        "enabled_loras": list(config.model.lora.enabled_loras),
+        "application_probability": config.model.lora.application_probability,
+    }
+    plugin_values = {
+        name: {"enabled": info.enabled, "order": info.order}
+        for name, info in plugin_manager.plugins.items()
+    }
+
+    try:
+        model_overrides = overrides.get("model") or {}
+        if "image_backend" in model_overrides:
+            config.model.image_backend = str(model_overrides["image_backend"]).lower()
+        if "ollama_image_model" in model_overrides:
+            config.model.ollama_image_model = str(model_overrides["ollama_image_model"]).strip()
+
+        image_overrides = overrides.get("image") or {}
+        for key in CONFIG_IMAGE_KEYS:
+            if key in image_overrides:
+                current_value = getattr(config.image, key)
+                value = image_overrides[key]
+                if isinstance(current_value, int):
+                    value = int(value)
+                elif isinstance(current_value, float):
+                    value = float(value)
+                setattr(config.image, key, value)
+
+        lora_overrides = overrides.get("lora") or {}
+        if "enabled_loras" in lora_overrides:
+            config.model.lora.enabled_loras = [
+                str(item).strip() for item in lora_overrides["enabled_loras"] if str(item).strip()
+            ]
+        if "application_probability" in lora_overrides:
+            config.model.lora.application_probability = float(
+                lora_overrides["application_probability"]
+            )
+
+        plugin_overrides = overrides.get("plugins") or {}
+        if "enabled" in plugin_overrides:
+            enabled = {str(item).strip() for item in plugin_overrides["enabled"]}
+            for name, info in plugin_manager.plugins.items():
+                info.enabled = name in enabled
+
+        yield
+    finally:
+        for key, value in image_values.items():
+            setattr(config.image, key, value)
+        config.model.image_backend = model_values["image_backend"]
+        config.model.ollama_image_model = model_values["ollama_image_model"]
+        config.model.lora.enabled_loras = lora_values["enabled_loras"]
+        config.model.lora.application_probability = lora_values["application_probability"]
+        for name, values in plugin_values.items():
+            if name in plugin_manager.plugins:
+                plugin_manager.plugins[name].enabled = values["enabled"]
+                plugin_manager.plugins[name].order = values["order"]
+
+
+def _object_payload(payload: dict[str, Any], key: str, recipe_id: str) -> dict[str, Any]:
+    value = payload.get(key, {})
+    if not isinstance(value, dict):
+        raise ValueError(f"Recipe {recipe_id} field {key} must be an object")
+    return dict(value)
+
+
+def _post_processing_payload(payload: dict[str, Any], recipe_id: str) -> list[dict[str, Any]]:
+    value = payload.get("post_processing", [])
+    if not isinstance(value, list):
+        raise ValueError(f"Recipe {recipe_id} field post_processing must be a list")
+    if not all(isinstance(item, dict) for item in value):
+        raise ValueError(f"Recipe {recipe_id} post_processing entries must be objects")
+    return [dict(item) for item in value]

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -45,7 +45,13 @@ from ..generators.factory import (
 )
 from ..generators.prompt_generator import PromptGenerator
 from ..plugins import ensure_initialized, plugin_manager
-from ..services import GenerationProgressEvent, GenerationServiceRequest, ImageGenService
+from ..services import (
+    GenerationProgressEvent,
+    GenerationServiceRequest,
+    ImageGenService,
+    apply_config_overrides,
+    resolve_workflow_recipe,
+)
 from .config import Config
 from .logging_config import setup_logging
 from .metrics import MetricsCollector
@@ -388,6 +394,11 @@ def generate(
         "--model",
         help="Override the image backend for this run (flux, ollama, zimage, qwen, small, turbo, smoke, mock)",
     ),
+    recipe: Optional[str] = typer.Option(
+        None,
+        "--recipe",
+        help="Run a built-in workflow recipe (for example text2img-default or mock-smoke)",
+    ),
     mock: bool = typer.Option(
         False,
         "--mock",
@@ -416,124 +427,151 @@ def generate(
                 transient=True,  # Hide finished tasks
             ) as progress:
                 try:
-                    # Update config with CLI options
-                    app.state.config.system.mps_use_fp16 = mps_use_fp16
+                    recipe_resolution = (
+                        resolve_workflow_recipe(recipe, prompt=prompt) if recipe else None
+                    )
+                    config_overrides = (
+                        recipe_resolution.config_overrides if recipe_resolution else {}
+                    )
+                    with apply_config_overrides(app.state.config, config_overrides):
+                        # Update config with CLI options
+                        app.state.config.system.mps_use_fp16 = mps_use_fp16
 
-                    resolved_backend = resolve_backend_with_overrides(
-                        backend_override=backend, mock=mock
-                    )
-                    validation_errors = validate_generation_config(
-                        app.state.config, resolved_backend
-                    )
-                    if validation_errors:
-                        for error in validation_errors:
-                            console.print(f"[red]Configuration error:[/red] {error}")
-                        raise typer.Exit(1)
+                        resolved_backend = resolve_backend_with_overrides(
+                            backend_override=backend, mock=mock
+                        )
+                        validation_errors = validate_generation_config(
+                            app.state.config, resolved_backend
+                        )
+                        if validation_errors:
+                            for error in validation_errors:
+                                console.print(f"[red]Configuration error:[/red] {error}")
+                            raise typer.Exit(1)
 
-                    # Initialize components
-                    init_task = progress.add_task(
-                        "[cyan]Initializing generation service...", total=None
-                    )
-                    if mock:
+                        # Initialize components
+                        init_task = progress.add_task(
+                            "[cyan]Initializing generation service...", total=None
+                        )
+                        if mock:
+                            console.print(
+                                "[yellow]Using mock image generator (no GPU required)[/yellow]"
+                            )
+                        if recipe_resolution:
+                            console.print(
+                                f"[cyan]Using workflow recipe:[/cyan] "
+                                f"{recipe_resolution.recipe.id}@{recipe_resolution.recipe.version}"
+                            )
+                        service = ImageGenService(
+                            app.state.config, output_dir=app.state.config.system.output_dir
+                        )
+                        metrics = MetricsCollector(app.state.config.system.log_dir / "metrics")
+                        progress.remove_task(init_task)
+
                         console.print(
-                            "[yellow]Using mock image generator (no GPU required)[/yellow]"
+                            f"[cyan]Using image backend:[/cyan] {resolved_backend} "
+                            f"(resolved: {resolved_backend}, "
+                            f"requested: {_requested_backend_name(app.state.config, backend, mock)})"
                         )
-                    service = ImageGenService(
-                        app.state.config, output_dir=app.state.config.system.output_dir
-                    )
-                    metrics = MetricsCollector(app.state.config.system.log_dir / "metrics")
-                    progress.remove_task(init_task)
 
-                    console.print(
-                        f"[cyan]Using image backend:[/cyan] {resolved_backend} "
-                        f"(resolved: {resolved_backend}, "
-                        f"requested: {_requested_backend_name(app.state.config, backend, mock)})"
-                    )
+                        # Start metrics collection
+                        metrics.start_batch()
 
-                    # Start metrics collection
-                    metrics.start_batch()
-
-                    generation_prompt = prompt
-                    if not prompt and interactive:
-                        prompt_gen = PromptGenerator(app.state.config)
-                        prompt_task = progress.add_task(
-                            "[cyan]Generating creative prompt...", total=None
+                        generation_prompt = (
+                            recipe_resolution.prompt if recipe_resolution else prompt
                         )
+                        generation_meta_prompt = (
+                            recipe_resolution.meta_prompt if recipe_resolution else None
+                        )
+                        generation_metadata = (
+                            recipe_resolution.metadata if recipe_resolution else {}
+                        )
+                        publication_state = (
+                            recipe_resolution.publication_state if recipe_resolution else "draft"
+                        )
+                        if not generation_prompt and interactive:
+                            prompt_gen = PromptGenerator(app.state.config)
+                            prompt_task = progress.add_task(
+                                "[cyan]Generating creative prompt...", total=None
+                            )
+                            try:
+                                generation_prompt = await prompt_gen.get_prompt_with_feedback()
+                            finally:
+                                progress.remove_task(prompt_task)
+                                prompt_gen.cleanup()
+
+                        # Generate image
+                        image_task = progress.add_task("[cyan]Generating image...", total=None)
                         try:
-                            generation_prompt = await prompt_gen.get_prompt_with_feedback()
-                        finally:
-                            progress.remove_task(prompt_task)
-                            prompt_gen.cleanup()
-
-                    # Generate image
-                    image_task = progress.add_task("[cyan]Generating image...", total=None)
-                    try:
-                        with temporary_backend_override(app.state.config, backend, mock):
-                            result = await await_with_generation_status(
-                                service.generate(
-                                    GenerationServiceRequest(
-                                        prompt=generation_prompt,
-                                        cleanup=True,
+                            with temporary_backend_override(app.state.config, backend, mock):
+                                result = await await_with_generation_status(
+                                    service.generate(
+                                        GenerationServiceRequest(
+                                            prompt=generation_prompt,
+                                            meta_prompt=generation_meta_prompt,
+                                            publication_state=publication_state,
+                                            metadata=generation_metadata,
+                                            cleanup=True,
+                                        ),
+                                        callback=print_generation_service_event,
                                     ),
-                                    callback=print_generation_service_event,
-                                ),
-                                backend_name=resolved_backend,
-                                phase="Image generation",
-                                output_path=None,
+                                    backend_name=resolved_backend,
+                                    phase="Image generation",
+                                    output_path=None,
+                                )
+                        except Exception as e:
+                            console.print(
+                                f"[red]Generation failed[/red]\n"
+                                f"Backend: {resolved_backend}\n"
+                                "Phase: image generation\n"
+                                f"Error: {str(e)}"
                             )
-                    except Exception as e:
+                            raise typer.Exit(1) from e
+                        finally:
+                            progress.remove_task(image_task)
+
                         console.print(
-                            f"[red]Generation failed[/red]\n"
-                            f"Backend: {resolved_backend}\n"
-                            "Phase: image generation\n"
-                            f"Error: {str(e)}"
+                            f"[cyan]Model/provider:[/cyan] {result.model_name}; "
+                            f"backend: {result.backend}"
                         )
-                        raise typer.Exit(1) from e
-                    finally:
-                        progress.remove_task(image_task)
-
-                    console.print(
-                        f"[cyan]Model/provider:[/cyan] {result.model_name}; "
-                        f"backend: {result.backend}"
-                    )
-                    console.print(
-                        f"[green]Image received and saved[/green] ({result.generation_time:.1f}s)"
-                    )
-
-                    # Show success message with details
-                    console.print(
-                        Panel(
-                            f"[bold green]Image generated successfully![/bold green]\n\n"
-                            f"Saved to: {result.image_path}\n"
-                            f"Prompt saved to: {result.image_path.with_suffix('.txt')}\n\n"
-                            f"[dim]Model: {result.model_name}\n"
-                            f"Backend: {result.backend}\n"
-                            f"Time: {result.generation_time:.1f}s\n"
-                            f"Prompt: {result.prompt}[/dim]",
-                            title="Success",
-                            border_style="green",
+                        console.print(
+                            f"[green]Image received and saved[/green] "
+                            f"({result.generation_time:.1f}s)"
                         )
-                    )
-                    if summary_json:
-                        print(
-                            json.dumps(
-                                {
-                                    "image_path": str(result.image_path),
-                                    "prompt_path": str(result.image_path.with_suffix(".txt")),
-                                    "relative_image_path": result.relative_image_path,
-                                    "prompt": result.prompt,
-                                    "backend": result.backend,
-                                    "model": result.model_name,
-                                    "generation_time": result.generation_time,
-                                    "metadata": result.metadata,
-                                    "created_at": result.created_at,
-                                },
-                                sort_keys=True,
+
+                        # Show success message with details
+                        console.print(
+                            Panel(
+                                f"[bold green]Image generated successfully![/bold green]\n\n"
+                                f"Saved to: {result.image_path}\n"
+                                f"Prompt saved to: {result.image_path.with_suffix('.txt')}\n\n"
+                                f"[dim]Model: {result.model_name}\n"
+                                f"Backend: {result.backend}\n"
+                                f"Time: {result.generation_time:.1f}s\n"
+                                f"Prompt: {result.prompt}[/dim]",
+                                title="Success",
+                                border_style="green",
                             )
                         )
+                        if summary_json:
+                            print(
+                                json.dumps(
+                                    {
+                                        "image_path": str(result.image_path),
+                                        "prompt_path": str(result.image_path.with_suffix(".txt")),
+                                        "relative_image_path": result.relative_image_path,
+                                        "prompt": result.prompt,
+                                        "backend": result.backend,
+                                        "model": result.model_name,
+                                        "generation_time": result.generation_time,
+                                        "metadata": result.metadata,
+                                        "created_at": result.created_at,
+                                    },
+                                    sort_keys=True,
+                                )
+                            )
 
-                    # End metrics collection
-                    metrics.end_batch()
+                        # End metrics collection
+                        metrics.end_batch()
 
                 except typer.Exit:
                     raise

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -293,6 +293,57 @@ def test_set_generation_config_updates_backend_and_loras(client):
         api_config.model.lora.application_probability = original_probability
 
 
+def test_recipes_endpoints_list_and_resolve_builtin_recipe(client):
+    """Recipe APIs should expose built-ins and resolve them into job payloads."""
+    response = client.get("/api/recipes")
+    assert response.status_code == 200
+    recipe_ids = {recipe["id"] for recipe in response.json()["recipes"]}
+    assert "mock-smoke" in recipe_ids
+
+    detail_response = client.get("/api/recipes/mock-smoke")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["backend_preference"] == "mock"
+
+    resolve_response = client.post(
+        "/api/recipes/mock-smoke/resolve",
+        json={"seed": 22, "client_request_id": "req-resolve-1"},
+    )
+    assert resolve_response.status_code == 200
+    resolved = resolve_response.json()["job_request"]
+    assert resolved["prompt"] == "DreamGen mock smoke test image"
+    assert resolved["seed"] == 22
+    assert resolved["recipe_id"] == "mock-smoke"
+    assert resolved["recipe_version"] == 1
+    assert resolved["metadata"]["recipe"]["id"] == "mock-smoke"
+    assert resolved["config_overrides"]["model"]["image_backend"] == "mock"
+
+
+def test_jobs_endpoint_runs_recipe_and_persists_recipe_metadata(client):
+    """Generation jobs created from recipes should persist recipe ID/version."""
+    response = client.post(
+        "/api/jobs",
+        json={
+            "recipe_id": "mock-smoke",
+            "seed": 33,
+            "client_request_id": "req-job-recipe-1",
+        },
+    )
+    assert response.status_code == 200
+    created = response.json()
+    assert created["request"]["recipe_id"] == "mock-smoke"
+    assert created["request"]["recipe_version"] == 1
+    assert created["request"]["config_overrides"]["model"]["image_backend"] == "mock"
+
+    job_response = client.get(f"/api/jobs/{created['id']}")
+    assert job_response.status_code == 200
+    job = job_response.json()
+    assert job["status"] == "succeeded"
+    assert job["request"]["recipe_id"] == "mock-smoke"
+    assert job["metadata"]["recipe"]["id"] == "mock-smoke"
+    assert job["metadata"]["recipe"]["version"] == 1
+    assert job["metadata"]["seed"] == 33
+
+
 def test_ollama_models_endpoint_includes_capabilities_and_resolved_models(client, monkeypatch):
     """The Ollama models endpoint should expose capabilities plus resolved prompt/image selections."""
     original_prompt_model = api_config.model.ollama_model

--- a/tests/test_cli_generation_progress.py
+++ b/tests/test_cli_generation_progress.py
@@ -69,6 +69,27 @@ def test_generate_summary_json_prints_machine_readable_result(tmp_path, monkeypa
     assert summary["relative_image_path"].startswith("/images/")
 
 
+def test_generate_accepts_workflow_recipe(tmp_path, monkeypatch):
+    """CLI generation should resolve built-in recipes into generation metadata."""
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+
+    result = runner.invoke(
+        app,
+        ["generate", "--recipe", "mock-smoke", "--summary-json"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Using workflow recipe:" in result.stdout
+    summary_line = next(
+        line for line in reversed(result.stdout.splitlines()) if line.startswith("{")
+    )
+    summary = json.loads(summary_line)
+    assert summary["backend"] == "mock"
+    assert summary["prompt"] == "DreamGen mock smoke test image"
+    assert summary["metadata"]["recipe"]["id"] == "mock-smoke"
+    assert summary["metadata"]["recipe"]["version"] == 1
+
+
 @pytest.mark.asyncio
 async def test_generation_status_emits_heartbeat_for_slow_operation(monkeypatch):
     """Long-running generation should produce periodic visible waiting output."""

--- a/tests/test_workflow_recipes.py
+++ b/tests/test_workflow_recipes.py
@@ -1,0 +1,84 @@
+"""Tests for workflow recipe loading and resolution."""
+
+from unittest.mock import MagicMock
+
+from src.plugins import plugin_manager
+from src.services import (
+    apply_config_overrides,
+    get_workflow_recipe,
+    list_workflow_recipes,
+    resolve_workflow_recipe,
+)
+
+
+def test_builtin_workflow_recipes_load_and_validate():
+    recipes = list_workflow_recipes()
+
+    recipe_ids = {recipe.id for recipe in recipes}
+    assert {
+        "text2img-default",
+        "zimage-lora",
+        "mock-smoke",
+        "publish-candidate",
+    }.issubset(recipe_ids)
+
+    mock_recipe = get_workflow_recipe("mock-smoke")
+    assert mock_recipe.version == 1
+    assert mock_recipe.backend_preference == "mock"
+    assert mock_recipe.prompt_strategy["type"] == "fixed"
+
+
+def test_resolve_workflow_recipe_returns_job_payload_with_metadata():
+    resolution = resolve_workflow_recipe(
+        "mock-smoke",
+        seed=12,
+        metadata={"client": "test"},
+    )
+
+    payload = resolution.to_job_payload(client_request_id="req-recipe-1")
+    assert payload["prompt"] == "DreamGen mock smoke test image"
+    assert payload["seed"] == 12
+    assert payload["client_request_id"] == "req-recipe-1"
+    assert payload["recipe_id"] == "mock-smoke"
+    assert payload["recipe_version"] == 1
+    assert payload["metadata"]["recipe"]["id"] == "mock-smoke"
+    assert payload["config_overrides"]["model"]["image_backend"] == "mock"
+    assert payload["config_overrides"]["image"]["width"] == 512
+
+
+def test_apply_config_overrides_temporarily_updates_runtime_config():
+    config = MagicMock()
+    config.model.image_backend = "auto"
+    config.model.ollama_image_model = ""
+    config.model.lora.enabled_loras = ["existing"]
+    config.model.lora.application_probability = 0.5
+    config.image.width = 1360
+    config.image.height = 768
+    config.image.num_inference_steps = 4
+    config.image.guidance_scale = 0.0
+    config.image.true_cfg_scale = 1.0
+
+    original_plugins = {name: info.enabled for name, info in plugin_manager.plugins.items()}
+
+    with apply_config_overrides(
+        config,
+        {
+            "model": {"image_backend": "mock"},
+            "image": {"width": 512, "height": 512},
+            "lora": {"enabled_loras": [], "application_probability": 0.0},
+            "plugins": {"enabled": []},
+        },
+    ):
+        assert config.model.image_backend == "mock"
+        assert config.image.width == 512
+        assert config.image.height == 512
+        assert config.model.lora.enabled_loras == []
+        assert config.model.lora.application_probability == 0.0
+        assert all(not info.enabled for info in plugin_manager.plugins.values())
+
+    assert config.model.image_backend == "auto"
+    assert config.image.width == 1360
+    assert config.image.height == 768
+    assert config.model.lora.enabled_loras == ["existing"]
+    assert config.model.lora.application_probability == 0.5
+    assert {name: info.enabled for name, info in plugin_manager.plugins.items()} == original_plugins


### PR DESCRIPTION
## Summary

Adds the workflow recipe foundation for #40 as a stacked PR on top of #55 / #39.

- Defines a versioned workflow recipe model with validation and runtime config override application.
- Adds built-in recipe JSON files for `text2img-default`, `zimage-lora`, `mock-smoke`, and `publish-candidate`.
- Adds API endpoints to list recipes, fetch recipe details, and resolve a recipe into a durable job payload.
- Adds `recipe_id` support to `/api/generate`, `/api/jobs`, and `dreamgen generate --recipe`.
- Persists recipe ID/version into job request payloads and generated metadata.

## Stack

Base branch is `codex/durable-generation-jobs` because recipe persistence into job records depends on the durable jobs work in PR #55. Once #55 lands, this can be retargeted to `main`.

## Validation

- `uv run pytest tests/test_workflow_recipes.py tests/test_generation_jobs.py tests/test_image_generation_service.py tests/test_api.py tests/test_cli_generation_progress.py` -> `39 passed`
- `uv run pytest tests/test_workflow_recipes.py tests/test_generation_jobs.py tests/test_image_generation_service.py tests/test_api.py::test_recipes_endpoints_list_and_resolve_builtin_recipe tests/test_api.py::test_jobs_endpoint_runs_recipe_and_persists_recipe_metadata tests/test_api.py::test_generate_endpoint_records_durable_job tests/test_cli_generation_progress.py::test_generate_accepts_workflow_recipe` -> `12 passed`
- `uv run pytest tests/ -k "not generate_without_prompt"` -> `85 passed, 1 skipped, 1 deselected`

A full `uv run pytest tests/` passed once before the final small error-path/metadata tweak (`86 passed, 1 skipped`), but a later full rerun stalled in the external no-prompt generation test, so the final broad run excludes that external prompt-generation path. FastAPI still emits existing `on_event` deprecation warnings during tests.