### PR TITLE
[codex] Add generation queue history UI

### DIFF
--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -17,12 +17,14 @@ import {
 import { AnimatePresence, motion } from "framer-motion";
 
 import Gallery from "@/components/Gallery";
+import QueueHistory from "@/components/QueueHistory";
 import Settings from "@/components/Settings";
 import TaskProgress from "@/components/TaskProgress";
 import {
   API_BASE,
   api,
   GenerationEvent,
+  GenerationJob,
   GenerateResponse,
   GenerationConfig,
   PluginInfo,
@@ -136,6 +138,8 @@ export default function Home() {
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
   const [generationConfig, setGenerationConfig] = useState<GenerationConfig | null>(null);
   const [generationEvents, setGenerationEvents] = useState<GenerationEvent[]>([]);
+  const [generationJobs, setGenerationJobs] = useState<GenerationJob[]>([]);
+  const [isJobsLoading, setIsJobsLoading] = useState(false);
   const [nextRunAt, setNextRunAt] = useState<Date | null>(null);
   const [, setClockTick] = useState(Date.now());
   const [sessionCount, setSessionCount] = useState(0);
@@ -229,6 +233,20 @@ export default function Home() {
     }
   }, []);
 
+  const loadGenerationJobs = useCallback(async () => {
+    setIsJobsLoading(true);
+    try {
+      const response = await api.getGenerationJobs(12);
+      startTransition(() => {
+        setGenerationJobs(response.jobs);
+      });
+    } catch (error) {
+      console.error("Failed to load generation jobs:", error);
+    } finally {
+      setIsJobsLoading(false);
+    }
+  }, []);
+
   runGenerationRef.current = async (source: "manual" | "loop") => {
     if (isGeneratingRef.current) return;
 
@@ -279,6 +297,7 @@ export default function Home() {
         loadRecentImages(),
         loadDashboardControls(),
         loadGenerationEvents(),
+        loadGenerationJobs(),
         api.getStatus().then(setStatus),
       ]);
     } catch (error) {
@@ -328,6 +347,7 @@ export default function Home() {
     loadRecentImages();
     loadDashboardControls();
     loadGenerationEvents();
+    loadGenerationJobs();
 
     const unsubscribe = api.subscribeWebSocket((data) => {
       const nextProgress = getTaskProgressUpdate(
@@ -349,9 +369,11 @@ export default function Home() {
       } else if (msg.type === "generation_completed") {
         addLog(`Saved ${String(msg.image_path ?? "image")}.`);
         void loadGenerationEvents();
+        void loadGenerationJobs();
       } else if (msg.type === "generation_error") {
         addLog(`Backend error: ${String(msg.error ?? "unknown")}`, "error");
         void loadGenerationEvents();
+        void loadGenerationJobs();
       }
     });
 
@@ -361,7 +383,20 @@ export default function Home() {
         clearTimeout(generationResetTimeoutRef.current);
       }
     };
-  }, [loadDashboardControls, loadGenerationEvents, loadRecentImages]);
+  }, [loadDashboardControls, loadGenerationEvents, loadGenerationJobs, loadRecentImages]);
+
+  useEffect(() => {
+    const hasActiveJobs = generationJobs.some(
+      (job) => job.status === "queued" || job.status === "running"
+    );
+    if (!hasActiveJobs) return;
+
+    const intervalId = window.setInterval(() => {
+      void loadGenerationJobs();
+    }, 4000);
+
+    return () => window.clearInterval(intervalId);
+  }, [generationJobs, loadGenerationJobs]);
 
   useEffect(() => {
     if (!isGenerating || !generationProgress || generationProgress.progress >= 96) return;
@@ -435,6 +470,34 @@ export default function Home() {
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
       addLog(`Failed to change backend: ${message}`, "error");
+    }
+  };
+
+  const copyJobPrompt = (prompt: string) => {
+    setPromptSeed(prompt);
+    promptSeedRef.current = prompt;
+    addLog("Copied job prompt into the generator.");
+  };
+
+  const rerunJob = async (job: GenerationJob) => {
+    try {
+      const prompt = job.prompt || job.request.prompt || undefined;
+      const queued = await api.createGenerationJob({
+        prompt,
+        meta_prompt: prompt ? undefined : job.request.meta_prompt ?? undefined,
+        seed: job.request.seed ?? undefined,
+        recipe_id: job.request.recipe_id ?? undefined,
+        publication_state: job.request.publication_state ?? "draft",
+        metadata: {
+          ...(job.request.metadata ?? {}),
+          rerun_of_job_id: job.id,
+        },
+      });
+      addLog(`Queued rerun ${queued.id.slice(0, 8)}.`);
+      await loadGenerationJobs();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      addLog(`Failed to queue rerun: ${message}`, "error");
     }
   };
 
@@ -861,6 +924,14 @@ export default function Home() {
                       </div>
 
                     </div>
+
+                    <QueueHistory
+                      jobs={generationJobs}
+                      isLoading={isJobsLoading}
+                      onRefresh={() => void loadGenerationJobs()}
+                      onCopyPrompt={copyJobPrompt}
+                      onRerun={(job) => void rerunJob(job)}
+                    />
 
                     <div className="ambient-panel rounded-[1.75rem] border border-border/80 p-5">
                       <div className="mb-4 flex items-center justify-between gap-3">

--- a/web-ui/components/QueueHistory.tsx
+++ b/web-ui/components/QueueHistory.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { Clock3, Copy, Play, RefreshCcw, RotateCcw, XCircle } from "lucide-react";
+
+import { API_BASE, type GenerationJob } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+interface QueueHistoryProps {
+  jobs: GenerationJob[];
+  isLoading?: boolean;
+  onRefresh: () => void;
+  onCopyPrompt: (prompt: string) => void;
+  onRerun: (job: GenerationJob) => void;
+}
+
+const STATUS_STYLES: Record<GenerationJob["status"], string> = {
+  queued: "border-amber-400/35 bg-amber-400/10 text-amber-200",
+  running: "border-primary/40 bg-primary/12 text-primary",
+  succeeded: "border-emerald-400/35 bg-emerald-400/10 text-emerald-200",
+  failed: "border-destructive/40 bg-destructive/10 text-destructive",
+  cancelled: "border-muted-foreground/30 bg-muted/60 text-muted-foreground",
+};
+
+const isActiveJob = (job: GenerationJob) => job.status === "queued" || job.status === "running";
+
+const formatTime = (value?: string | null) => {
+  if (!value) return "pending";
+  return new Date(value).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+};
+
+const jobPrompt = (job: GenerationJob) => job.prompt || job.request.prompt || "";
+
+const truncate = (value: string, max = 86) =>
+  value.length > max ? `${value.slice(0, max).trim()}...` : value;
+
+export default function QueueHistory({
+  jobs,
+  isLoading = false,
+  onRefresh,
+  onCopyPrompt,
+  onRerun,
+}: QueueHistoryProps) {
+  const activeJobs = jobs.filter(isActiveJob);
+  const recentJobs = jobs.filter((job) => !isActiveJob(job)).slice(0, 5);
+
+  return (
+    <div className="ambient-panel rounded-[1.75rem] border border-border/80 p-5">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+            Queue
+          </div>
+          <h2 className="mt-1 text-lg font-semibold text-foreground">Jobs and reruns</h2>
+        </div>
+        <button
+          onClick={onRefresh}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 text-muted-foreground transition hover:border-primary/40 hover:text-foreground"
+          title="Refresh jobs"
+        >
+          <RefreshCcw className={cn("h-4 w-4", isLoading && "animate-spin")} />
+        </button>
+      </div>
+
+      <div className="grid gap-3">
+        <div className="rounded-2xl border border-border/60 bg-background/78 px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <Clock3 className="h-4 w-4 text-primary" />
+              {activeJobs.length} active
+            </div>
+            <span className="text-xs text-muted-foreground">{jobs.length} loaded</span>
+          </div>
+          {activeJobs.length > 0 ? (
+            <div className="mt-3 space-y-2">
+              {activeJobs.map((job) => (
+                <div key={job.id} className="space-y-2">
+                  <div className="flex items-center justify-between gap-3 text-xs">
+                    <span className="truncate text-foreground">
+                      {truncate(jobPrompt(job) || job.request.meta_prompt || "Generated prompt job", 58)}
+                    </span>
+                    <span className="shrink-0 text-muted-foreground">{job.progress}%</span>
+                  </div>
+                  <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-primary transition-[width] duration-500"
+                      style={{ width: `${Math.max(4, Math.min(100, job.progress))}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-2 text-sm leading-6 text-muted-foreground">
+              No queued or running jobs.
+            </div>
+          )}
+        </div>
+
+        {recentJobs.length > 0 ? (
+          <div className="space-y-3">
+            {recentJobs.map((job) => {
+              const prompt = jobPrompt(job);
+              const imagePath = job.relative_image_path;
+              return (
+                <div
+                  key={job.id}
+                  className="rounded-2xl border border-border/60 bg-background/78 p-3"
+                >
+                  <div className="flex gap-3">
+                    {imagePath ? (
+                      // Backend-served generated files are not routed through Next image optimization.
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={`${API_BASE}${imagePath}`}
+                        alt="Generated job artifact"
+                        className="h-14 w-14 shrink-0 rounded-xl object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl border border-border/60 bg-muted/50">
+                        <XCircle className="h-5 w-5 text-muted-foreground" />
+                      </div>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center justify-between gap-2">
+                        <span
+                          className={cn(
+                            "rounded-full border px-2 py-0.5 text-[11px] capitalize",
+                            STATUS_STYLES[job.status]
+                          )}
+                        >
+                          {job.status}
+                        </span>
+                        <span className="shrink-0 text-[11px] text-muted-foreground">
+                          {formatTime(job.completed_at ?? job.updated_at)}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-sm leading-6 text-foreground">
+                        {truncate(prompt || job.request.meta_prompt || job.error || "No prompt recorded")}
+                      </p>
+                      <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+                        <span>{job.backend ?? "backend pending"}</span>
+                        {job.request.seed !== null && job.request.seed !== undefined ? (
+                          <span>seed {job.request.seed}</span>
+                        ) : null}
+                        {job.request.recipe_id ? <span>{job.request.recipe_id}</span> : null}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="mt-3 grid grid-cols-2 gap-2">
+                    <button
+                      onClick={() => onCopyPrompt(prompt)}
+                      disabled={!prompt}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl border border-border/70 px-3 py-2 text-xs text-muted-foreground transition hover:border-primary/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                      Copy prompt
+                    </button>
+                    <button
+                      onClick={() => onRerun(job)}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-primary px-3 py-2 text-xs text-primary-foreground transition hover:opacity-95"
+                    >
+                      {job.status === "failed" ? (
+                        <Play className="h-3.5 w-3.5" />
+                      ) : (
+                        <RotateCcw className="h-3.5 w-3.5" />
+                      )}
+                      Rerun
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-border/60 bg-background/78 px-4 py-8 text-center text-sm text-muted-foreground">
+            Completed jobs will appear here after generation.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -16,6 +16,7 @@ export interface GenerateRequest {
   use_mock?: boolean;
   enable_plugins?: boolean;
   seed?: number;
+  recipe_id?: string;
   client_request_id?: string;
 }
 
@@ -160,6 +161,56 @@ export interface GenerationEventsResponse {
   limit: number;
 }
 
+export type GenerationJobStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+
+export interface GenerationJobRequest {
+  prompt?: string | null;
+  meta_prompt?: string | null;
+  seed?: number | null;
+  publication_state?: string;
+  metadata?: Record<string, unknown>;
+  recipe_id?: string | null;
+  recipe_version?: number | null;
+  config_overrides?: Record<string, unknown>;
+}
+
+export interface GenerationJob {
+  id: string;
+  status: GenerationJobStatus;
+  request: GenerationJobRequest;
+  client_request_id?: string | null;
+  created_at: string;
+  updated_at: string;
+  started_at?: string | null;
+  completed_at?: string | null;
+  progress: number;
+  prompt?: string | null;
+  backend?: string | null;
+  model_name?: string | null;
+  image_path?: string | null;
+  relative_image_path?: string | null;
+  generation_time?: number | null;
+  error?: string | null;
+  attempts: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface GenerationJobsResponse {
+  jobs: GenerationJob[];
+  limit: number;
+  offset: number;
+}
+
+export interface CreateGenerationJobRequest {
+  prompt?: string;
+  meta_prompt?: string;
+  seed?: number;
+  recipe_id?: string;
+  publication_state?: string;
+  client_request_id?: string;
+  metadata?: Record<string, unknown>;
+}
+
 export type PublicationState = 'draft' | 'published' | 'hidden' | 'featured' | 'rejected';
 
 export interface GalleryPublication {
@@ -281,6 +332,34 @@ export class ImageGenAPI {
   async getGenerationEvents(limit: number = 25): Promise<GenerationEventsResponse> {
     const response = await fetch(`${this.baseUrl}/api/generation/events?limit=${limit}`);
     if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get generation events'));
+    return response.json();
+  }
+
+  async getGenerationJobs(
+    limit: number = 12,
+    offset: number = 0,
+    status?: GenerationJobStatus
+  ): Promise<GenerationJobsResponse> {
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+    if (status) params.set('status', status);
+
+    const response = await fetch(`${this.baseUrl}/api/jobs?${params.toString()}`);
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get generation jobs'));
+    return response.json();
+  }
+
+  async createGenerationJob(request: CreateGenerationJobRequest): Promise<GenerationJob> {
+    const response = await fetch(`${this.baseUrl}/api/jobs`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+    });
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to create generation job'));
     return response.json();
   }
 


### PR DESCRIPTION
## Summary

Adds the first operator queue/history surface for #41 as a stacked PR on top of #56.

- Extends the frontend API client with durable generation job types plus list/create methods.
- Adds a `QueueHistory` dashboard panel showing active queued/running jobs and recent completed/failed jobs.
- Adds copy-prompt and rerun actions based on persisted job request data, including recipe-aware reruns when available.
- Polls active jobs and refreshes job history on generation completion/error WebSocket events.

## Why this feature

I reviewed the open issue chain and did a quick external UX scan. Modern image-generation workflows strongly emphasize queue/history and reusing prior generation settings. ComfyUI documents queue/history mechanics for generated outputs, and A1111-style workflows expose reuse actions such as sending prior generation parameters back into another run. That maps directly to #41 and builds on the durable jobs and recipe stack already in PRs #55 and #56.

## Stack

Base branch is `codex/workflow-recipes`, because this UI benefits from recipe-aware job request data from #56. Once #55 and #56 land, this can be retargeted forward.

## Validation

- `npx tsc --noEmit` -> passed
- `npm run build` -> blocked by `next/font` Google Fonts fetch timeout for `JetBrains Mono` and `Space Grotesk`, not by TypeScript
- In-app browser check at `http://127.0.0.1:7860` verified the dashboard renders and the queue/history panel appears without obvious layout overlap

Note: `npm ci` installed frontend dependencies locally for validation; `node_modules` remains ignored.