### PR TITLE
[codex] Add experiment traceability controls

### DIFF
--- a/host-image/package-lock.json
+++ b/host-image/package-lock.json
@@ -41,17 +41,17 @@
 			}
 		},
 		"node_modules/@cloudflare/vitest-pool-workers": {
-			"version": "0.16.10",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.10.tgz",
-			"integrity": "sha512-cHYJ67zi+L4o2Ped8DCfRv0kWl/VNaUUicl1JStxoMsw+32WxExAlYYlAjNludTN6F5y0KScLXmXma2WoTLMvw==",
+			"version": "0.16.15",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.15.tgz",
+			"integrity": "sha512-R0kZhIm4uSxOeTWPHY9xYIFPGRBEHPzl/n9BbHZSY/gk0n16uDU7T1JZe372oTF+diXG1uVBWqiiRc7Hxstdow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cjs-module-lexer": "^1.2.3",
+				"cjs-module-lexer": "1.2.3",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260526.0",
-				"wrangler": "4.95.0",
-				"zod": "^3.25.76"
+				"miniflare": "4.20260611.0",
+				"wrangler": "4.100.0",
+				"zod": "3.25.76"
 			},
 			"peerDependencies": {
 				"@vitest/runner": "^4.1.0",
@@ -60,9 +60,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260526.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260526.1.tgz",
-			"integrity": "sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==",
+			"version": "1.20260611.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260611.1.tgz",
+			"integrity": "sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA==",
 			"cpu": [
 				"x64"
 			],
@@ -77,9 +77,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260526.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260526.1.tgz",
-			"integrity": "sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==",
+			"version": "1.20260611.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260611.1.tgz",
+			"integrity": "sha512-yBbVXvbZyltR3I7NJdC4C4ItkItjZSiabcA/3HzEWOUQjLVKFqRh4so6ToHr70VCYh8VGeR8EDZL23igLhXqFQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -94,9 +94,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260526.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260526.1.tgz",
-			"integrity": "sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==",
+			"version": "1.20260611.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260611.1.tgz",
+			"integrity": "sha512-PfNjpxOlaIgZFYuhD7+neEEewCN2Ud993wEEN0fmbtSOax1AK53LGqmXUDvFhnbkHxJLFAxYCSNISW8QbzaAIg==",
 			"cpu": [
 				"x64"
 			],
@@ -111,9 +111,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260526.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260526.1.tgz",
-			"integrity": "sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==",
+			"version": "1.20260611.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260611.1.tgz",
+			"integrity": "sha512-GEp4XbuIKjlF8pakqXcUDJfKiJosD/Q7S83J0d+r+z9XIlYGfF3ntm08e2aiF5TFTwp3fnG4yMoPUAKNhNJpvQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -128,9 +128,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260526.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260526.1.tgz",
-			"integrity": "sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==",
+			"version": "1.20260611.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260611.1.tgz",
+			"integrity": "sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw==",
 			"cpu": [
 				"x64"
 			],
@@ -170,9 +170,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -192,9 +192,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -209,9 +209,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
 			"cpu": [
 				"arm"
 			],
@@ -226,9 +226,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
 			"cpu": [
 				"arm64"
 			],
@@ -243,9 +243,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
 			"cpu": [
 				"x64"
 			],
@@ -260,9 +260,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -277,9 +277,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
 			"cpu": [
 				"x64"
 			],
@@ -294,9 +294,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
 			"cpu": [
 				"arm64"
 			],
@@ -311,9 +311,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -328,9 +328,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
 			"cpu": [
 				"arm"
 			],
@@ -345,9 +345,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -362,9 +362,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
 			"cpu": [
 				"ia32"
 			],
@@ -379,9 +379,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
 			"cpu": [
 				"loong64"
 			],
@@ -396,9 +396,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -413,9 +413,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -430,9 +430,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -447,9 +447,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
 			"cpu": [
 				"s390x"
 			],
@@ -464,9 +464,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
 			"cpu": [
 				"x64"
 			],
@@ -481,9 +481,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
 			"cpu": [
 				"arm64"
 			],
@@ -498,9 +498,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
 			"cpu": [
 				"x64"
 			],
@@ -515,9 +515,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -532,9 +532,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
 			"cpu": [
 				"x64"
 			],
@@ -549,9 +549,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -566,9 +566,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
 			"cpu": [
 				"x64"
 			],
@@ -583,9 +583,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -600,9 +600,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
 			"cpu": [
 				"ia32"
 			],
@@ -617,9 +617,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
 			"cpu": [
 				"x64"
 			],
@@ -1152,14 +1152,14 @@
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
+				"@tybys/wasm-util": "^0.10.2"
 			},
 			"funding": {
 				"type": "github",
@@ -1171,9 +1171,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-			"integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+			"version": "0.133.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+			"integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1210,9 +1210,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+			"integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1227,9 +1227,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+			"integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1244,9 +1244,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+			"integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
 			"cpu": [
 				"x64"
 			],
@@ -1261,9 +1261,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+			"integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
 			"cpu": [
 				"x64"
 			],
@@ -1278,9 +1278,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-			"integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+			"integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
 			"cpu": [
 				"arm"
 			],
@@ -1295,9 +1295,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+			"integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1312,9 +1312,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+			"integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1329,9 +1329,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+			"integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1346,9 +1346,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+			"integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
 			"cpu": [
 				"s390x"
 			],
@@ -1363,9 +1363,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+			"integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
 			"cpu": [
 				"x64"
 			],
@@ -1380,9 +1380,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+			"integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
 			"cpu": [
 				"x64"
 			],
@@ -1397,9 +1397,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+			"integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1414,9 +1414,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-			"integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+			"integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
 			"cpu": [
 				"wasm32"
 			],
@@ -1432,10 +1432,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+			"integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1450,9 +1461,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+			"integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
 			"cpu": [
 				"x64"
 			],
@@ -1467,9 +1478,9 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-			"integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1487,9 +1498,9 @@
 			}
 		},
 		"node_modules/@speed-highlight/core": {
-			"version": "1.2.15",
-			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
-			"integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+			"version": "1.2.17",
+			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+			"integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -1501,9 +1512,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1530,23 +1541,23 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-			"integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+			"integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.5",
-				"@vitest/utils": "4.1.5",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1555,13 +1566,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-			"integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+			"integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.5",
+				"@vitest/spy": "4.1.9",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -1582,9 +1593,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-			"integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+			"integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1595,13 +1606,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-			"integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+			"integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.5",
+				"@vitest/utils": "4.1.9",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -1609,14 +1620,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-			"integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+			"integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.5",
-				"@vitest/utils": "4.1.5",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -1625,9 +1636,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-			"integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+			"integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1635,13 +1646,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-			"integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+			"integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.5",
+				"@vitest/pretty-format": "4.1.9",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1677,9 +1688,9 @@
 			}
 		},
 		"node_modules/cjs-module-lexer": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1732,9 +1743,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -1745,32 +1756,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.3",
-				"@esbuild/android-arm": "0.27.3",
-				"@esbuild/android-arm64": "0.27.3",
-				"@esbuild/android-x64": "0.27.3",
-				"@esbuild/darwin-arm64": "0.27.3",
-				"@esbuild/darwin-x64": "0.27.3",
-				"@esbuild/freebsd-arm64": "0.27.3",
-				"@esbuild/freebsd-x64": "0.27.3",
-				"@esbuild/linux-arm": "0.27.3",
-				"@esbuild/linux-arm64": "0.27.3",
-				"@esbuild/linux-ia32": "0.27.3",
-				"@esbuild/linux-loong64": "0.27.3",
-				"@esbuild/linux-mips64el": "0.27.3",
-				"@esbuild/linux-ppc64": "0.27.3",
-				"@esbuild/linux-riscv64": "0.27.3",
-				"@esbuild/linux-s390x": "0.27.3",
-				"@esbuild/linux-x64": "0.27.3",
-				"@esbuild/netbsd-arm64": "0.27.3",
-				"@esbuild/netbsd-x64": "0.27.3",
-				"@esbuild/openbsd-arm64": "0.27.3",
-				"@esbuild/openbsd-x64": "0.27.3",
-				"@esbuild/openharmony-arm64": "0.27.3",
-				"@esbuild/sunos-x64": "0.27.3",
-				"@esbuild/win32-arm64": "0.27.3",
-				"@esbuild/win32-ia32": "0.27.3",
-				"@esbuild/win32-x64": "0.27.3"
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
 		"node_modules/estree-walker": {
@@ -2108,16 +2119,16 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260526.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260526.0.tgz",
-			"integrity": "sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA==",
+			"version": "4.20260611.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260611.0.tgz",
+			"integrity": "sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
-				"sharp": "^0.34.5",
+				"sharp": "0.34.5",
 				"undici": "7.24.8",
-				"workerd": "1.20260526.1",
+				"workerd": "1.20260611.1",
 				"ws": "8.20.1",
 				"youch": "4.1.0-beta.10"
 			},
@@ -2129,9 +2140,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2148,15 +2159,18 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/path-to-regexp": {
 			"version": "6.3.0",
@@ -2193,9 +2207,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.10",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -2213,7 +2227,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -2222,14 +2236,14 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-			"integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+			"integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.127.0",
-				"@rolldown/pluginutils": "1.0.0-rc.17"
+				"@oxc-project/types": "=0.133.0",
+				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -2238,87 +2252,27 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+				"@rolldown/binding-android-arm64": "1.0.3",
+				"@rolldown/binding-darwin-arm64": "1.0.3",
+				"@rolldown/binding-darwin-x64": "1.0.3",
+				"@rolldown/binding-freebsd-x64": "1.0.3",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.3",
+				"@rolldown/binding-linux-arm64-musl": "1.0.3",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-musl": "1.0.3",
+				"@rolldown/binding-openharmony-arm64": "1.0.3",
+				"@rolldown/binding-wasm32-wasi": "1.0.3",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.3",
+				"@rolldown/binding-win32-x64-msvc": "1.0.3"
 			}
-		},
-		"node_modules/rosie-skills": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/rosie-skills/-/rosie-skills-0.6.4.tgz",
-			"integrity": "sha512-ojfhSiQRdZ2QyWbmKAHOSAUbaLYrTc5zIH7mS1jKoP8KCFSQddwVhMyFqldckTeybTfW3zNcsZzyOTzGTN1SBA==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"bin": {
-				"rosie-skills": "dist/bin.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"rosie-skills-darwin-arm64": "0.6.4",
-				"rosie-skills-freebsd-x64": "0.6.4",
-				"rosie-skills-linux-x64": "0.6.4"
-			}
-		},
-		"node_modules/rosie-skills-darwin-arm64": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/rosie-skills-darwin-arm64/-/rosie-skills-darwin-arm64-0.6.4.tgz",
-			"integrity": "sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/rosie-skills-freebsd-x64": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/rosie-skills-freebsd-x64/-/rosie-skills-freebsd-x64-0.6.4.tgz",
-			"integrity": "sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/rosie-skills-linux-x64": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/rosie-skills-linux-x64/-/rosie-skills-linux-x64-0.6.4.tgz",
-			"integrity": "sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"os": [
-				"linux"
-			]
 		},
 		"node_modules/semver": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -2425,9 +2379,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2435,9 +2389,9 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2504,17 +2458,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.0.10",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-			"integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+			"version": "8.0.16",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+			"integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
-				"postcss": "^8.5.10",
-				"rolldown": "1.0.0-rc.17",
-				"tinyglobby": "^0.2.16"
+				"postcss": "^8.5.15",
+				"rolldown": "1.0.3",
+				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -2530,7 +2484,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.1.0",
+				"@vitejs/devtools": "^0.1.18",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
@@ -2582,19 +2536,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.5",
-				"@vitest/mocker": "4.1.5",
-				"@vitest/pretty-format": "4.1.5",
-				"@vitest/runner": "4.1.5",
-				"@vitest/snapshot": "4.1.5",
-				"@vitest/spy": "4.1.5",
-				"@vitest/utils": "4.1.5",
+				"@vitest/expect": "4.1.9",
+				"@vitest/mocker": "4.1.9",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/runner": "4.1.9",
+				"@vitest/snapshot": "4.1.9",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -2622,12 +2576,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.5",
-				"@vitest/browser-preview": "4.1.5",
-				"@vitest/browser-webdriverio": "4.1.5",
-				"@vitest/coverage-istanbul": "4.1.5",
-				"@vitest/coverage-v8": "4.1.5",
-				"@vitest/ui": "4.1.5",
+				"@vitest/browser-playwright": "4.1.9",
+				"@vitest/browser-preview": "4.1.9",
+				"@vitest/browser-webdriverio": "4.1.9",
+				"@vitest/coverage-istanbul": "4.1.9",
+				"@vitest/coverage-v8": "4.1.9",
+				"@vitest/ui": "4.1.9",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -2689,9 +2643,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260526.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260526.1.tgz",
-			"integrity": "sha512-IHzymht98p10JH1zzwdCpbViAqw97HrwKl7+KfZeASFMsYSrIsAULWdPn0LRC5FTUzBpamLNyKCCKxbgXHgRHQ==",
+			"version": "1.20260611.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260611.1.tgz",
+			"integrity": "sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -2702,17 +2656,17 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260526.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260526.1",
-				"@cloudflare/workerd-linux-64": "1.20260526.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260526.1",
-				"@cloudflare/workerd-windows-64": "1.20260526.1"
+				"@cloudflare/workerd-darwin-64": "1.20260611.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260611.1",
+				"@cloudflare/workerd-linux-64": "1.20260611.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260611.1",
+				"@cloudflare/workerd-windows-64": "1.20260611.1"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.95.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.95.0.tgz",
-			"integrity": "sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg==",
+			"version": "4.100.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.100.0.tgz",
+			"integrity": "sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
@@ -2720,13 +2674,13 @@
 				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260526.0",
+				"miniflare": "4.20260611.0",
 				"path-to-regexp": "6.3.0",
-				"rosie-skills": "^0.6.3",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260526.1"
+				"workerd": "1.20260611.1"
 			},
 			"bin": {
+				"cf-wrangler": "bin/cf-wrangler.js",
 				"wrangler": "bin/wrangler.js",
 				"wrangler2": "bin/wrangler.js"
 			},
@@ -2734,10 +2688,10 @@
 				"node": ">=22.0.0"
 			},
 			"optionalDependencies": {
-				"fsevents": "~2.3.2"
+				"fsevents": "2.3.3"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260526.1"
+				"@cloudflare/workers-types": "^4.20260611.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -2746,9 +2700,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.20.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/host-image/package.json
+++ b/host-image/package.json
@@ -14,5 +14,9 @@
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.5",
 		"wrangler": "^4.85.0"
+	},
+	"overrides": {
+		"esbuild": "^0.28.1",
+		"ws": "^8.21.0"
 	}
 }

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -92,6 +92,7 @@ app = FastAPI(
 
 # Configure CORS for Next.js frontend
 # Get CORS origins from environment variable or use defaults
+local_dev_origin_regex = r"http://(localhost|127\.0\.0\.1):\d+"
 cors_origins_env = os.getenv("CORS_ORIGINS", "")
 if cors_origins_env:
     # Split by comma and strip whitespace
@@ -111,6 +112,7 @@ else:
 app.add_middleware(
     CORSMiddleware,
     allow_origins=cors_origins,
+    allow_origin_regex=local_dev_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -166,9 +168,25 @@ def inspect_local_zimage_model(model_path: Path) -> tuple[str, int]:
     return ("partial", size)
 
 
+def resolved_prompt_model_name() -> str:
+    """Return the active completion-capable Ollama model, falling back to configured value."""
+    configured_prompt_model = config.model.ollama_model
+    try:
+        return (
+            resolve_ollama_model(list_ollama_models(), configured_prompt_model, "completion")
+            or configured_prompt_model
+        )
+    except Exception as exc:
+        logger.warning("Could not resolve configured Ollama prompt model: %s", exc)
+        return configured_prompt_model
+
+
 def generation_config_payload() -> Dict[str, Any]:
     """Serialize mutable generation/runtime settings for the frontend."""
     image_backend = config.model.image_backend
+    configured_prompt_model = config.model.ollama_model
+    prompt_model = resolved_prompt_model_name()
+
     image_model_by_backend = {
         "auto": "auto resolver",
         "flux": config.model.flux_model,
@@ -190,15 +208,17 @@ def generation_config_payload() -> Dict[str, Any]:
         "guidance_scale": config.image.guidance_scale,
         "true_cfg_scale": config.image.true_cfg_scale,
         "ollama_temperature": config.model.ollama_temperature,
-        "ollama_model": config.model.ollama_model,
-        "prompt_model": config.model.ollama_model,
+        "ollama_model": configured_prompt_model,
+        "prompt_model": prompt_model,
+        "configured_prompt_model": configured_prompt_model,
         "image_backend": image_backend,
         "image_model": image_model,
         "ollama_image_model": config.model.ollama_image_model,
         "pipeline": {
             "prompt": {
                 "provider": "ollama",
-                "model": config.model.ollama_model,
+                "model": prompt_model,
+                "configured_model": configured_prompt_model,
             },
             "image": {
                 "backend": image_backend,
@@ -248,6 +268,116 @@ def normalize_gallery_key(image_path: str) -> str:
     return normalized
 
 
+def metadata_lookup(metadata: Dict[str, Any], key: str) -> Any:
+    """Read common experiment fields from either legacy or structured metadata."""
+    experiment = metadata.get("experiment") if isinstance(metadata.get("experiment"), dict) else {}
+    pipeline = experiment.get("pipeline") if isinstance(experiment.get("pipeline"), dict) else {}
+    parameters = (
+        experiment.get("parameters") if isinstance(experiment.get("parameters"), dict) else {}
+    )
+
+    if key == "backend":
+        return metadata.get("backend") or pipeline.get("resolved_backend")
+    if key == "model":
+        return metadata.get("model") or pipeline.get("model")
+    if key == "prompt_family":
+        return metadata.get("prompt_family") or experiment.get("prompt_family")
+    if key == "seed":
+        return metadata.get("seed") or parameters.get("seed")
+    return metadata.get(key)
+
+
+def display_metadata_for_catalog(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Return catalog metadata adjusted for display without mutating sidecars."""
+    experiment = metadata.get("experiment")
+    if not isinstance(experiment, dict):
+        return metadata
+
+    prompt = experiment.get("prompt") if isinstance(experiment.get("prompt"), dict) else {}
+    pipeline = experiment.get("pipeline") if isinstance(experiment.get("pipeline"), dict) else {}
+    if prompt.get("source") != "generated":
+        return metadata
+
+    configured_prompt_model = config.model.ollama_model
+    recorded_prompt_model = pipeline.get("prompt_model") or prompt.get("model")
+    if recorded_prompt_model != configured_prompt_model:
+        return metadata
+
+    resolved_prompt_model = resolved_prompt_model_name()
+    if not resolved_prompt_model or resolved_prompt_model == recorded_prompt_model:
+        return metadata
+
+    display_metadata = dict(metadata)
+    display_experiment = dict(experiment)
+    display_prompt = dict(prompt)
+    display_pipeline = dict(pipeline)
+    display_prompt.setdefault("configured_model", recorded_prompt_model)
+    display_prompt["model"] = resolved_prompt_model
+    display_pipeline.setdefault("configured_prompt_model", recorded_prompt_model)
+    display_pipeline["prompt_model"] = resolved_prompt_model
+    display_experiment["prompt"] = display_prompt
+    display_experiment["pipeline"] = display_pipeline
+    display_experiment["prompt_model_resolution"] = "resolved_from_configured_model"
+    display_metadata["experiment"] = display_experiment
+    return display_metadata
+
+
+def matches_gallery_filters(
+    entry: Dict[str, Any],
+    *,
+    backend: Optional[str] = None,
+    model: Optional[str] = None,
+    prompt_family: Optional[str] = None,
+    quality_flag: Optional[str] = None,
+) -> bool:
+    """Return whether a catalog entry matches operator review filters."""
+    metadata = entry.get("metadata", {})
+    if backend and str(metadata_lookup(metadata, "backend")) != backend:
+        return False
+    if model and str(metadata_lookup(metadata, "model")) != model:
+        return False
+    if prompt_family and str(metadata_lookup(metadata, "prompt_family")) != prompt_family:
+        return False
+    if quality_flag:
+        flags = {str(flag) for flag in entry.get("quality_flags", [])}
+        metadata_flags = metadata.get("quality_flags", [])
+        if isinstance(metadata_flags, str):
+            flags.update(flag.strip() for flag in metadata_flags.split(",") if flag.strip())
+        else:
+            flags.update(str(flag).strip() for flag in metadata_flags if str(flag).strip())
+        if quality_flag not in flags:
+            return False
+    return True
+
+
+def gallery_experiment_facets(entries: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+    """Build distinct review filters from catalog metadata."""
+    facets = {
+        "backends": set(),
+        "models": set(),
+        "prompt_families": set(),
+        "quality_flags": set(),
+        "publication_states": set(),
+    }
+    for entry in entries:
+        metadata = entry.get("metadata", {})
+        for facet_key, metadata_key in (
+            ("backends", "backend"),
+            ("models", "model"),
+            ("prompt_families", "prompt_family"),
+        ):
+            value = metadata_lookup(metadata, metadata_key)
+            if value not in (None, ""):
+                facets[facet_key].add(str(value))
+        if entry.get("publication_state"):
+            facets["publication_states"].add(str(entry["publication_state"]))
+        for flag in entry.get("quality_flags", []):
+            if str(flag).strip():
+                facets["quality_flags"].add(str(flag))
+
+    return {key: sorted(values) for key, values in facets.items()}
+
+
 def build_gallery_index(output_dir: Path) -> List[Dict[str, Any]]:
     """Build public gallery metadata from the backend publication catalog."""
     if not catalog_path_for(output_dir).exists():
@@ -272,7 +402,7 @@ def build_gallery_index(output_dir: Path) -> List[Dict[str, Any]]:
             ),
             "size": stat_result.st_size,
             "prompt_hash": image_file.stem.rsplit("_", 1)[-1],
-            "metadata": catalog_entry.get("metadata", {}),
+            "metadata": display_metadata_for_catalog(catalog_entry.get("metadata", {})),
             "publication": {
                 "id": catalog_entry.get("id"),
                 "state": catalog_entry.get("publication_state"),
@@ -339,9 +469,17 @@ class GenerateRequest(BaseModel):
     """Request model for image generation"""
 
     prompt: Optional[str] = Field(None, description="Optional custom prompt")
+    meta_prompt: Optional[str] = Field(None, description="Optional prompt-generation steering text")
     enable_plugins: bool = Field(True, description="Enable plugin enhancements")
     seed: Optional[int] = Field(None, description="Random seed for reproducibility")
     recipe_id: Optional[str] = Field(None, description="Optional workflow recipe ID")
+    experiment_label: Optional[str] = Field(None, description="Optional operator label for the run")
+    prompt_family: Optional[str] = Field(
+        None, description="Optional prompt family for review filters"
+    )
+    quality_flags: List[str] = Field(
+        default_factory=list, description="Operator quality flags to attach to this run"
+    )
     client_request_id: Optional[str] = Field(
         None, description="Client-provided request ID used to correlate progress events"
     )
@@ -365,6 +503,13 @@ class JobCreateRequest(BaseModel):
     seed: Optional[int] = Field(None, description="Random seed for reproducibility")
     recipe_id: Optional[str] = Field(None, description="Optional workflow recipe ID")
     publication_state: str = Field("draft", description="Initial publication state")
+    experiment_label: Optional[str] = Field(None, description="Optional operator label for the run")
+    prompt_family: Optional[str] = Field(
+        None, description="Optional prompt family for review filters"
+    )
+    quality_flags: List[str] = Field(
+        default_factory=list, description="Operator quality flags to attach to this run"
+    )
     client_request_id: Optional[str] = Field(
         None, description="Client-provided request ID used to correlate progress events"
     )
@@ -375,10 +520,6 @@ class PublicationUpdateRequest(BaseModel):
     """Request model for changing gallery publication state."""
 
     state: str = Field(..., description="Publication state for this image")
-    allow_placeholder_publish: bool = Field(
-        False,
-        description="Allow publishing mock/test placeholder images when explicitly requested",
-    )
 
 
 class EditRequest(BaseModel):
@@ -666,6 +807,27 @@ async def run_generation_job_safely(job_id: str) -> None:
         logger.error("Generation job %s failed: %s", job_id, exc)
 
 
+def experiment_request_metadata(
+    *,
+    metadata: Dict[str, Any] | None = None,
+    experiment_label: Optional[str] = None,
+    prompt_family: Optional[str] = None,
+    quality_flags: Optional[List[str]] = None,
+    enable_plugins: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Merge operator experiment annotations into job metadata."""
+    merged = dict(metadata or {})
+    if experiment_label:
+        merged["experiment_label"] = experiment_label
+    if prompt_family:
+        merged["prompt_family"] = prompt_family
+    if quality_flags:
+        merged["quality_flags"] = [str(flag).strip() for flag in quality_flags if str(flag).strip()]
+    if enable_plugins is not None:
+        merged["plugins_enabled_requested"] = enable_plugins
+    return merged
+
+
 def generation_job_from_request(
     *,
     prompt: Optional[str],
@@ -674,9 +836,20 @@ def generation_job_from_request(
     publication_state: str,
     client_request_id: Optional[str],
     metadata: Dict[str, Any] | None = None,
+    experiment_label: Optional[str] = None,
+    prompt_family: Optional[str] = None,
+    quality_flags: Optional[List[str]] = None,
+    enable_plugins: Optional[bool] = None,
     recipe_id: Optional[str] = None,
 ) -> GenerationJobCreate:
     """Build a job creation payload, resolving a workflow recipe when requested."""
+    merged_metadata = experiment_request_metadata(
+        metadata=metadata,
+        experiment_label=experiment_label,
+        prompt_family=prompt_family,
+        quality_flags=quality_flags,
+        enable_plugins=enable_plugins,
+    )
     if not recipe_id:
         return GenerationJobCreate(
             prompt=prompt,
@@ -684,7 +857,7 @@ def generation_job_from_request(
             seed=seed,
             publication_state=publication_state,
             client_request_id=client_request_id,
-            metadata=metadata or {},
+            metadata=merged_metadata,
         )
 
     resolution = resolve_workflow_recipe(
@@ -692,7 +865,7 @@ def generation_job_from_request(
         prompt=prompt,
         meta_prompt=meta_prompt,
         seed=seed,
-        metadata=metadata,
+        metadata=merged_metadata,
     )
     payload = resolution.to_job_payload(client_request_id=client_request_id)
     return GenerationJobCreate(**payload)
@@ -1325,10 +1498,14 @@ async def generate_image(request: GenerateRequest):
         job = generation_job_store.create_job(
             generation_job_from_request(
                 prompt=request.prompt,
-                meta_prompt=None,
+                meta_prompt=request.meta_prompt,
                 seed=request.seed,
                 publication_state="draft",
                 client_request_id=request.client_request_id,
+                experiment_label=request.experiment_label,
+                prompt_family=request.prompt_family,
+                quality_flags=request.quality_flags,
+                enable_plugins=request.enable_plugins,
                 recipe_id=request.recipe_id,
             )
         )
@@ -1372,6 +1549,9 @@ async def create_generation_job(request: JobCreateRequest, background_tasks: Bac
                 publication_state=request.publication_state,
                 client_request_id=request.client_request_id,
                 metadata=request.metadata,
+                experiment_label=request.experiment_label,
+                prompt_family=request.prompt_family,
+                quality_flags=request.quality_flags,
                 recipe_id=request.recipe_id,
             )
         )
@@ -1438,6 +1618,10 @@ async def get_gallery(limit: int = 50, offset: int = 0):
 @app.get("/api/gallery/catalog")
 async def get_gallery_catalog(
     publication_state: Optional[str] = Query(None, alias="state"),
+    backend: Optional[str] = Query(None),
+    model: Optional[str] = Query(None),
+    prompt_family: Optional[str] = Query(None),
+    quality_flag: Optional[str] = Query(None),
     limit: int = 100,
     offset: int = 0,
 ):
@@ -1456,10 +1640,22 @@ async def get_gallery_catalog(
     if publication_state:
         normalized_state = publication_state.strip().lower()
         entries = [entry for entry in entries if entry.get("publication_state") == normalized_state]
+    entries = [
+        entry
+        for entry in entries
+        if matches_gallery_filters(
+            entry,
+            backend=backend,
+            model=model,
+            prompt_family=prompt_family,
+            quality_flag=quality_flag,
+        )
+    ]
 
     page_entries = []
     for entry in entries[offset : offset + limit]:
         payload = dict(entry)
+        payload["metadata"] = display_metadata_for_catalog(entry.get("metadata", {}))
         image_file = OUTPUT_DIR / str(entry.get("path", ""))
         if image_file.exists():
             payload["size"] = image_file.stat().st_size
@@ -1472,6 +1668,19 @@ async def get_gallery_catalog(
         "limit": limit,
         "offset": offset,
     }
+
+
+@app.get("/api/gallery/facets")
+async def get_gallery_facets():
+    """Return distinct experiment/catalog filters for local review workflows."""
+    if not catalog_path_for(OUTPUT_DIR).exists():
+        await asyncio.to_thread(
+            backfill_catalog, OUTPUT_DIR, default_state="published", include_placeholders=True
+        )
+
+    catalog = await asyncio.to_thread(load_catalog, OUTPUT_DIR)
+    entries = list(catalog["assets"].values())
+    return gallery_experiment_facets(entries)
 
 
 @app.get("/api/gallery/sync/status")
@@ -1526,7 +1735,6 @@ async def update_image_publication(image_path: str, request: PublicationUpdateRe
             OUTPUT_DIR,
             key,
             request.state,
-            allow_placeholder_publish=request.allow_placeholder_publish,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/src/services/image_generation.py
+++ b/src/services/image_generation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import inspect
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -74,7 +75,73 @@ class GenerationServiceResult:
     created_at: str
 
 
+@dataclass(frozen=True)
+class PromptResolution:
+    """Resolved prompt text plus the model that produced it, when applicable."""
+
+    prompt: str
+    prompt_model: str | None = None
+
+
 ProgressCallback = Callable[[GenerationProgressEvent], Awaitable[None] | None]
+
+
+def _config_value(root: Any, *path: str, default: Any = None) -> Any:
+    """Read a nested config attribute without assuming every test double is complete."""
+    value = root
+    for part in path:
+        value = getattr(value, part, default)
+        if value is default:
+            return default
+    return value
+
+
+def _metadata_scalar(value: Any) -> Any:
+    """Return a JSON-safe metadata value for config fields."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if type(value).__module__.startswith("unittest.mock"):
+        return None
+    return str(value)
+
+
+def _metadata_list(value: Any) -> list[Any]:
+    """Return a JSON-safe list for optional config sequences."""
+    if not value or type(value).__module__.startswith("unittest.mock"):
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [_metadata_scalar(item) for item in value]
+    return [_metadata_scalar(value)]
+
+
+def _prompt_fingerprint(
+    *,
+    prompt: str,
+    backend: str,
+    model_name: str,
+    seed: int | None,
+    width: int | None,
+    height: int | None,
+    steps: int | None,
+    guidance_scale: float | None,
+    true_cfg_scale: float | None,
+) -> str:
+    """Build a stable short key for grouping repeatable experiment runs."""
+    payload = "|".join(
+        str(value)
+        for value in (
+            prompt,
+            backend,
+            model_name,
+            seed,
+            width,
+            height,
+            steps,
+            guidance_scale,
+            true_cfg_scale,
+        )
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
 def loading_message_for_backend(backend_name: str) -> str:
@@ -97,6 +164,98 @@ class ImageGenService:
         self.config = config
         self.output_dir = output_dir or config.system.output_dir
 
+    def _build_experiment_metadata(
+        self,
+        *,
+        request: GenerationServiceRequest,
+        final_prompt: str,
+        backend_name: str,
+        model_name: str,
+        generation_time: float,
+        generation_metadata: dict[str, Any],
+        resolved_seed: int | None,
+        active_plugins: list[str],
+        prompt_model: str | None,
+    ) -> dict[str, Any]:
+        """Capture the reproducibility envelope for one local model probe."""
+        width = _metadata_scalar(_config_value(self.config, "image", "width"))
+        height = _metadata_scalar(_config_value(self.config, "image", "height"))
+        steps = _metadata_scalar(_config_value(self.config, "image", "num_inference_steps"))
+        guidance_scale = _metadata_scalar(_config_value(self.config, "image", "guidance_scale"))
+        true_cfg_scale = _metadata_scalar(_config_value(self.config, "image", "true_cfg_scale"))
+        configured_backend = _metadata_scalar(
+            _config_value(self.config, "model", "image_backend", default=backend_name)
+        )
+        configured_prompt_model = _metadata_scalar(
+            _config_value(self.config, "model", "ollama_model")
+        )
+        prompt_model = _metadata_scalar(prompt_model)
+        enabled_loras = _metadata_list(
+            _config_value(self.config, "model", "lora", "enabled_loras", default=[])
+        )
+        lora_probability = _config_value(
+            self.config, "model", "lora", "application_probability", default=None
+        )
+        lora_probability = _metadata_scalar(lora_probability)
+        raw_quality_flags = request.metadata.get("quality_flags") or []
+        if isinstance(raw_quality_flags, str):
+            quality_flags = [flag.strip() for flag in raw_quality_flags.split(",") if flag.strip()]
+        else:
+            quality_flags = [str(flag).strip() for flag in raw_quality_flags if str(flag).strip()]
+        diagnostic = backend_name in {"mock", "smoke-test"} or bool(
+            generation_metadata.get("is_placeholder")
+        )
+        if diagnostic and "diagnostic" not in quality_flags:
+            quality_flags.append("diagnostic")
+
+        return {
+            "id": _prompt_fingerprint(
+                prompt=final_prompt,
+                backend=backend_name,
+                model_name=model_name,
+                seed=resolved_seed,
+                width=width,
+                height=height,
+                steps=steps,
+                guidance_scale=guidance_scale,
+                true_cfg_scale=true_cfg_scale,
+            ),
+            "label": request.metadata.get("experiment_label"),
+            "prompt_family": request.metadata.get("prompt_family"),
+            "prompt": {
+                "source": "operator" if request.prompt else "generated",
+                "meta_prompt": request.meta_prompt,
+                "final": final_prompt,
+                "model": prompt_model,
+                "configured_model": configured_prompt_model,
+            },
+            "pipeline": {
+                "configured_backend": configured_backend,
+                "resolved_backend": backend_name,
+                "model": model_name,
+                "prompt_model": prompt_model,
+                "configured_prompt_model": configured_prompt_model,
+            },
+            "parameters": {
+                "seed": resolved_seed,
+                "width": width,
+                "height": height,
+                "steps": steps,
+                "guidance_scale": guidance_scale,
+                "true_cfg_scale": true_cfg_scale,
+            },
+            "enhancers": {
+                "plugins": active_plugins,
+                "loras": enabled_loras,
+                "lora_application_probability": lora_probability,
+            },
+            "timing": {
+                "generation_seconds": generation_time,
+            },
+            "diagnostic": diagnostic,
+            "quality_flags": quality_flags,
+        }
+
     async def _emit(
         self,
         callback: ProgressCallback | None,
@@ -112,7 +271,7 @@ class ImageGenService:
         self,
         request: GenerationServiceRequest,
         callback: ProgressCallback | None,
-    ) -> str:
+    ) -> PromptResolution:
         if request.prompt:
             await self._emit(
                 callback,
@@ -124,7 +283,7 @@ class ImageGenService:
                     payload={"prompt": request.prompt},
                 ),
             )
-            return request.prompt
+            return PromptResolution(prompt=request.prompt)
 
         await self._emit(
             callback,
@@ -135,7 +294,8 @@ class ImageGenService:
                 detail="Building a fresh prompt from Ollama and the active plugins.",
             ),
         )
-        prompt = await PromptGenerator(self.config).generate_prompt(meta_prompt=request.meta_prompt)
+        prompt_generator = PromptGenerator(self.config)
+        prompt = await prompt_generator.generate_prompt(meta_prompt=request.meta_prompt)
         await self._emit(
             callback,
             GenerationProgressEvent(
@@ -146,7 +306,7 @@ class ImageGenService:
                 payload={"prompt": prompt},
             ),
         )
-        return prompt
+        return PromptResolution(prompt=prompt, prompt_model=prompt_generator.model_name)
 
     async def generate(
         self,
@@ -166,7 +326,8 @@ class ImageGenService:
             ),
         )
 
-        final_prompt = await self._resolve_prompt(request, callback)
+        prompt_resolution = await self._resolve_prompt(request, callback)
+        final_prompt = prompt_resolution.prompt
         if backend is None:
             image_gen_raw, backend_name = create_image_generator(self.config)
             image_gen = cast(ImageBackend, image_gen_raw)
@@ -232,6 +393,18 @@ class ImageGenService:
         resolved_seed = generation_metadata.get("seed")
         if resolved_seed is None and request.seed is not None and seed_supported:
             resolved_seed = request.seed
+        active_plugins = [name for name, info in plugin_manager.plugins.items() if info.enabled]
+        experiment_metadata = self._build_experiment_metadata(
+            request=request,
+            final_prompt=final_prompt,
+            backend_name=backend_name,
+            model_name=model_name,
+            generation_time=generation_time,
+            generation_metadata=generation_metadata,
+            resolved_seed=resolved_seed,
+            active_plugins=active_plugins,
+            prompt_model=prompt_resolution.prompt_model,
+        )
 
         existing_metadata = read_image_metadata(image_path)
         saved_metadata = {
@@ -242,6 +415,10 @@ class ImageGenService:
             "configured_backend": self.config.model.image_backend,
             "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
             "seed": resolved_seed,
+            "model": model_name,
+            "generation_time": generation_time,
+            "experiment": experiment_metadata,
+            "quality_flags": experiment_metadata["quality_flags"],
         }
         write_image_metadata(image_path, saved_metadata)
         publication_entry = register_image(
@@ -252,11 +429,14 @@ class ImageGenService:
             publication_state=request.publication_state,
         )
         relative_image_path = f"/images/{image_path.relative_to(self.output_dir).as_posix()}"
-        active_plugins = [name for name, info in plugin_manager.plugins.items() if info.enabled]
         response_metadata = {
             **request.metadata,
             **generation_metadata,
             "backend": backend_name,
+            "model": model_name,
+            "generation_time": generation_time,
+            "experiment": experiment_metadata,
+            "quality_flags": experiment_metadata["quality_flags"],
             "publication": {
                 "id": publication_entry["id"],
                 "state": publication_entry["publication_state"],

--- a/src/utils/publication_catalog.py
+++ b/src/utils/publication_catalog.py
@@ -129,23 +129,26 @@ def build_catalog_entry(
     prompt: str | None = None,
     metadata: dict[str, Any] | None = None,
     publication_state: str = "draft",
-    allow_placeholder_publish: bool = False,
 ) -> dict[str, Any]:
     """Build a normalized catalog entry for an image."""
     key = image_key(image_path, output_dir)
     metadata = metadata or read_image_metadata(image_path)
     placeholder = is_placeholder_artifact(image_path, metadata)
     state = normalize_publication_state(publication_state)
-    if (
-        placeholder
-        and state in (PUBLIC_GALLERY_STATES | {"draft"})
-        and not allow_placeholder_publish
-    ):
+    if placeholder and state in (PUBLIC_GALLERY_STATES | {"draft"}):
         state = "rejected"
 
-    quality_flags = []
+    experiment_metadata = metadata.get("experiment")
+    if not isinstance(experiment_metadata, dict):
+        experiment_metadata = {}
+    metadata_flags = metadata.get("quality_flags") or experiment_metadata.get("quality_flags", [])
+    if isinstance(metadata_flags, str):
+        flag_values = [flag.strip() for flag in metadata_flags.split(",")]
+    else:
+        flag_values = [str(flag).strip() for flag in metadata_flags]
+    quality_flags = sorted({flag for flag in flag_values if flag})
     if placeholder:
-        quality_flags.append("placeholder")
+        quality_flags = sorted({*quality_flags, "placeholder"})
 
     return {
         "id": image_id_for(key),
@@ -155,7 +158,7 @@ def build_catalog_entry(
         "created_at": created_at_for(image_path),
         "updated_at": utc_now(),
         "publication_state": state,
-        "publishable": not placeholder or allow_placeholder_publish,
+        "publishable": not placeholder,
         "quality_flags": quality_flags,
     }
 
@@ -175,7 +178,6 @@ def register_image(
     prompt: str | None = None,
     metadata: dict[str, Any] | None = None,
     publication_state: str = "draft",
-    allow_placeholder_publish: bool = False,
 ) -> dict[str, Any]:
     """Add or refresh an image in the catalog."""
     catalog = load_catalog(output_dir)
@@ -188,7 +190,6 @@ def register_image(
         prompt=prompt,
         metadata=metadata,
         publication_state=state,
-        allow_placeholder_publish=allow_placeholder_publish,
     )
     catalog["assets"][key] = entry
     save_catalog(output_dir, catalog)
@@ -269,8 +270,6 @@ def set_publication_state(
     output_dir: Path,
     key: str,
     publication_state: str,
-    *,
-    allow_placeholder_publish: bool = False,
 ) -> dict[str, Any]:
     """Update the publication state for one catalog entry."""
     state = normalize_publication_state(publication_state)
@@ -286,12 +285,12 @@ def set_publication_state(
 
     metadata = read_image_metadata(image_path)
     placeholder = is_placeholder_artifact(image_path, metadata)
-    if placeholder and state in PUBLIC_GALLERY_STATES and not allow_placeholder_publish:
-        raise PermissionError("Placeholder images cannot be published without override.")
+    if placeholder and state in PUBLIC_GALLERY_STATES:
+        raise PermissionError("Placeholder images cannot be published.")
 
     entry["publication_state"] = state
     entry["updated_at"] = utc_now()
-    entry["publishable"] = not placeholder or allow_placeholder_publish
+    entry["publishable"] = not placeholder
     if placeholder:
         flags = set(entry.get("quality_flags", []))
         flags.add("placeholder")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -80,6 +80,20 @@ def test_status_endpoint(client):
     ]
 
 
+def test_cors_allows_local_review_ports(client):
+    """Local Next.js review servers should not produce browser fetch errors."""
+    response = client.options(
+        "/api/status",
+        headers={
+            "Origin": "http://localhost:7862",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:7862"
+
+
 def test_plugins_endpoint(client):
     """Test the /api/plugins endpoint"""
     response = client.get("/api/plugins")
@@ -111,10 +125,50 @@ def test_generate_endpoint(client):
     metadata = data["metadata"]
     assert "backend" in metadata
     assert "plugins_used" in metadata
+    assert metadata["experiment"]["prompt"]["source"] == "operator"
+    assert metadata["experiment"]["pipeline"]["resolved_backend"] == metadata["backend"]
+    assert metadata["experiment"]["parameters"]["width"] == 1360
+    assert "diagnostic" in metadata["experiment"]["quality_flags"]
 
     # Verify image path format
     assert data["image_path"].startswith("/images/")
     assert data["image_path"].endswith(".png")
+
+
+def test_generate_endpoint_records_experiment_annotations(client):
+    """Generation requests should persist operator-facing experiment annotations."""
+    response = client.post(
+        "/api/generate",
+        json={
+            "prompt": "Typography stress test",
+            "meta_prompt": "Probe text rendering boundaries",
+            "seed": 77,
+            "experiment_label": "text probe",
+            "prompt_family": "typography",
+            "quality_flags": ["text", "layout"],
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    experiment = data["metadata"]["experiment"]
+    assert experiment["label"] == "text probe"
+    assert experiment["prompt_family"] == "typography"
+    assert experiment["prompt"]["meta_prompt"] == "Probe text rendering boundaries"
+    assert experiment["parameters"]["seed"] == 77
+    assert set(experiment["quality_flags"]) >= {"text", "layout", "diagnostic"}
+
+    catalog = load_catalog(Path(_TEST_OUTPUT_DIR))
+    relative_key = data["image_path"].replace("/images/", "")
+    assert (
+        catalog["assets"][relative_key]["metadata"]["experiment"]["prompt_family"] == "typography"
+    )
+    assert set(catalog["assets"][relative_key]["quality_flags"]) >= {
+        "text",
+        "layout",
+        "diagnostic",
+        "placeholder",
+    }
 
 
 def test_prompt_endpoint_accepts_client_request_id(client, monkeypatch):
@@ -233,14 +287,33 @@ def test_generation_events_endpoint_records_recent_lifecycle(client):
     assert all("timestamp" in event for event in matching)
 
 
-def test_generation_config_endpoint(client):
+def test_generation_config_endpoint(client, monkeypatch):
     """The generation config endpoint should expose backend and LoRA settings."""
+    monkeypatch.setattr(
+        "src.api.server.list_ollama_models",
+        lambda: [
+            OllamaModelInfo(
+                name="llama3.2:3b",
+                size=1,
+                modified="2026-06-15T12:00:00-05:00",
+                digest="digest-llama",
+                format="gguf",
+                family="llama",
+                capabilities=["completion"],
+                can_prompt=True,
+                can_vision=False,
+                can_image=False,
+            )
+        ],
+    )
+
     response = client.get("/api/config/generation")
     assert response.status_code == 200
 
     data = response.json()
     assert data["image_backend"] == "mock"
     assert data["prompt_model"] == "llama3.2:3b"
+    assert data["configured_prompt_model"] == "llama3.2:3b"
     assert data["image_model"] == "mock generator"
     assert data["pipeline"]["prompt"]["model"] == "llama3.2:3b"
     assert data["pipeline"]["image"]["backend"] == "mock"
@@ -255,8 +328,26 @@ def test_generation_config_endpoint(client):
     assert data["ernie_prompt_enhancer"] is True
 
 
-def test_set_generation_config_updates_backend_and_loras(client):
+def test_set_generation_config_updates_backend_and_loras(client, monkeypatch):
     """Runtime generation settings should accept backend and LoRA updates."""
+    monkeypatch.setattr(
+        "src.api.server.list_ollama_models",
+        lambda: [
+            OllamaModelInfo(
+                name="qwen3.6:27b",
+                size=1,
+                modified="2026-06-15T12:00:00-05:00",
+                digest="digest-qwen",
+                format="gguf",
+                family="qwen35",
+                capabilities=["completion"],
+                can_prompt=True,
+                can_vision=False,
+                can_image=False,
+            )
+        ],
+    )
+
     original_backend = api_config.model.image_backend
     original_ollama_model = api_config.model.ollama_model
     original_ollama_image_model = api_config.model.ollama_image_model
@@ -288,6 +379,7 @@ def test_set_generation_config_updates_backend_and_loras(client):
         assert data["image_backend"] == "small"
         assert data["ollama_model"] == "qwen3.6:27b"
         assert data["prompt_model"] == "qwen3.6:27b"
+        assert data["configured_prompt_model"] == "qwen3.6:27b"
         assert data["image_model"] == api_config.model.small_sd_model
         assert data["pipeline"]["prompt"]["model"] == "qwen3.6:27b"
         assert data["pipeline"]["image"]["model"] == api_config.model.small_sd_model
@@ -627,8 +719,128 @@ def test_gallery_sync_status_reports_catalog_publish_plan(client):
     assert any(asset["key"].endswith("syncfeed.png") for asset in data["preview_assets"])
 
 
+def test_gallery_catalog_filters_and_facets_use_experiment_metadata(client):
+    """Gallery review should be filterable by backend, model, prompt family, and quality flag."""
+    output_root = Path(_TEST_OUTPUT_DIR)
+    week_dir = output_root / "2099" / "week_06"
+    week_dir.mkdir(parents=True, exist_ok=True)
+
+    image_path = week_dir / "image_20990106_000001_filterbee.png"
+    image = Image.new("RGB", (64, 64), color=(25, 70, 120))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((10, 10, 50, 42), fill=(210, 230, 80))
+    image.save(image_path)
+    image_path.with_suffix(".txt").write_text("filter me")
+    write_image_metadata(
+        image_path,
+        {
+            "backend": "small-sd",
+            "model": "segmind/tiny-sd",
+            "is_placeholder": False,
+            "experiment": {
+                "prompt_family": "layout",
+                "quality_flags": ["composition"],
+            },
+            "quality_flags": ["composition"],
+        },
+    )
+
+    response = client.post("/api/gallery/catalog/backfill?default_state=published")
+    assert response.status_code == 200
+
+    response = client.get(
+        "/api/gallery/catalog?backend=small-sd&model=segmind%2Ftiny-sd"
+        "&prompt_family=layout&quality_flag=composition"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert any(asset["path"].endswith("filterbee.png") for asset in data["assets"])
+
+    response = client.get("/api/gallery/catalog?prompt_family=typography")
+    assert response.status_code == 200
+    assert not any(asset["path"].endswith("filterbee.png") for asset in response.json()["assets"])
+
+    facets_response = client.get("/api/gallery/facets")
+    assert facets_response.status_code == 200
+    facets = facets_response.json()
+    assert "small-sd" in facets["backends"]
+    assert "segmind/tiny-sd" in facets["models"]
+    assert "layout" in facets["prompt_families"]
+    assert "composition" in facets["quality_flags"]
+
+
+def test_gallery_catalog_displays_resolved_prompt_model(client, monkeypatch):
+    """Old generated-prompt metadata should not display a stale configured Ollama alias."""
+    output_root = Path(_TEST_OUTPUT_DIR)
+    week_dir = output_root / "2099" / "week_07"
+    week_dir.mkdir(parents=True, exist_ok=True)
+
+    image_path = week_dir / "image_20990107_000001_promptmodel.png"
+    image = Image.new("RGB", (64, 64), color=(45, 80, 110))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((8, 8, 42, 42), fill=(230, 170, 90))
+    image.save(image_path)
+    image_path.with_suffix(".txt").write_text("generated prompt model test")
+    write_image_metadata(
+        image_path,
+        {
+            "backend": "small-sd",
+            "model": "segmind/tiny-sd",
+            "is_placeholder": False,
+            "experiment": {
+                "prompt": {
+                    "source": "generated",
+                    "model": "gpt-oss:latest",
+                    "final": "generated prompt model test",
+                },
+                "pipeline": {
+                    "resolved_backend": "small-sd",
+                    "model": "segmind/tiny-sd",
+                    "prompt_model": "gpt-oss:latest",
+                },
+            },
+        },
+    )
+
+    mock_models = [
+        OllamaModelInfo(
+            name="qwen3.5:9b",
+            size=1,
+            modified="2026-06-15T12:00:00-05:00",
+            digest="digest-qwen",
+            format="gguf",
+            family="qwen35",
+            capabilities=["completion"],
+            can_prompt=True,
+            can_vision=False,
+            can_image=False,
+        )
+    ]
+    original_prompt_model = api_config.model.ollama_model
+    monkeypatch.setattr("src.api.server.list_ollama_models", lambda: mock_models)
+    try:
+        api_config.model.ollama_model = "gpt-oss:latest"
+        response = client.post("/api/gallery/catalog/backfill?default_state=published")
+        assert response.status_code == 200
+
+        response = client.get("/api/gallery/catalog?limit=100")
+        assert response.status_code == 200
+        entry = next(
+            asset
+            for asset in response.json()["assets"]
+            if asset["path"].endswith("promptmodel.png")
+        )
+        experiment = entry["metadata"]["experiment"]
+        assert experiment["prompt"]["model"] == "qwen3.5:9b"
+        assert experiment["prompt"]["configured_model"] == "gpt-oss:latest"
+        assert experiment["pipeline"]["prompt_model"] == "qwen3.5:9b"
+        assert experiment["pipeline"]["configured_prompt_model"] == "gpt-oss:latest"
+    finally:
+        api_config.model.ollama_model = original_prompt_model
+
+
 def test_placeholder_cannot_be_published_without_override(client):
-    """Mock placeholders should stay unpublished unless the operator explicitly overrides."""
+    """Mock placeholders should stay unpublished even if a stale client sends an override."""
     output_root = Path(_TEST_OUTPUT_DIR)
     week_dir = output_root / "2099" / "week_04"
     week_dir.mkdir(parents=True, exist_ok=True)
@@ -652,8 +864,7 @@ def test_placeholder_cannot_be_published_without_override(client):
         f"/api/gallery/publication/{relative_path}",
         json={"state": "published", "allow_placeholder_publish": True},
     )
-    assert response.status_code == 200
-    assert response.json()["publication_state"] == "published"
+    assert response.status_code == 409
 
 
 def test_delete_image_removes_metadata_sidecar(client):

--- a/tests/test_ernie_image_generator.py
+++ b/tests/test_ernie_image_generator.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from PIL import Image
 
+import src.generators.ernie_image_generator as ernie_module
 from src.generators.ernie_image_generator import ErnieImageGenerator
 from src.utils.config import Config
 
@@ -40,11 +41,9 @@ async def test_generate_image_uses_ernie_pipeline(monkeypatch, tmp_path):
     pipeline_cls = MagicMock()
     pipeline_cls.from_pretrained.return_value = pipe
 
-    monkeypatch.setattr("src.generators.ernie_image_generator.ErnieImagePipeline", pipeline_cls)
-    monkeypatch.setattr(
-        "src.generators.ernie_image_generator.incomplete_model_downloads", lambda _model: []
-    )
-    monkeypatch.setattr("src.generators.ernie_image_generator.is_model_cached", lambda _model: True)
+    monkeypatch.setattr(ernie_module, "ErnieImagePipeline", pipeline_cls)
+    monkeypatch.setattr(ernie_module, "incomplete_model_downloads", lambda _model: [])
+    monkeypatch.setattr(ernie_module, "is_model_cached", lambda _model: True)
 
     path, _duration, model_name = await generator.generate_image(
         'A bilingual poster that says "DREAMGEN"',

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -63,19 +63,29 @@ async def test_service_generates_image_metadata_and_catalog_entry(mock_service_c
     assert result.backend == "mock"
     assert result.metadata["backend"] == "mock"
     assert result.metadata["seed"] == 123
+    assert result.metadata["model"] == "mock"
+    assert result.metadata["generation_time"] >= 0
+    assert result.metadata["experiment"]["parameters"]["seed"] == 123
+    assert result.metadata["experiment"]["parameters"]["width"] == 64
+    assert result.metadata["experiment"]["pipeline"]["resolved_backend"] == "mock"
+    assert result.metadata["experiment"]["prompt"]["source"] == "operator"
+    assert result.metadata["experiment"]["diagnostic"] is True
+    assert "diagnostic" in result.metadata["experiment"]["quality_flags"]
     assert result.metadata["publication"]["state"] == "rejected"
-    assert result.metadata["publication"]["quality_flags"] == ["placeholder"]
+    assert result.metadata["publication"]["quality_flags"] == ["diagnostic", "placeholder"]
 
     metadata = read_image_metadata(result.image_path)
     assert metadata["backend"] == "mock"
     assert metadata["configured_backend"] == "mock"
     assert metadata["seed"] == 123
+    assert metadata["experiment"]["id"]
+    assert metadata["quality_flags"] == ["diagnostic"]
 
     catalog = load_catalog(tmp_path)
     relative_key = result.image_path.relative_to(tmp_path).as_posix()
     assert catalog["assets"][relative_key]["prompt"] == "service boundary test"
     assert catalog["assets"][relative_key]["publication_state"] == "rejected"
-    assert catalog["assets"][relative_key]["quality_flags"] == ["placeholder"]
+    assert catalog["assets"][relative_key]["quality_flags"] == ["diagnostic", "placeholder"]
 
 
 @pytest.mark.asyncio
@@ -127,3 +137,31 @@ async def test_service_can_reuse_caller_owned_backend(mock_service_config, tmp_p
     assert result.metadata["backend_double"] is True
     assert result.metadata["force_reinit"] is True
     assert result.metadata["seed"] == 99
+
+
+@pytest.mark.asyncio
+async def test_service_records_resolved_prompt_model(mock_service_config, tmp_path, monkeypatch):
+    """Generated prompt metadata should use the model that actually produced it."""
+
+    async def fake_generate_prompt(self, meta_prompt=None):
+        self.model_name = "qwen3.5:9b"
+        return "generated prompt from resolved model"
+
+    monkeypatch.setattr(
+        "src.services.image_generation.PromptGenerator.generate_prompt",
+        fake_generate_prompt,
+    )
+
+    service = ImageGenService(mock_service_config, output_dir=tmp_path)
+    backend = ReusableBackend()
+
+    result = await service.generate(
+        GenerationServiceRequest(meta_prompt="probe prompt model"),
+        backend=backend,
+        backend_name="reusable",
+    )
+
+    experiment = result.metadata["experiment"]
+    assert experiment["prompt"]["source"] == "generated"
+    assert experiment["prompt"]["model"] == "qwen3.5:9b"
+    assert experiment["pipeline"]["prompt_model"] == "qwen3.5:9b"

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -58,6 +58,7 @@ type RecentImage = {
   path: string;
   prompt: string;
   created_at: string;
+  metadata?: GenerateResponse["metadata"];
 };
 
 const CADENCE_OPTIONS: CadenceOption[] = [
@@ -83,6 +84,9 @@ const STORAGE_KEYS = {
   promptSeed: "dreamgen.promptSeed",
   cadenceMinutes: "dreamgen.cadenceMinutes",
   sessionLoop: "dreamgen.sessionLoop",
+  experimentLabel: "dreamgen.experimentLabel",
+  promptFamily: "dreamgen.promptFamily",
+  qualityFlags: "dreamgen.qualityFlags",
 };
 
 const readString = (key: string, fallback: string) => {
@@ -123,6 +127,12 @@ const formatCountdown = (target: Date | null) => {
 const truncatePrompt = (prompt: string, max = 88) =>
   prompt.length > max ? `${prompt.slice(0, max).trim()}...` : prompt;
 
+const splitQualityFlags = (value: string) =>
+  value
+    .split(",")
+    .map((flag) => flag.trim())
+    .filter(Boolean);
+
 const describeGenerationEvent = (event: GenerationEvent) => {
   if (event.type === "generation_error") return `Error: ${event.error ?? "unknown"}`;
   if (event.type === "generation_started") return "Generation started";
@@ -136,6 +146,9 @@ export default function Home() {
   const [activeTab, setActiveTab] = useState<TabId>("generate");
   const [promptSeed, setPromptSeed] = useState("");
   const [metaPrompt, setMetaPrompt] = useState("");
+  const [experimentLabel, setExperimentLabel] = useState("");
+  const [promptFamily, setPromptFamily] = useState("");
+  const [qualityFlags, setQualityFlags] = useState("");
   const [promptError, setPromptError] = useState<string | null>(null);
   const [isGeneratingPrompt, setIsGeneratingPrompt] = useState(false);
   const [promptProgress, setPromptProgress] = useState<ProgressSnapshot | null>(null);
@@ -161,6 +174,9 @@ export default function Home() {
   const [logs, setLogs] = useState<string[]>(["DreamGen is ready."]);
 
   const promptSeedRef = useRef(promptSeed);
+  const experimentLabelRef = useRef(experimentLabel);
+  const promptFamilyRef = useRef(promptFamily);
+  const qualityFlagsRef = useRef(qualityFlags);
   const cadenceMinutesRef = useRef(cadenceMinutes);
   const isGeneratingRef = useRef(isGenerating);
   const statusRef = useRef<SystemStatus | null>(status);
@@ -190,6 +206,33 @@ export default function Home() {
       ? generationConfig?.ollama_image_model || "Ollama image model"
       : generationConfig?.image_model ?? selectedBackend;
   const lastActivity = logs[logs.length - 1];
+  const currentExperiment = currentImage?.metadata.experiment;
+  const currentParameters = currentExperiment?.parameters;
+  const currentTiming = currentExperiment?.timing;
+  const currentQualityFlags =
+    currentExperiment?.quality_flags ?? currentImage?.metadata.quality_flags ?? [];
+  const currentExperimentRows = [
+    { label: "Run ID", value: currentExperiment?.id },
+    { label: "Prompt family", value: currentExperiment?.prompt_family },
+    { label: "Seed", value: currentParameters?.seed ?? currentImage?.metadata.seed },
+    {
+      label: "Size",
+      value:
+        currentParameters?.width && currentParameters?.height
+          ? `${currentParameters.width} x ${currentParameters.height}`
+          : undefined,
+    },
+    { label: "Steps", value: currentParameters?.steps },
+    { label: "Guidance", value: currentParameters?.guidance_scale },
+    { label: "True CFG", value: currentParameters?.true_cfg_scale },
+    {
+      label: "Time",
+      value:
+        currentTiming?.generation_seconds ?? currentImage?.metadata.generation_time
+          ? `${(currentTiming?.generation_seconds ?? currentImage?.metadata.generation_time ?? 0).toFixed(2)}s`
+          : undefined,
+    },
+  ].filter((row) => row.value !== undefined && row.value !== null && row.value !== "");
 
   const addLog = (message: string, type: "info" | "error" = "info") => {
     const timestamp = new Date().toLocaleTimeString();
@@ -214,6 +257,7 @@ export default function Home() {
               prompt: latestImage.prompt,
               image_path: latestImage.path,
               metadata: {
+                ...(latestImage.metadata ?? {}),
                 backend: latestStatus?.backend ?? "unknown",
                 plugins_used: latestStatus?.active_plugins ?? [],
               },
@@ -291,8 +335,12 @@ export default function Home() {
     try {
       const response = await api.generate({
         prompt: promptSeedRef.current.trim() || undefined,
+        meta_prompt: metaPrompt || undefined,
         enable_plugins: true,
         seed: seed ?? undefined,
+        experiment_label: experimentLabelRef.current.trim() || undefined,
+        prompt_family: promptFamilyRef.current.trim() || undefined,
+        quality_flags: splitQualityFlags(qualityFlagsRef.current),
         client_request_id: clientRequestId,
       });
 
@@ -334,6 +382,9 @@ export default function Home() {
 
   useEffect(() => {
     setPromptSeed(readString(STORAGE_KEYS.promptSeed, ""));
+    setExperimentLabel(readString(STORAGE_KEYS.experimentLabel, ""));
+    setPromptFamily(readString(STORAGE_KEYS.promptFamily, ""));
+    setQualityFlags(readString(STORAGE_KEYS.qualityFlags, ""));
     setCadenceMinutes(readNumber(STORAGE_KEYS.cadenceMinutes, 60));
     setLoopEnabled(readBoolean(STORAGE_KEYS.sessionLoop, false));
   }, []);
@@ -343,6 +394,24 @@ export default function Home() {
     window.localStorage.setItem(STORAGE_KEYS.promptSeed, promptSeed);
     promptSeedRef.current = promptSeed;
   }, [promptSeed]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_KEYS.experimentLabel, experimentLabel);
+    experimentLabelRef.current = experimentLabel;
+  }, [experimentLabel]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_KEYS.promptFamily, promptFamily);
+    promptFamilyRef.current = promptFamily;
+  }, [promptFamily]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_KEYS.qualityFlags, qualityFlags);
+    qualityFlagsRef.current = qualityFlags;
+  }, [qualityFlags]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -572,6 +641,15 @@ export default function Home() {
         seed: job.request.seed ?? undefined,
         recipe_id: job.request.recipe_id ?? undefined,
         publication_state: job.request.publication_state ?? "draft",
+        experiment_label:
+          typeof job.metadata.experiment_label === "string"
+            ? job.metadata.experiment_label
+            : undefined,
+        prompt_family:
+          typeof job.metadata.prompt_family === "string" ? job.metadata.prompt_family : undefined,
+        quality_flags: Array.isArray(job.metadata.quality_flags)
+          ? job.metadata.quality_flags.map(String)
+          : undefined,
         metadata: {
           ...(job.request.metadata ?? {}),
           rerun_of_job_id: job.id,
@@ -846,6 +924,42 @@ export default function Home() {
                                       />
                                     </div>
 
+                                    <div className="grid gap-3 sm:grid-cols-2">
+                                      <div>
+                                        <label className="mb-2 block text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                          Experiment label
+                                        </label>
+                                        <input
+                                          value={experimentLabel}
+                                          onChange={(event) => setExperimentLabel(event.target.value)}
+                                          placeholder="text probe, backend sweep"
+                                          className="w-full rounded-xl border border-input/85 bg-background/95 px-3 py-2 text-sm text-foreground outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                                        />
+                                      </div>
+                                      <div>
+                                        <label className="mb-2 block text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                          Prompt family
+                                        </label>
+                                        <input
+                                          value={promptFamily}
+                                          onChange={(event) => setPromptFamily(event.target.value)}
+                                          placeholder="hands, text, layout"
+                                          className="w-full rounded-xl border border-input/85 bg-background/95 px-3 py-2 text-sm text-foreground outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                                        />
+                                      </div>
+                                      <div className="sm:col-span-2">
+                                        <label className="mb-2 block text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                          Quality flags
+                                        </label>
+                                        <input
+                                          value={qualityFlags}
+                                          onChange={(event) => setQualityFlags(event.target.value)}
+                                          placeholder="diagnostic, text-failure, publish-candidate"
+                                          className="w-full rounded-xl border border-input/85 bg-background/95 px-3 py-2 text-sm text-foreground outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                                        />
+                                      </div>
+                                    </div>
+
                                     <div className="flex flex-wrap items-center justify-between gap-3">
                                       <span className="text-xs leading-6 text-muted-foreground">
                                         {promptSeed.trim()
@@ -992,6 +1106,45 @@ export default function Home() {
                         </div>
                       </div>
 
+                      {currentExperimentRows.length > 0 && (
+                        <div className="mb-4 rounded-2xl border border-border/60 bg-background/78 px-4 py-3">
+                          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                              Experiment
+                            </div>
+                            {currentExperiment?.diagnostic && (
+                              <span className="rounded border border-amber-400/40 px-2 py-0.5 text-[11px] text-amber-300">
+                                diagnostic
+                              </span>
+                            )}
+                          </div>
+                          <dl className="grid gap-2 sm:grid-cols-2">
+                            {currentExperimentRows.map((row) => (
+                              <div key={row.label} className="min-w-0">
+                                <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                                  {row.label}
+                                </dt>
+                                <dd className="mt-1 truncate text-xs font-medium text-foreground" title={String(row.value)}>
+                                  {String(row.value)}
+                                </dd>
+                              </div>
+                            ))}
+                          </dl>
+                          {currentQualityFlags.length > 0 && (
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              {currentQualityFlags.map((flag) => (
+                                <span
+                                  key={flag}
+                                  className="rounded border border-border px-2 py-0.5 text-[11px] text-muted-foreground"
+                                >
+                                  {flag}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )}
+
                       <div className="min-h-[380px] rounded-[1.5rem] border border-border/70 bg-background/70 p-4">
                         <AnimatePresence mode="wait">
                           {isGenerating ? (
@@ -1090,7 +1243,7 @@ export default function Home() {
                             <div className="mt-3 space-y-2">
                               {generationEvents.slice(0, 4).map((event, index) => (
                                 <div
-                                  key={`${event.timestamp}-${event.id ?? index}-${event.type}`}
+                                  key={`${event.timestamp}-${event.id ?? "event"}-${event.type}-${event.name ?? ""}-${index}`}
                                   className="flex items-start justify-between gap-3 text-xs"
                                 >
                                   <span className="min-w-0 capitalize text-foreground">
@@ -1146,6 +1299,7 @@ export default function Home() {
                                     prompt: image.prompt,
                                     image_path: image.path,
                                     metadata: {
+                                      ...(image.metadata ?? {}),
                                       backend: status?.backend ?? "unknown",
                                       plugins_used: status?.active_plugins ?? [],
                                     },

--- a/web-ui/components/Gallery.tsx
+++ b/web-ui/components/Gallery.tsx
@@ -11,6 +11,7 @@ import {
   api,
   API_BASE,
   type GalleryCatalogEntry,
+  type GalleryFacets,
   type GallerySyncStatus,
   type PublicationState,
 } from "@/lib/api";
@@ -132,6 +133,11 @@ export default function Gallery() {
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>("week");
   const [catalogFilter, setCatalogFilter] = useState<CatalogFilter>("all");
+  const [backendFilter, setBackendFilter] = useState("all");
+  const [modelFilter, setModelFilter] = useState("all");
+  const [promptFamilyFilter, setPromptFamilyFilter] = useState("all");
+  const [qualityFlagFilter, setQualityFlagFilter] = useState("all");
+  const [facets, setFacets] = useState<GalleryFacets | null>(null);
   const [syncStatus, setSyncStatus] = useState<GallerySyncStatus | null>(null);
   const [copiedPromptPath, setCopiedPromptPath] = useState<string | null>(null);
   const loadRequestRef = useRef(0);
@@ -185,16 +191,32 @@ export default function Gallery() {
     loadRequestRef.current = requestId;
     const limit = viewMode === "all" ? ALL_PAGE_SIZE : WEEK_PAGE_SIZE;
     const offset = viewMode === "all" ? page * ALL_PAGE_SIZE : 0;
-    const cacheKey = `gallery_catalog_${viewMode}_${catalogFilter}_${page}_${limit}`;
+    const cacheKey = [
+      "gallery_catalog",
+      viewMode,
+      catalogFilter,
+      backendFilter,
+      modelFilter,
+      promptFamilyFilter,
+      qualityFlagFilter,
+      page,
+      limit,
+    ].join("_");
 
     setLoading(true);
     setError(null);
 
     try {
       console.log('Fetching gallery catalog from API');
-      const [catalogResponse, publishStatus] = await Promise.all([
-        api.getGalleryCatalog(limit, offset, catalogFilter, GALLERY_TIMEOUT_MS),
+      const [catalogResponse, publishStatus, facetResponse] = await Promise.all([
+        api.getGalleryCatalog(limit, offset, catalogFilter, GALLERY_TIMEOUT_MS, {
+          backend: backendFilter === "all" ? undefined : backendFilter,
+          model: modelFilter === "all" ? undefined : modelFilter,
+          prompt_family: promptFamilyFilter === "all" ? undefined : promptFamilyFilter,
+          quality_flag: qualityFlagFilter === "all" ? undefined : qualityFlagFilter,
+        }),
         api.getGallerySyncStatus(10),
+        api.getGalleryFacets(),
       ]);
 
       if (loadRequestRef.current !== requestId) return;
@@ -215,6 +237,7 @@ export default function Gallery() {
       setImages(response.images);
       setTotal(response.total);
       setSyncStatus(publishStatus);
+      setFacets(facetResponse);
 
       if (viewMode === "week") {
         organizeByWeek(response.images);
@@ -248,7 +271,16 @@ export default function Gallery() {
         setLoading(false);
       }
     }
-  }, [catalogFilter, organizeByWeek, page, viewMode]);
+  }, [
+    backendFilter,
+    catalogFilter,
+    modelFilter,
+    organizeByWeek,
+    page,
+    promptFamilyFilter,
+    qualityFlagFilter,
+    viewMode,
+  ]);
 
   const getWeekNumber = (date: Date): number => {
     const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
@@ -288,7 +320,7 @@ export default function Gallery() {
 
   useEffect(() => {
     setPage(0);
-  }, [catalogFilter, viewMode]);
+  }, [backendFilter, catalogFilter, modelFilter, promptFamilyFilter, qualityFlagFilter, viewMode]);
 
   const getImageUrl = (imagePath: string) => `${API_BASE}${imagePath}`;
 
@@ -464,7 +496,74 @@ export default function Gallery() {
       }));
   };
 
+  const getExperimentRows = (image: GalleryImage) => {
+    const experiment = image.metadata.experiment;
+    if (!experiment || typeof experiment !== "object") return [];
+    const data = experiment as {
+      id?: string;
+      label?: string | null;
+      prompt_family?: string | null;
+      diagnostic?: boolean;
+      pipeline?: { resolved_backend?: string; model?: string; prompt_model?: string };
+      parameters?: {
+        seed?: number | null;
+        width?: number | null;
+        height?: number | null;
+        steps?: number | null;
+        guidance_scale?: number | null;
+        true_cfg_scale?: number | null;
+      };
+      timing?: { generation_seconds?: number };
+      enhancers?: { plugins?: string[]; loras?: string[] };
+    };
+    const parameters = data.parameters ?? {};
+    const pipeline = data.pipeline ?? {};
+    const timing = data.timing ?? {};
+    const enhancers = data.enhancers ?? {};
+
+    return [
+      { key: "id", label: "run id", value: data.id },
+      { key: "label", label: "label", value: data.label },
+      { key: "prompt_family", label: "prompt family", value: data.prompt_family },
+      { key: "backend", label: "backend", value: pipeline.resolved_backend },
+      { key: "model", label: "model", value: pipeline.model },
+      { key: "prompt_model", label: "prompt model", value: pipeline.prompt_model },
+      { key: "seed", label: "seed", value: parameters.seed },
+      {
+        key: "size",
+        label: "size",
+        value:
+          parameters.width && parameters.height
+            ? `${parameters.width} x ${parameters.height}`
+            : undefined,
+      },
+      { key: "steps", label: "steps", value: parameters.steps },
+      { key: "guidance", label: "guidance", value: parameters.guidance_scale },
+      { key: "true_cfg", label: "true cfg", value: parameters.true_cfg_scale },
+      {
+        key: "generation_time",
+        label: "time",
+        value:
+          typeof timing.generation_seconds === "number"
+            ? `${timing.generation_seconds.toFixed(2)}s`
+            : undefined,
+      },
+      {
+        key: "plugins",
+        label: "plugins",
+        value: enhancers.plugins?.length ? enhancers.plugins.join(", ") : undefined,
+      },
+      {
+        key: "loras",
+        label: "loras",
+        value: enhancers.loras?.length ? enhancers.loras.join(", ") : undefined,
+      },
+      { key: "diagnostic", label: "diagnostic", value: data.diagnostic },
+    ].filter((row) => row.value !== undefined && row.value !== null && row.value !== "");
+  };
+
   const selectedMetadataRows = selectedImage ? getMetadataRows(selectedImage) : [];
+  const selectedExperimentRows = selectedImage ? getExperimentRows(selectedImage) : [];
 
   const renderStateBadge = (state: PublicationState, className?: string) => (
     <span
@@ -619,6 +718,62 @@ export default function Gallery() {
                 {PUBLICATION_OPTIONS.map((option) => (
                   <option key={option.state} value={option.state}>
                     {option.label}
+                  </option>
+                ))}
+              </select>
+
+              <select
+                value={backendFilter}
+                onChange={(event) => setBackendFilter(event.target.value)}
+                className="h-8 rounded-md border border-border bg-background px-2 text-sm"
+                title="Filter by backend"
+              >
+                <option value="all">All backends</option>
+                {(facets?.backends ?? []).map((backend) => (
+                  <option key={backend} value={backend}>
+                    {backend}
+                  </option>
+                ))}
+              </select>
+
+              <select
+                value={modelFilter}
+                onChange={(event) => setModelFilter(event.target.value)}
+                className="h-8 max-w-[180px] rounded-md border border-border bg-background px-2 text-sm"
+                title="Filter by model"
+              >
+                <option value="all">All models</option>
+                {(facets?.models ?? []).map((model) => (
+                  <option key={model} value={model}>
+                    {model}
+                  </option>
+                ))}
+              </select>
+
+              <select
+                value={promptFamilyFilter}
+                onChange={(event) => setPromptFamilyFilter(event.target.value)}
+                className="h-8 rounded-md border border-border bg-background px-2 text-sm"
+                title="Filter by prompt family"
+              >
+                <option value="all">All families</option>
+                {(facets?.prompt_families ?? []).map((family) => (
+                  <option key={family} value={family}>
+                    {family}
+                  </option>
+                ))}
+              </select>
+
+              <select
+                value={qualityFlagFilter}
+                onChange={(event) => setQualityFlagFilter(event.target.value)}
+                className="h-8 rounded-md border border-border bg-background px-2 text-sm"
+                title="Filter by quality flag"
+              >
+                <option value="all">All flags</option>
+                {(facets?.quality_flags ?? []).map((flag) => (
+                  <option key={flag} value={flag}>
+                    {flag}
                   </option>
                 ))}
               </select>
@@ -923,16 +1078,32 @@ export default function Gallery() {
                           );
                         })}
                       </div>
-                      {selectedImage.publication.quality_flags.length > 0 && (
-                        <div className="mt-3 flex flex-wrap gap-2">
-                          {selectedImage.publication.quality_flags.map((flag) => (
-                            <span key={flag} className="rounded border border-border px-2 py-0.5 text-xs text-muted-foreground">
-                              {flag}
+                    {selectedImage.publication.quality_flags.length > 0 && (
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {selectedImage.publication.quality_flags.map((flag) => (
+                          <span key={flag} className="rounded border border-border px-2 py-0.5 text-xs text-muted-foreground">
+                            {flag}
                             </span>
                           ))}
                         </div>
                       )}
                     </div>
+
+                    {selectedExperimentRows.length > 0 && (
+                      <div className="rounded-md border border-border bg-muted/30 p-3">
+                        <div className="mb-2 text-[11px] uppercase tracking-wide text-muted-foreground">Experiment</div>
+                        <dl className="grid gap-2">
+                          {selectedExperimentRows.map((row) => (
+                            <div key={row.key} className="grid grid-cols-[120px_minmax(0,1fr)] gap-3 text-xs">
+                              <dt className="capitalize text-muted-foreground">{row.label}</dt>
+                              <dd className="break-words font-medium text-foreground">
+                                {formatMetadataValue(row.value)}
+                              </dd>
+                            </div>
+                          ))}
+                        </dl>
+                      </div>
+                    )}
 
                     {selectedMetadataRows.length > 0 && (
                       <div className="rounded-md border border-border bg-muted/30 p-3">

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -13,11 +13,51 @@ const WS_BASE = normalizeBase(
 
 export interface GenerateRequest {
   prompt?: string;
+  meta_prompt?: string;
   use_mock?: boolean;
   enable_plugins?: boolean;
   seed?: number;
   recipe_id?: string;
+  experiment_label?: string;
+  prompt_family?: string;
+  quality_flags?: string[];
   client_request_id?: string;
+}
+
+export interface ExperimentMetadata {
+  id?: string;
+  label?: string | null;
+  prompt_family?: string | null;
+  prompt?: {
+    source?: string;
+    meta_prompt?: string | null;
+    final?: string;
+    model?: string | null;
+  };
+  pipeline?: {
+    configured_backend?: string;
+    resolved_backend?: string;
+    model?: string;
+    prompt_model?: string | null;
+  };
+  parameters?: {
+    seed?: number | null;
+    width?: number | null;
+    height?: number | null;
+    steps?: number | null;
+    guidance_scale?: number | null;
+    true_cfg_scale?: number | null;
+  };
+  enhancers?: {
+    plugins?: string[];
+    loras?: string[];
+    lora_application_probability?: number | null;
+  };
+  timing?: {
+    generation_seconds?: number;
+  };
+  diagnostic?: boolean;
+  quality_flags?: string[];
 }
 
 export interface GenerateResponse {
@@ -26,6 +66,10 @@ export interface GenerateResponse {
   image_path: string;
   metadata: {
     backend: string;
+    model?: string;
+    generation_time?: number;
+    experiment?: ExperimentMetadata;
+    quality_flags?: string[];
     plugins_used: string[];
     seed?: number;
     provider?: string;
@@ -129,6 +173,7 @@ export interface GenerationConfig {
   ollama_temperature: number;
   ollama_model?: string;
   prompt_model?: string;
+  configured_prompt_model?: string;
   image_backend?: string;
   image_model?: string;
   ollama_image_model?: string;
@@ -136,6 +181,7 @@ export interface GenerationConfig {
     prompt: {
       provider: string;
       model: string;
+      configured_model?: string;
     };
     image: {
       backend: string;
@@ -222,6 +268,9 @@ export interface CreateGenerationJobRequest {
   seed?: number;
   recipe_id?: string;
   publication_state?: string;
+  experiment_label?: string;
+  prompt_family?: string;
+  quality_flags?: string[];
   client_request_id?: string;
   metadata?: Record<string, unknown>;
 }
@@ -271,6 +320,21 @@ export interface GallerySyncStatus {
   skipped_preview: Array<{ key: string; reason: string }>;
   command: string;
   message: string;
+}
+
+export interface GalleryFacets {
+  backends: string[];
+  models: string[];
+  prompt_families: string[];
+  quality_flags: string[];
+  publication_states: string[];
+}
+
+export interface GalleryCatalogFilters {
+  backend?: string;
+  model?: string;
+  prompt_family?: string;
+  quality_flag?: string;
 }
 
 const extractErrorMessage = async (response: Response, fallback: string) => {
@@ -404,7 +468,8 @@ export class ImageGenAPI {
     limit: number = 100,
     offset: number = 0,
     state?: PublicationState | 'all',
-    timeoutMs: number = 20000
+    timeoutMs: number = 20000,
+    filters: GalleryCatalogFilters = {}
   ): Promise<GalleryCatalogResponse> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -413,6 +478,10 @@ export class ImageGenAPI {
       offset: String(offset),
     });
     if (state && state !== 'all') params.set('state', state);
+    if (filters.backend) params.set('backend', filters.backend);
+    if (filters.model) params.set('model', filters.model);
+    if (filters.prompt_family) params.set('prompt_family', filters.prompt_family);
+    if (filters.quality_flag) params.set('quality_flag', filters.quality_flag);
 
     try {
       const response = await fetch(`${this.baseUrl}/api/gallery/catalog?${params.toString()}`, {
@@ -437,17 +506,22 @@ export class ImageGenAPI {
     return response.json();
   }
 
+  async getGalleryFacets(): Promise<GalleryFacets> {
+    const response = await fetch(`${this.baseUrl}/api/gallery/facets`);
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get gallery facets'));
+    return response.json();
+  }
+
   async updatePublicationState(
     imagePath: string,
-    state: PublicationState,
-    allowPlaceholderPublish: boolean = false
+    state: PublicationState
   ): Promise<GalleryCatalogEntry> {
     const response = await fetch(`${this.baseUrl}/api/gallery/publication/${encodeURIComponent(imagePath)}`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ state, allow_placeholder_publish: allowPlaceholderPublish }),
+      body: JSON.stringify({ state }),
     });
     if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to update publication state'));
     return response.json();


### PR DESCRIPTION
## Summary

Adds experiment traceability across generation, API, catalog review, and the web UI so DreamGen behaves more like a local model-probing instrument.

## What changed

- Persist a structured `experiment` metadata envelope with prompt source, meta-prompt, backend/model, seed, dimensions, steps, guidance, enhancer state, timing, diagnostic status, and quality flags.
- Add request-level experiment annotations: `experiment_label`, `prompt_family`, `quality_flags`, and `meta_prompt` on the compatibility generate path.
- Resolve stale configured Ollama prompt aliases for display, so generated-prompt metadata shows the actual usable prompt model while preserving the configured alias.
- Add gallery catalog filtering by backend, model, prompt family, and quality flag, plus a new `/api/gallery/facets` endpoint.
- Add Generate-screen controls for experiment label, prompt family, and quality flags, plus a current-output experiment snapshot.
- Add Gallery filters and selected-image experiment details.
- Remove the placeholder publication override so mock/smoke diagnostic artifacts cannot be published by stale clients.
- Allow arbitrary localhost review ports through API CORS to avoid false browser fetch/React errors during local review.
- Refresh `host-image` lockfile and add npm overrides for patched `esbuild`/`ws` versions so the Worker audit check passes.

## Related issues

- Related to #42: adds catalog filters, selected-image experiment details, publication-state safety, and quality flags, but does not complete batch actions/search/collection curation.
- Related to #45: adds structured lifecycle/experiment metadata and recent generation event display, but does not complete the broader OpenTelemetry/metrics scope.
- Related to #43: improves model/prompt resolution visibility, but does not complete a centralized runtime manager.

No broad roadmap issue is fully closed by this PR.

## Validation

- Browser sweep on `http://localhost:7862/`: Create, prompt modals, Gallery, Gallery controls, Settings, and all Settings tabs produced 0 new actionable console warnings/errors.
- `./.venv-test/Scripts/python.exe -m pytest tests/ -m "not slow" -q` - 100 passed, 1 deselected.
- `npm run lint` - passed.
- `npm run build` - passed.
- `./.venv-test/Scripts/python.exe -m compileall src` - passed.
- `host-image`: `npm ci`, `npx tsc --noEmit`, `npm test -- --run`, and `npm audit --audit-level=moderate` all passed locally.