### PR TITLE
Fix stale prompt model config fallback

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -63,6 +63,8 @@ ERNIE_IMAGE_PROMPT_ENHANCER=true
 # If running Ollama locally, use host.docker.internal on Windows/Mac
 # or the actual host IP on Linux
 OLLAMA_HOST=http://host.docker.internal:11434
+# Preferred local completion model. If this is stale, DreamGen will select an
+# available completion-capable model and normalize the runtime setting.
 OLLAMA_MODEL=llama3.2:3b
 # Optional: only used when IMAGE_BACKEND=ollama
 OLLAMA_IMAGE_MODEL=

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ MOCK_MODE=false
 HF_TOKEN=
 
 # Prompt generation
+# Preferred local Ollama completion model. If this is stale, DreamGen will select
+# an available completion-capable local model and normalize the runtime setting.
 OLLAMA_MODEL=llama3.2:3b
 # Optional: used only when IMAGE_BACKEND=ollama
 OLLAMA_IMAGE_MODEL=

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ uv sync
 # Configure the app
 cp .env.example .env
 # Edit .env for your machine:
-# - OLLAMA_MODEL must point at a local Ollama model
+# - OLLAMA_MODEL is the preferred local prompt model; DreamGen normalizes stale values at runtime
 # - OLLAMA_IMAGE_MODEL is optional and only used for IMAGE_BACKEND=ollama
 # - HF_TOKEN is optional for small/turbo/smoke public models
 # - IMAGE_BACKEND=qwen enables the NF4 Qwen-Image backend for text-heavy posters and signage

--- a/host-image/package-lock.json
+++ b/host-image/package-lock.json
@@ -41,16 +41,16 @@
 			}
 		},
 		"node_modules/@cloudflare/vitest-pool-workers": {
-			"version": "0.16.15",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.15.tgz",
-			"integrity": "sha512-R0kZhIm4uSxOeTWPHY9xYIFPGRBEHPzl/n9BbHZSY/gk0n16uDU7T1JZe372oTF+diXG1uVBWqiiRc7Hxstdow==",
+			"version": "0.16.20",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.20.tgz",
+			"integrity": "sha512-buw0YgsAMT7s60wcmyxbtciEJjMJzKcWzayDMPhWaqMqfQzW+0WPLV67Lobn4C80nkNQhYocEJPnrEhLWnOf+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cjs-module-lexer": "1.2.3",
-				"esbuild": "0.27.3",
-				"miniflare": "4.20260611.0",
-				"wrangler": "4.100.0",
+				"esbuild": "0.28.1",
+				"miniflare": "4.20260625.0",
+				"wrangler": "4.105.0",
 				"zod": "3.25.76"
 			},
 			"peerDependencies": {
@@ -60,9 +60,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260611.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260611.1.tgz",
-			"integrity": "sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA==",
+			"version": "1.20260625.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260625.1.tgz",
+			"integrity": "sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A==",
 			"cpu": [
 				"x64"
 			],
@@ -77,9 +77,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260611.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260611.1.tgz",
-			"integrity": "sha512-yBbVXvbZyltR3I7NJdC4C4ItkItjZSiabcA/3HzEWOUQjLVKFqRh4so6ToHr70VCYh8VGeR8EDZL23igLhXqFQ==",
+			"version": "1.20260625.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260625.1.tgz",
+			"integrity": "sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw==",
 			"cpu": [
 				"arm64"
 			],
@@ -94,9 +94,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260611.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260611.1.tgz",
-			"integrity": "sha512-PfNjpxOlaIgZFYuhD7+neEEewCN2Ud993wEEN0fmbtSOax1AK53LGqmXUDvFhnbkHxJLFAxYCSNISW8QbzaAIg==",
+			"version": "1.20260625.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260625.1.tgz",
+			"integrity": "sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ==",
 			"cpu": [
 				"x64"
 			],
@@ -111,9 +111,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260611.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260611.1.tgz",
-			"integrity": "sha512-GEp4XbuIKjlF8pakqXcUDJfKiJosD/Q7S83J0d+r+z9XIlYGfF3ntm08e2aiF5TFTwp3fnG4yMoPUAKNhNJpvQ==",
+			"version": "1.20260625.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260625.1.tgz",
+			"integrity": "sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -128,9 +128,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260611.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260611.1.tgz",
-			"integrity": "sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw==",
+			"version": "1.20260625.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260625.1.tgz",
+			"integrity": "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow==",
 			"cpu": [
 				"x64"
 			],
@@ -2119,17 +2119,17 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260611.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260611.0.tgz",
-			"integrity": "sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg==",
+			"version": "4.20260625.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260625.0.tgz",
+			"integrity": "sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "0.34.5",
-				"undici": "7.24.8",
-				"workerd": "1.20260611.1",
-				"ws": "8.20.1",
+				"undici": "7.28.0",
+				"workerd": "1.20260625.1",
+				"ws": "8.21.0",
 				"youch": "4.1.0-beta.10"
 			},
 			"bin": {
@@ -2438,9 +2438,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-			"integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2643,9 +2643,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260611.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260611.1.tgz",
-			"integrity": "sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w==",
+			"version": "1.20260625.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260625.1.tgz",
+			"integrity": "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -2656,28 +2656,28 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260611.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260611.1",
-				"@cloudflare/workerd-linux-64": "1.20260611.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260611.1",
-				"@cloudflare/workerd-windows-64": "1.20260611.1"
+				"@cloudflare/workerd-darwin-64": "1.20260625.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260625.1",
+				"@cloudflare/workerd-linux-64": "1.20260625.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260625.1",
+				"@cloudflare/workerd-windows-64": "1.20260625.1"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.100.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.100.0.tgz",
-			"integrity": "sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg==",
+			"version": "4.105.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.105.0.tgz",
+			"integrity": "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.5.0",
 				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
-				"esbuild": "0.27.3",
-				"miniflare": "4.20260611.0",
+				"esbuild": "0.28.1",
+				"miniflare": "4.20260625.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260611.1"
+				"workerd": "1.20260625.1"
 			},
 			"bin": {
 				"cf-wrangler": "bin/cf-wrangler.js",
@@ -2691,7 +2691,7 @@
 				"fsevents": "2.3.3"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260611.1"
+				"@cloudflare/workers-types": "^4.20260625.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -46,6 +46,7 @@ from src.services import (
 from src.utils.config import Config
 from src.utils.gallery_publisher import DEFAULT_BUCKET, build_publish_status
 from src.utils.ollama import (
+    OllamaModelInfo,
     get_ollama_version,
     list_ollama_models,
     ollama_host,
@@ -173,12 +174,48 @@ def resolved_prompt_model_name() -> str:
     configured_prompt_model = config.model.ollama_model
     try:
         return (
-            resolve_ollama_model(list_ollama_models(), configured_prompt_model, "completion")
+            resolve_prompt_model_from_models(
+                list_ollama_models(),
+                default_to_configured=True,
+            )
             or configured_prompt_model
         )
     except Exception as exc:
         logger.warning("Could not resolve configured Ollama prompt model: %s", exc)
         return configured_prompt_model
+
+
+def set_configured_prompt_model(model_name: str) -> None:
+    """Update the process-wide preferred Ollama prompt model."""
+    config.model.ollama_model = model_name
+    os.environ["OLLAMA_MODEL"] = model_name
+
+
+def resolve_prompt_model_from_models(
+    models: List[OllamaModelInfo],
+    *,
+    reconcile_config: bool = False,
+    default_to_configured: bool = False,
+) -> Optional[str]:
+    """Resolve a prompt model and optionally promote the resolved model into config."""
+    configured_prompt_model = config.model.ollama_model
+    resolved_model = resolve_ollama_model(models, configured_prompt_model, "completion")
+
+    if resolved_model and reconcile_config and resolved_model != configured_prompt_model:
+        logger.info(
+            "Updating Ollama prompt model config from %s to available local model %s",
+            configured_prompt_model,
+            resolved_model,
+        )
+        set_configured_prompt_model(resolved_model)
+
+    if resolved_model:
+        return resolved_model
+
+    if default_to_configured:
+        return configured_prompt_model
+
+    return None
 
 
 def generation_config_payload() -> Dict[str, Any]:
@@ -1291,7 +1328,11 @@ async def get_ollama_models():
     """Get list of available Ollama models"""
     try:
         models = list_ollama_models()
-        current_prompt = resolve_ollama_model(models, config.model.ollama_model, "completion")
+        current_prompt = resolve_prompt_model_from_models(
+            models,
+            reconcile_config=True,
+            default_to_configured=False,
+        )
         current_image = resolve_ollama_model(models, config.model.ollama_image_model, "image")
         try:
             version = get_ollama_version()
@@ -1335,11 +1376,7 @@ async def set_ollama_model(data: dict):
         raise HTTPException(status_code=400, detail="Model name is required")
 
     try:
-        # Update config
-        config.model.ollama_model = model_name
-
-        # Also update environment variable for persistence
-        os.environ["OLLAMA_MODEL"] = model_name
+        set_configured_prompt_model(model_name)
 
         logger.info(f"Ollama model set to: {model_name}")
         return {"message": f"Ollama model set to {model_name}", "model": model_name}
@@ -1374,8 +1411,7 @@ async def set_generation_config(data: dict):
             prompt_model = str(data["ollama_model"]).strip()
             if not prompt_model:
                 raise ValueError("ollama_model must not be empty")
-            config.model.ollama_model = prompt_model
-            os.environ["OLLAMA_MODEL"] = prompt_model
+            set_configured_prompt_model(prompt_model)
         if "image_backend" in data:
             backend = str(data["image_backend"]).lower()
             if backend not in ALLOWED_IMAGE_BACKENDS:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -463,9 +463,10 @@ def test_jobs_endpoint_runs_recipe_and_persists_recipe_metadata(client):
 
 
 def test_ollama_models_endpoint_includes_capabilities_and_resolved_models(client, monkeypatch):
-    """The Ollama models endpoint should expose capabilities plus resolved prompt/image selections."""
+    """The Ollama models endpoint should expose capabilities and normalize stale prompt config."""
     original_prompt_model = api_config.model.ollama_model
     original_image_model = api_config.model.ollama_image_model
+    original_env_prompt_model = os.environ.get("OLLAMA_MODEL")
 
     mock_models = [
         OllamaModelInfo(
@@ -506,16 +507,22 @@ def test_ollama_models_endpoint_includes_capabilities_and_resolved_models(client
 
         data = response.json()
         assert data["current"] == "qwen3.6:27b"
-        assert data["configured_prompt"] == "llama3.2:3b"
+        assert data["configured_prompt"] == "qwen3.6:27b"
         assert data["current_image"] == "x/z-image-turbo:latest"
         assert data["configured_image"] == "x/z-image-turbo"
         assert data["version"] == "0.21.2"
         assert data["models"][0]["can_image"] is True
         assert data["models"][1]["can_prompt"] is True
         assert "vision" in data["models"][1]["capabilities"]
+        assert api_config.model.ollama_model == "qwen3.6:27b"
+        assert os.environ["OLLAMA_MODEL"] == "qwen3.6:27b"
     finally:
         api_config.model.ollama_model = original_prompt_model
         api_config.model.ollama_image_model = original_image_model
+        if original_env_prompt_model is None:
+            os.environ.pop("OLLAMA_MODEL", None)
+        else:
+            os.environ["OLLAMA_MODEL"] = original_env_prompt_model
 
 
 def test_gallery_endpoint(client):

--- a/web-ui/components/Settings.tsx
+++ b/web-ui/components/Settings.tsx
@@ -490,11 +490,6 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                         <div className="mt-3 text-sm font-medium text-foreground break-all">
                           {activePromptModel ?? promptModelFallback ?? "No prompt model"}
                         </div>
-                        {configuredPromptModel && activePromptModel && configuredPromptModel !== activePromptModel && (
-                          <div className="mt-2 text-xs text-amber-700 dark:text-amber-300">
-                            Configured {configuredPromptModel}; using {activePromptModel}.
-                          </div>
-                        )}
                         <div className="mt-3 flex flex-wrap gap-2">
                           {loadingOllama ? (
                             <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
@@ -890,12 +885,6 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                   </div>
                 ) : ollamaModels && ollamaModels.models.length > 0 ? (
                   <div className="space-y-6">
-                    {configuredPromptModel && activePromptModel && configuredPromptModel !== activePromptModel && (
-                      <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
-                        Configured prompt model <code>{configuredPromptModel}</code> is not usable on this host. DreamGen is falling back to <code>{activePromptModel}</code>.
-                      </div>
-                    )}
-
                     <div>
                       <div className="mb-3">
                         <h4 className="font-medium">Prompt Models</h4>


### PR DESCRIPTION
## Summary
- Normalize stale Ollama prompt model config to the resolved local completion-capable model in the API.
- Remove the persistent prompt-model fallback warning from Settings once the backend has reconciled the active model.
- Update environment docs and API coverage for the runtime normalization behavior.

## Root Cause
The backend resolved a usable prompt model but continued reporting the stale configured `OLLAMA_MODEL`, which made the frontend show a scary fallback banner even when DreamGen had a valid active prompt model.

## Validation
- `uv run pytest tests/test_api.py tests/test_ollama_integration.py tests/test_config_env.py`
- `npm run lint`
- `npm run build`
- Previously verified on Docker: `/api/ollama/models` and `/api/config/generation` report `ornith:9b` as both active and configured, and Settings shows `ornith:9b` as Active Prompt without the fallback warning.