### PR TITLE
Add ad-hoc CLI image output

### DIFF
--- a/src/services/image_generation.py
+++ b/src/services/image_generation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import shutil
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -47,6 +48,8 @@ class GenerationServiceRequest:
     publication_state: str = "draft"
     cleanup: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
+    output_path: Path | None = None
+    add_to_gallery: bool = True
 
 
 @dataclass(frozen=True)
@@ -359,7 +362,7 @@ class ImageGenService:
         )
 
         storage = StorageManager(str(self.output_dir))
-        requested_output_path = storage.get_output_path(final_prompt)
+        requested_output_path = request.output_path or storage.get_output_path(final_prompt)
         await self._emit(
             callback,
             GenerationProgressEvent(
@@ -374,6 +377,17 @@ class ImageGenService:
                 force_reinit=request.force_reinit,
                 seed=request.seed,
             )
+            if image_path.resolve() != requested_output_path.resolve():
+                requested_output_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(image_path), str(requested_output_path))
+                for suffix in (".txt", ".meta.json"):
+                    source_sidecar = image_path.with_suffix(suffix)
+                    if source_sidecar.exists():
+                        shutil.move(
+                            str(source_sidecar),
+                            str(requested_output_path.with_suffix(suffix)),
+                        )
+                image_path = requested_output_path
         finally:
             if request.cleanup:
                 image_gen.cleanup()
@@ -384,7 +398,11 @@ class ImageGenService:
                 name="finalizing_output",
                 progress=92,
                 label="Finalizing output",
-                detail="Saving metadata and writing the finished image to the gallery.",
+                detail=(
+                    "Saving metadata and writing the finished image to the gallery."
+                    if request.add_to_gallery
+                    else "Saving metadata for the ad-hoc output."
+                ),
             ),
         )
 
@@ -421,14 +439,18 @@ class ImageGenService:
             "quality_flags": experiment_metadata["quality_flags"],
         }
         write_image_metadata(image_path, saved_metadata)
-        publication_entry = register_image(
-            image_path,
-            self.output_dir,
-            prompt=final_prompt,
-            metadata=saved_metadata,
-            publication_state=request.publication_state,
-        )
-        relative_image_path = f"/images/{image_path.relative_to(self.output_dir).as_posix()}"
+        publication_entry = None
+        if request.add_to_gallery:
+            publication_entry = register_image(
+                image_path,
+                self.output_dir,
+                prompt=final_prompt,
+                metadata=saved_metadata,
+                publication_state=request.publication_state,
+            )
+            relative_image_path = f"/images/{image_path.relative_to(self.output_dir).as_posix()}"
+        else:
+            relative_image_path = str(image_path.resolve())
         response_metadata = {
             **request.metadata,
             **generation_metadata,
@@ -437,12 +459,16 @@ class ImageGenService:
             "generation_time": generation_time,
             "experiment": experiment_metadata,
             "quality_flags": experiment_metadata["quality_flags"],
-            "publication": {
-                "id": publication_entry["id"],
-                "state": publication_entry["publication_state"],
-                "publishable": publication_entry["publishable"],
-                "quality_flags": publication_entry["quality_flags"],
-            },
+            "publication": (
+                {
+                    "id": publication_entry["id"],
+                    "state": publication_entry["publication_state"],
+                    "publishable": publication_entry["publishable"],
+                    "quality_flags": publication_entry["quality_flags"],
+                }
+                if publication_entry
+                else {"state": "untracked", "publishable": False}
+            ),
             "plugins_used": active_plugins,
             "seed": resolved_seed,
         }

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -55,6 +55,7 @@ from ..services import (
 from .config import Config
 from .logging_config import setup_logging
 from .metrics import MetricsCollector
+from .storage import StorageManager
 from .troubleshoot import SystemDiagnostics
 
 # Initialize rich console for better output
@@ -441,6 +442,17 @@ def generate(
         "--summary-json",
         help="Print a machine-readable generation summary after success",
     ),
+    no_gallery: bool = typer.Option(
+        False,
+        "--no-gallery",
+        help="Save an ad-hoc image in the current directory without adding it to the gallery",
+    ),
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        "--ad-hoc-path",
+        help="Save outside the gallery at this PNG file or directory",
+    ),
 ) -> None:
     """Generate a single image using AI-generated prompts or a custom prompt."""
 
@@ -527,6 +539,21 @@ def generate(
                                 prompt_gen.cleanup()
 
                         # Generate image
+                        ad_hoc = no_gallery or output is not None
+                        requested_output_path = None
+                        if ad_hoc:
+                            target = (output or Path.cwd()).expanduser()
+                            if target.suffix.lower() == ".png":
+                                requested_output_path = target
+                            else:
+                                filename = (
+                                    StorageManager(".")
+                                    .get_output_path(generation_prompt or "generated image")
+                                    .name
+                                )
+                                requested_output_path = target / filename
+                            requested_output_path = requested_output_path.resolve()
+
                         image_task = progress.add_task("[cyan]Generating image...", total=None)
                         try:
                             with temporary_backend_override(app.state.config, backend, mock):
@@ -538,12 +565,14 @@ def generate(
                                             publication_state=publication_state,
                                             metadata=generation_metadata,
                                             cleanup=True,
+                                            output_path=requested_output_path,
+                                            add_to_gallery=not ad_hoc,
                                         ),
                                         callback=print_generation_service_event,
                                     ),
                                     backend_name=resolved_backend,
                                     phase="Image generation",
-                                    output_path=None,
+                                    output_path=requested_output_path,
                                 )
                         except Exception as e:
                             console.print(

--- a/tests/test_cli_generation_progress.py
+++ b/tests/test_cli_generation_progress.py
@@ -48,6 +48,54 @@ def test_generate_accepts_model_alias_for_backend(tmp_path, monkeypatch):
     assert "resolved: mock" in result.stdout
 
 
+def test_generate_no_gallery_saves_in_current_directory(tmp_path, monkeypatch):
+    gallery_dir = tmp_path / "gallery"
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    monkeypatch.setenv("OUTPUT_DIR", str(gallery_dir))
+
+    with runner.isolated_filesystem(temp_dir=work_dir):
+        result = runner.invoke(
+            app, ["generate", "--mock", "--prompt", "ad hoc prompt", "--no-gallery"]
+        )
+        images = list(Path.cwd().glob("*.png"))
+
+    assert result.exit_code == 0, result.stdout
+    assert len(images) == 1
+    assert not (gallery_dir / ".gallery_catalog.json").exists()
+
+
+def test_generate_output_path_implies_no_gallery(tmp_path, monkeypatch):
+    gallery_dir = tmp_path / "gallery"
+    output_path = tmp_path / "agent-output" / "result.png"
+    monkeypatch.setenv("OUTPUT_DIR", str(gallery_dir))
+
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            "--mock",
+            "--prompt",
+            "agent image",
+            "--output",
+            str(output_path),
+            "--summary-json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert output_path.exists()
+    assert output_path.with_suffix(".txt").exists()
+    assert output_path.with_suffix(".meta.json").exists()
+    assert not (gallery_dir / ".gallery_catalog.json").exists()
+    summary_line = next(
+        line for line in reversed(result.stdout.splitlines()) if line.startswith("{")
+    )
+    summary = json.loads(summary_line)
+    assert summary["image_path"] == str(output_path)
+    assert summary["metadata"]["publication"]["state"] == "untracked"
+
+
 def test_generate_summary_json_prints_machine_readable_result(tmp_path, monkeypatch):
     """Automation can consume a stable summary after human-readable output."""
     monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -140,6 +140,26 @@ async def test_service_can_reuse_caller_owned_backend(mock_service_config, tmp_p
 
 
 @pytest.mark.asyncio
+async def test_service_ad_hoc_output_skips_catalog(mock_service_config, tmp_path):
+    gallery_dir = tmp_path / "gallery"
+    output_path = tmp_path / "agent" / "result.png"
+    service = ImageGenService(mock_service_config, output_dir=gallery_dir)
+
+    result = await service.generate(
+        GenerationServiceRequest(
+            prompt="ad hoc service test",
+            output_path=output_path,
+            add_to_gallery=False,
+        )
+    )
+
+    assert result.image_path == output_path
+    assert result.relative_image_path == str(output_path.resolve())
+    assert result.publication == {"state": "untracked", "publishable": False}
+    assert not (gallery_dir / ".gallery_catalog.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_service_records_resolved_prompt_model(mock_service_config, tmp_path, monkeypatch):
     """Generated prompt metadata should use the model that actually produced it."""
 


### PR DESCRIPTION
Adds local ad-hoc image output for agents and operators. The generate command now supports --no-gallery for a uniquely named PNG in the current directory and --output/--ad-hoc-path for an explicit PNG file or directory; either mode skips gallery catalog registration while preserving prompt and metadata sidecars. The shared generation service accepts an exact output path, marks non-gallery artifacts as untracked, and normalizes backends that return a different path. Validation: 12 focused tests passed; black, isort, pylint, pre-commit checks, and diff checks passed. The broader suite reached the existing Windows diffsynth/pyarrow native crash in the real Z-Image pipeline test.