### PR TITLE
feat(runtime): release candidate with verified Mage-Flow

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -6,9 +6,11 @@
 # ========================================
 
 # Model Configuration
-# zimage: prefer local Z-Image-Turbo; fall back to Small Stable Diffusion until ready
-# auto: prefer ready local Z-Image-Turbo, then FLUX, then the small public model
+# auto: use verified Mage-Flow when ready, then ready local Z-Image-Turbo,
+# cached FLUX, and finally the small public model
+# zimage: force local Z-Image-Turbo with truthful Small SD fallback until ready
 # flux: force FLUX
+# mageflow: force Microsoft Mage-Flow through the isolated local CUDA sidecar
 # ollama: use an image-capable Ollama model over the configured Ollama host
 # small: force the small public fallback model
 # qwen: force Qwen-Image for text-rich posters, signs, and bilingual typography
@@ -16,7 +18,20 @@
 # turbo: force the fast turbo model
 # smoke: force the internal smoke-test model
 # mock: placeholder images only
-IMAGE_BACKEND=zimage
+IMAGE_BACKEND=auto
+
+# Microsoft Mage-Flow runs in an isolated local CUDA sidecar.
+MAGEFLOW_MODEL=microsoft/Mage-Flow
+MAGEFLOW_MODEL_REVISION=faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9
+MAGEFLOW_URL=http://mageflow:8001
+MAGEFLOW_STEPS=20
+MAGEFLOW_CFG=5.0
+MAGEFLOW_TIMEOUT_SECONDS=1800
+MAGEFLOW_ATTENTION=sdpa
+MAGEFLOW_MIN_VRAM_GB=20
+MAGEFLOW_PORT=25801
+# Pinned official source commit used by Dockerfile.mageflow.
+MAGEFLOW_SOURCE_SHA=6cefeb40e4c8ecc404ecb73732a91878939f27e0
 
 # Backward compatibility for older scripts. Leave false when using IMAGE_BACKEND.
 # Set to true only if you explicitly want placeholder images.
@@ -103,7 +118,9 @@ DEBUG=false
 # Hot reload (development only)
 RELOAD=false
 
-# Shared cache and model assets
+# Shared cache and model assets. Use an absolute path when running Compose from
+# a worktree so downloaded model snapshots survive checkout/container changes.
+# AI_CACHE_DIR=C:/Users/vaski/projects/dreamgen/.cache
 AI_CACHE_DIR=./.cache
 
 # Host gallery/output directory mounted into the backend.
@@ -111,6 +128,11 @@ AI_CACHE_DIR=./.cache
 # On Windows, prefer forward slashes in .env.docker, for example:
 # OUTPUT_HOST_DIR=C:/Users/vaski/projects/dreamgen/output
 OUTPUT_HOST_DIR=./output
+# Optional durable paths for model assets when reviewing from a worktree.
+CHECKPOINT_HOST_DIR=./ckpts
+LORA_HOST_DIR=./loras
+REF_REPOS_HOST_DIR=./ref-repos
+LOG_HOST_DIR=./logs
 
 # ========================================
 # GPU CONFIGURATION (Optional)

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -6,7 +6,8 @@
 # ========================================
 
 # Model Configuration
-# auto: use FLUX if cached, otherwise fall back to the small public model
+# zimage: prefer local Z-Image-Turbo; fall back to Small Stable Diffusion until ready
+# auto: prefer ready local Z-Image-Turbo, then FLUX, then the small public model
 # flux: force FLUX
 # ollama: use an image-capable Ollama model over the configured Ollama host
 # small: force the small public fallback model
@@ -15,7 +16,7 @@
 # turbo: force the fast turbo model
 # smoke: force the internal smoke-test model
 # mock: placeholder images only
-IMAGE_BACKEND=auto
+IMAGE_BACKEND=zimage
 
 # Backward compatibility for older scripts. Leave false when using IMAGE_BACKEND.
 # Set to true only if you explicitly want placeholder images.

--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,13 @@
 # Copy to .env and adjust for your machine
 
 # Image backend selection
-# auto: use FLUX if cached, otherwise small public fallback
+# auto: use ready Mage-Flow, then cached FLUX, otherwise small public fallback
 # flux: FLUX text-to-image
 # ollama: Ollama image generation via the local Ollama host
+# mageflow: Microsoft Mage-Flow through the isolated local CUDA sidecar
 # zimage: local Z-Image-Turbo checkout + weights
 # qwen: Qwen-Image backend for text-rich posters, signs, and bilingual typography
+# ernie: ERNIE-Image-Turbo prompt-enhanced renderer
 # small: small public Stable Diffusion fallback
 # turbo: SD Turbo backend
 # smoke: smoke-test model only
@@ -37,6 +39,14 @@ FLUX_MODEL=black-forest-labs/FLUX.1-schnell
 # Z-Image configuration
 # Clone ref-repos/Z-Image and download weights locally before using IMAGE_BACKEND=zimage
 ZIMAGE_MODEL_PATH=ckpts/Z-Image-Turbo
+
+# Microsoft Mage-Flow (public, ungated, research-only)
+MAGEFLOW_MODEL=microsoft/Mage-Flow
+MAGEFLOW_MODEL_REVISION=faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9
+MAGEFLOW_URL=http://localhost:25801
+MAGEFLOW_STEPS=20
+MAGEFLOW_CFG=5.0
+MAGEFLOW_TIMEOUT_SECONDS=1800
 ZIMAGE_ATTENTION=_sdpa
 ZIMAGE_COMPILE=false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,12 @@ Docker notes for reviewers:
 - Ollama is expected on `http://host.docker.internal:11434` from inside Docker on this machine.
 - If generated images look like diagnostic noise, the stack is likely on `smoke`; use `auto` or `small` for a real visual check.
 
+### Presentation preview rule
+
+Any DreamGen preview presented for review must come from a fresh Docker rebuild followed by
+container health and affected API/UI checks. Local Next.js dev servers may be used for
+development only and must not be presented as the current Docker/reviewer surface.
+
 ### Post-merge Docker deployment SOP
 
 After a branch is merged to `main`, do not treat a local dev server as the deployed review surface. The Next.js dev server on ports such as `3000` or `3001` is only for hot-reload development. The Docker stack is the reviewer/staging-like surface:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,9 @@ docker compose --env-file .env.docker down
 ```
 
 Docker notes for reviewers:
-- Default path is `IMAGE_BACKEND=zimage`: use Z-Image-Turbo when its local checkpoint is ready; otherwise report the unavailable preferred model and fall back to the smaller public model.
+- Default path is `IMAGE_BACKEND=auto`: use Mage-Flow only when its isolated runtime
+  and pinned public checkpoint are ready, then ready Z-Image-Turbo, cached FLUX,
+  or the smaller public model.
 - `HF_TOKEN` is optional for `auto`, `small`, `turbo`, and `smoke`; it is required if Docker needs to download gated Hugging Face models such as some FLUX variants.
 - Backend runs on `25800`, frontend runs on `7860`.
 - Ollama is expected on `http://host.docker.internal:11434` from inside Docker on this machine.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ docker compose --env-file .env.docker down
 ```
 
 Docker notes for reviewers:
-- Default path is `IMAGE_BACKEND=auto`: use FLUX if already cached, otherwise fall back to the smaller public model.
+- Default path is `IMAGE_BACKEND=zimage`: use Z-Image-Turbo when its local checkpoint is ready; otherwise report the unavailable preferred model and fall back to the smaller public model.
 - `HF_TOKEN` is optional for `auto`, `small`, `turbo`, and `smoke`; it is required if Docker needs to download gated Hugging Face models such as some FLUX variants.
 - Backend runs on `25800`, frontend runs on `7860`.
 - Ollama is expected on `http://host.docker.internal:11434` from inside Docker on this machine.

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -15,10 +15,11 @@ RUN apt-get update && apt-get install -y \
 # Copy dependency files first for better caching
 COPY pyproject.toml uv.lock ./
 
-# Create virtual environment and install dependencies
-# UV will handle Python and all dependencies
-RUN uv venv /opt/venv && \
-    uv pip install --python /opt/venv/bin/python --system -r pyproject.toml
+# Install the exact production dependency set captured in uv.lock.  Resolving
+# pyproject.toml directly here ignores tool.uv.sources and can select an
+# incompatible diffusers/huggingface-hub combination from the first index.
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+RUN uv sync --frozen --no-dev --no-install-project
 
 # Set up environment for builder stage too
 ENV PATH="/opt/venv/bin:$PATH"
@@ -48,7 +49,7 @@ COPY --chown=appuser:appuser data/ ./data/
 COPY --chown=appuser:appuser pyproject.toml uv.lock ./
 
 # Create necessary directories with proper permissions
-RUN mkdir -p /app/output /app/models /app/logs && \
+RUN mkdir -p /app/output /app/models /app/logs /app/.cache && \
     chown -R appuser:appuser /app
 
 # Switch to non-root user

--- a/Dockerfile.mageflow
+++ b/Dockerfile.mageflow
@@ -1,0 +1,53 @@
+# Isolated runtime for Microsoft Mage-Flow.
+#
+# Mage-Flow's tested Torch/Transformers versions are intentionally kept out of
+# DreamGen's main backend environment so existing generators retain their lock.
+FROM ghcr.io/astral-sh/uv:0.5.14-python3.11-bookworm-slim
+
+ARG MAGEFLOW_SOURCE_SHA=6cefeb40e4c8ecc404ecb73732a91878939f27e0
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/microsoft/Mage.git /opt/Mage \
+    && git -C /opt/Mage checkout "${MAGEFLOW_SOURCE_SHA}"
+
+RUN uv venv /opt/venv \
+    && uv pip install --python /opt/venv/bin/python \
+      torch==2.13.0 torchvision==0.28.0 \
+      --index-url https://download.pytorch.org/whl/cu130 \
+    && uv pip install --python /opt/venv/bin/python \
+      diffusers==0.38.0 \
+      transformers==5.5.0 \
+      accelerate==1.13.0 \
+      safetensors==0.8.0 \
+      "huggingface_hub>=0.20" \
+      einops==0.8.2 \
+      pydantic==2.12.5 \
+      pillow==12.3.0 \
+      numpy==2.4.3 \
+      loguru==0.7.3 \
+      "fastapi>=0.100" \
+      "uvicorn[standard]>=0.23" \
+    && uv pip install --python /opt/venv/bin/python --no-deps /opt/Mage/mage_flow
+
+WORKDIR /app
+COPY mageflow-service/app.py /app/app.py
+
+ENV PATH="/opt/venv/bin:$PATH"
+ENV HF_HOME=/models
+ENV MAGEFLOW_MODEL=microsoft/Mage-Flow
+ENV MAGEFLOW_MODEL_REVISION=faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9
+ENV MAGEFLOW_ATTENTION=sdpa
+ENV MAGEFLOW_MIN_VRAM_GB=20
+ENV MAGEFLOW_SOURCE_SHA=${MAGEFLOW_SOURCE_SHA}
+
+EXPOSE 8001
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD curl -f http://localhost:8001/health || exit 1
+
+ENTRYPOINT ["/opt/venv/bin/python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ cp .env.example .env
 # - HF_TOKEN is optional for small/turbo/smoke public models
 # - IMAGE_BACKEND=qwen enables the NF4 Qwen-Image backend for text-heavy posters and signage
 # - IMAGE_BACKEND=ernie enables ERNIE-Image-Turbo for prompt-enhanced multilingual text rendering
-# - IMAGE_BACKEND=zimage is the default preference; it uses Z-Image-Turbo when the local checkpoint is ready and reports a Small Stable Diffusion fallback until then
-# - IMAGE_BACKEND=auto prefers ready Z-Image-Turbo, then FLUX, then the small public fallback
+# - IMAGE_BACKEND=auto uses verified Mage-Flow when ready, then ready Z-Image-Turbo, cached FLUX, or Small SD
+# - IMAGE_BACKEND=zimage forces Z-Image-Turbo with truthful Small SD fallback until ready
+# - Mage-Flow is public but research-only and runs in an isolated CUDA sidecar
 
 # Generate from the CLI
 uv run dreamgen generate
@@ -96,6 +97,14 @@ For Z-Image review in Docker:
 - put LoRAs under `./loras/<name>/*.safetensors`
 - use **Settings → Models** to download `Z-Image-Turbo`
 - use **Settings → Models** to switch the active backend to `Z-Image`
+
+For Microsoft Mage-Flow review:
+
+- read [the verified availability/runtime note](docs/MAGE_FLOW.md)
+- use **Settings → Models** to download the pinned RL checkpoint
+  `microsoft/Mage-Flow@faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9`
+- wait for both checkpoint and isolated runtime readiness
+- select `Mage-Flow`, or leave `Auto` enabled once its card reports `READY`
 - use **Settings → Plugins** to enable `lora` and then select active LoRAs in the Models panel
 
 For Ollama-backed image generation:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Generate unlimited AI images locally with no subscriptions, no cloud APIs, and complete privacy. Your machine dreams with you! ✨
 
+DreamGen is an independent research and artistic hobby project for exploring
+what local image models "dream," how their behavior changes, and where their
+boundaries appear. It is not a hosted production image service. Model names and
+upstream projects are identified for reproducibility; their inclusion does not
+imply sponsorship, endorsement, or affiliation.
+
 ![Do androids dream of electric sheep?](https://host-image.agentic.workers.dev/)
 
 ## ✨ Modern Web Interface
@@ -101,6 +107,8 @@ For Z-Image review in Docker:
 For Microsoft Mage-Flow review:
 
 - read [the verified availability/runtime note](docs/MAGE_FLOW.md)
+- treat it as a local research probe consistent with Microsoft's published
+  research-only guidance, not as a production-service backend
 - use **Settings → Models** to download the pinned RL checkpoint
   `microsoft/Mage-Flow@faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9`
 - wait for both checkpoint and isolated runtime readiness

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ cp .env.example .env
 # - HF_TOKEN is optional for small/turbo/smoke public models
 # - IMAGE_BACKEND=qwen enables the NF4 Qwen-Image backend for text-heavy posters and signage
 # - IMAGE_BACKEND=ernie enables ERNIE-Image-Turbo for prompt-enhanced multilingual text rendering
-# - IMAGE_BACKEND=auto uses FLUX if cached, otherwise the small public fallback
+# - IMAGE_BACKEND=zimage is the default preference; it uses Z-Image-Turbo when the local checkpoint is ready and reports a Small Stable Diffusion fallback until then
+# - IMAGE_BACKEND=auto prefers ready Z-Image-Turbo, then FLUX, then the small public fallback
 
 # Generate from the CLI
 uv run dreamgen generate

--- a/VISION.md
+++ b/VISION.md
@@ -9,6 +9,13 @@ Treat DreamGen as an instrument for probing models, not just a button that makes
 nice pictures. It should keep moving with the best image engines that people can
 actually download and run on one high-end consumer machine.
 
+DreamGen is an independent research, artistic hobby project about machine
+"dreaming." It is not a hosted production image service. Research-only model
+guidance can therefore be compatible with the project when local use is lawful,
+the intended-use limits stay visible, and operators remain in control. Including
+a model does not imply that its authors sponsor, endorse, or are affiliated with
+DreamGen.
+
 ## Use This Lens
 
 When changing or extending DreamGen, prefer work that helps answer questions like:

--- a/VISION.md
+++ b/VISION.md
@@ -6,7 +6,8 @@ how their boundaries shift when prompts, seeds, LoRAs, enhancers, and backends
 change.
 
 Treat DreamGen as an instrument for probing models, not just a button that makes
-nice pictures.
+nice pictures. It should keep moving with the best image engines that people can
+actually download and run on one high-end consumer machine.
 
 ## Use This Lens
 
@@ -30,6 +31,12 @@ DreamGen should stay local-first and operator-controlled. Private prompts,
 generated images, model choices, and experiment history should remain local
 unless the operator deliberately publishes them.
 
+The target machine is a Windows workstation with an NVIDIA RTX 4090-class
+24 GB GPU or better. DreamGen should optimize unapologetically for that audience:
+people building a personal visual laboratory and palette of experiments on one
+consumer machine. Apple Silicon and MLX are not a primary compatibility target;
+the MLX ecosystem already serves that hardware with engines optimized for it.
+
 The UI, CLI, API, gallery, and metadata should make model exploration easier by
 surfacing:
 
@@ -41,6 +48,39 @@ surfacing:
 
 Do not hide fallback, mock, or smoke behavior behind successful-looking output.
 Diagnostic images are useful only when they are clearly labeled as diagnostic.
+
+## Engine Support Window
+
+DreamGen supports exactly three image engines at a time:
+
+1. **Featured:** the newest credible, publicly downloadable engine that runs
+   locally on the target machine.
+2. **Comparison:** the strongest useful prior engine for repeatable A/B
+   experiments.
+3. **Fallback:** the smallest dependable engine that keeps the instrument usable
+   when the larger runtimes are unavailable.
+
+As of July 2026, that set is:
+
+- **Featured / latest:** Microsoft Mage-Flow (RL-aligned checkpoint)
+- **Comparison:** Z-Image-Turbo
+- **Fallback:** Small Stable Diffusion
+
+"Latest" is a maintained product claim, not marketing filler. The Settings and
+System surfaces should advertise the current featured engine, its exact source
+and checkpoint revision, why it was selected, and whether this machine is truly
+ready to run it.
+
+An engine may be open source, research-only, commercially licensed, or
+non-commercial. What matters for inclusion is that it is legally and freely
+downloadable for local use, runnable without a paid generation API, interesting
+to probe, and honest about its license and intended-use limits.
+
+When a new featured engine earns a place, rotate the support window. Do not keep
+old generators as permanent compatibility baggage: remove their runtime,
+configuration, UI, tests, and documentation once they fall outside the supported
+three. Historical gallery metadata should remain readable even after an engine
+is retired.
 
 ## What Good Work Looks Like
 
@@ -58,6 +98,8 @@ Examples:
 - safer publication controls so exploratory artifacts do not become public by
   accident
 - small backend improvements that preserve comparability across models
+- disciplined engine rotations that replace stale support instead of adding a
+  fourth backend
 
 ## Keep Out
 
@@ -67,8 +109,11 @@ site, or a grab bag of unrelated automation.
 Be skeptical of:
 
 - cloud-first generation paths
+- paid generation APIs standing in for a downloadable local engine
+- support work aimed at hardware below the RTX 4090-class target
 - features that make experiments less reproducible
 - backend additions with no clear way to inspect their behavior
+- dormant generators kept indefinitely "just in case"
 - UI that hides model settings in favor of a simplified magic button
 - publication flows that blur private exploration and public gallery output
 - broad rewrites that do not improve model probing, comparison, or artifact
@@ -76,6 +121,7 @@ Be skeptical of:
 
 ## North Star
 
-A user should be able to ask, "What is this model's imagination made of, and
-where does it stop?" DreamGen should help them find out, save the evidence, and
-compare the answer across models.
+A person with a powerful consumer GPU should be able to install today's most
+interesting downloadable image engine and ask, "What is this model's imagination
+made of, and where does it stop?" DreamGen should help them find out, save the
+evidence, and compare it with the two engines that matter most.

--- a/cloudflare-gallery/functions/api/images/[[path]].js
+++ b/cloudflare-gallery/functions/api/images/[[path]].js
@@ -1,13 +1,28 @@
+const CURRENT_MANIFEST_KEY = '_dreamgen/current.json';
+
 export async function onRequestGet(ctx) {
   const path = ctx.params.path?.join('/') || '';
 
-  // List all images with optional prompt/metadata sidecars.
+  // The release manifest is the approval boundary and the canonical ordering.
   if (!path) {
+    const manifest = await readJson(ctx.env.GALLERY, CURRENT_MANIFEST_KEY);
+    if (isReleaseManifest(manifest)) {
+      const images = manifest.items.map(item => buildManifestImageRecord(item, manifest));
+      return Response.json(images, {
+        headers: {
+          'Cache-Control': 'no-store',
+          'X-DreamGen-Release': manifest.release_id,
+          'ETag': `"${manifest.release_id}"`
+        }
+      });
+    }
+
+    // Backward-compatible fallback before the first manifest-based publish.
     const objects = await listAllObjects(ctx.env.GALLERY);
     const objectKeys = new Set(objects.map(o => o.key));
     const imageObjects = objects
       .filter(o => /\.(png|jpg|jpeg|webp|gif)$/i.test(o.key))
-      .sort((a, b) => sortTimestamp(b) - sortTimestamp(a));
+      .sort((a, b) => sortTimestamp(b) - sortTimestamp(a) || a.key.localeCompare(b.key));
 
     const images = [];
     for (const object of imageObjects) {
@@ -38,13 +53,70 @@ export async function onRequestGet(ctx) {
     json: 'application/json; charset=utf-8'
   };
 
-  return new Response(file.body, {
-    headers: {
-      'Content-Type': file.httpMetadata?.contentType || contentTypes[ext] || 'application/octet-stream',
-      'Cache-Control': ext === 'txt' ? 'public, max-age=3600' : 'public, max-age=31536000',
-      'Access-Control-Allow-Origin': '*'
-    }
+  const requestUrl = new URL(ctx.request.url);
+  const contentVersion = requestUrl.searchParams.get('v');
+  const headers = new Headers({
+    'Content-Type': file.httpMetadata?.contentType || contentTypes[ext] || 'application/octet-stream',
+    'Cache-Control': contentVersion
+      ? 'public, max-age=31536000, immutable'
+      : 'public, max-age=300, must-revalidate',
+    'Access-Control-Allow-Origin': '*'
   });
+  if (file.httpEtag) headers.set('ETag', file.httpEtag);
+
+  return new Response(file.body, { headers });
+}
+
+function isReleaseManifest(value) {
+  return Boolean(
+    value &&
+    value.schema_version === 1 &&
+    typeof value.release_id === 'string' &&
+    Array.isArray(value.items)
+  );
+}
+
+function buildManifestImageRecord(item, manifest) {
+  const metadata = item.metadata && typeof item.metadata === 'object' ? item.metadata : {};
+  const createdAt = item.created_at || metadata.generated_at || null;
+  const createdDate = createdAt ? new Date(createdAt) : parseDateFromFilename(item.key);
+  const backend = metadata.backend || metadata.provider || metadata.model_backend || 'unknown';
+  const model = metadata.model || metadata.model_name || metadata.ollama_model || backend;
+  const plugins = Array.isArray(metadata.plugins_used) ? metadata.plugins_used : [];
+  const loras = Array.isArray(metadata.loras) ? metadata.loras : [];
+  const publicationState = item.publication_state || metadata?.publication?.state || 'published';
+
+  return {
+    key: item.key,
+    position: item.position,
+    releaseId: manifest.release_id,
+    assetVersion: item.asset_version,
+    imageUrl: versionedAssetUrl(item.key, item.asset_version),
+    uploaded: manifest.published_at,
+    createdAt,
+    approvedAt: item.approved_at || null,
+    dateStr: formatMonthYear(createdDate),
+    week: extractWeek(item.key),
+    captionKey: item.caption_key || null,
+    captionUrl: item.caption_key
+      ? versionedAssetUrl(item.caption_key, item.caption_version || item.asset_version)
+      : null,
+    hasCaption: Boolean(item.caption_key),
+    metadataKey: item.metadata_key || null,
+    metadata,
+    backend,
+    model,
+    plugins,
+    loras,
+    featured: publicationState === 'featured' || item.featured === true,
+    publicationState,
+    sharePath: `/?image=${encodeURIComponent(item.key)}`
+  };
+}
+
+function versionedAssetUrl(key, version) {
+  const encodedKey = String(key).split('/').map(encodeURIComponent).join('/');
+  return `/api/images/${encodedKey}?v=${encodeURIComponent(version)}`;
 }
 
 async function buildImageRecord(bucket, object, objectKeys) {
@@ -110,15 +182,16 @@ function sortTimestamp(object) {
 }
 
 function parseDateFromFilename(filename) {
-  const match = filename.match(/(\d{8})/);
+  const match = filename.match(/(\d{4})(\d{2})(\d{2})(?:_(\d{2})(\d{2})(\d{2}))?/);
   if (!match) return null;
-
-  const dateStr = match[1];
-  const year = dateStr.substring(0, 4);
-  const month = dateStr.substring(4, 6);
-  const day = dateStr.substring(6, 8);
-
-  return new Date(Number(year), Number(month) - 1, Number(day));
+  return new Date(Date.UTC(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3]),
+    Number(match[4] || 0),
+    Number(match[5] || 0),
+    Number(match[6] || 0)
+  ));
 }
 
 function formatMonthYear(date) {

--- a/cloudflare-gallery/public/index.html
+++ b/cloudflare-gallery/public/index.html
@@ -876,7 +876,7 @@
         const res = await fetch('/api/images');
         if (!res.ok) {
           if (res.status === 401 || res.status === 403) {
-            setLoading('Gallery API authorization failed');
+            setLoading('Cloudflare gallery storage is not authorized for this deployment');
             return;
           }
           setLoading(`Gallery API error ${res.status}`);

--- a/cloudflare-gallery/public/index.html
+++ b/cloudflare-gallery/public/index.html
@@ -889,7 +889,9 @@
           return;
         }
 
-        state.allImages = imagesList.map(normalizeImage).sort((a, b) => b.sortTime - a.sortTime);
+        // The API response order is the signed-off release order. Do not re-sort it
+        // client-side and accidentally revive stale bucket objects.
+        state.allImages = imagesList.map(normalizeImage);
 
         if (state.allImages.length === 0) {
           setLoading('No published images yet');
@@ -925,8 +927,10 @@
       return {
         ...item,
         key: item.key,
-        imageUrl: `/api/images/${encodeKey(item.key)}`,
-        captionUrl: item.captionKey ? `/api/images/${encodeKey(item.captionKey)}` : null,
+        imageUrl: item.imageUrl || versionedAssetUrl(item.key, item.assetVersion),
+        captionUrl: item.captionUrl || (
+          item.captionKey ? versionedAssetUrl(item.captionKey, item.assetVersion) : null
+        ),
         createdDate,
         sortTime: createdDate && !Number.isNaN(createdDate.getTime())
           ? createdDate.getTime()
@@ -946,6 +950,11 @@
 
     function encodeKey(key) {
       return String(key).split('/').map(encodeURIComponent).join('/');
+    }
+
+    function versionedAssetUrl(key, version) {
+      const url = `/api/images/${encodeKey(key)}`;
+      return version ? `${url}?v=${encodeURIComponent(version)}` : url;
     }
 
     function setupFilters() {
@@ -1121,9 +1130,16 @@
     }
 
     function parseDate(filename) {
-      const match = filename.match(/(\d{4})(\d{2})(\d{2})/);
+      const match = filename.match(/(\d{4})(\d{2})(\d{2})(?:_(\d{2})(\d{2})(\d{2}))?/);
       if (!match) return null;
-      return new Date(match[1], parseInt(match[2]) - 1, match[3]);
+      return new Date(Date.UTC(
+        Number(match[1]),
+        Number(match[2]) - 1,
+        Number(match[3]),
+        Number(match[4] || 0),
+        Number(match[5] || 0),
+        Number(match[6] || 0)
+      ));
     }
 
     function formatDate(date) {

--- a/data/dream_source_motifs.json
+++ b/data/dream_source_motifs.json
@@ -1,0 +1,44 @@
+{
+  "place": [
+    "a flooded observatory at the edge of a salt desert",
+    "a night market beneath an abandoned space elevator",
+    "a moss-covered train station inside a vast greenhouse",
+    "a quiet apartment suspended over an unfamiliar coastline",
+    "a library carved into the walls of a volcanic cave"
+  ],
+  "material": [
+    "oxidized copper and wet paper",
+    "milky glass, velvet, and black sand",
+    "translucent amber resin and pale stone",
+    "brushed aluminum, linen, and rainwater",
+    "charcoal wood, wax, and pearl dust"
+  ],
+  "light": [
+    "low blue dawn filtered through mist",
+    "warm sodium lamps interrupted by moonlight",
+    "green bioluminescent reflections under clouded glass",
+    "a thin eclipse rim with soft interior glow",
+    "late-afternoon gold fading into violet shadow"
+  ],
+  "camera": [
+    "a patient eye-level 50mm view",
+    "a distant architectural wide shot",
+    "a low handheld close perspective",
+    "a high oblique view as if remembered from above",
+    "a slow anamorphic tracking frame"
+  ],
+  "era": [
+    "a near-future archive",
+    "a forgotten 1970s field station",
+    "an ancient ritual site reinterpreted by machines",
+    "a post-collapse domestic future",
+    "an age that has no agreed calendar"
+  ],
+  "mood": [
+    "quiet anticipation",
+    "tender dislocation",
+    "lucid unease",
+    "ceremonial wonder",
+    "homesick curiosity"
+  ]
+}

--- a/data/lora_metadata.json
+++ b/data/lora_metadata.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "loras": {
+    "pxlstl": {
+      "display_name": "Pixel Art",
+      "kind": "style",
+      "trigger": "pxlstl",
+      "trigger_placement": "suffix",
+      "trigger_required": true,
+      "source": "https://huggingface.co/mks0813/z-image-turbo-pixel-art-lora",
+      "base_model": "Tongyi-MAI/Z-Image-Turbo"
+    },
+    "childrens drawings": {
+      "display_name": "Children's Drawings",
+      "kind": "style",
+      "trigger": "childrens drawings",
+      "trigger_placement": "suffix",
+      "trigger_required": false,
+      "source": "https://huggingface.co/ostris/z_image_turbo_childrens_drawings",
+      "base_model": "Tongyi-MAI/Z-Image-Turbo"
+    },
+    "HST photo": {
+      "display_name": "Historic Color Photography",
+      "kind": "style",
+      "trigger": "HST photo",
+      "trigger_placement": "suffix",
+      "trigger_required": true,
+      "source": "https://huggingface.co/AlekseyCalvin/HistoricColor_Z-image-Turbo-LoRA",
+      "base_model": "Tongyi-MAI/Z-Image-Turbo"
+    },
+    "elusarca anime style": {
+      "display_name": "Elusarca Anime Style",
+      "kind": "style",
+      "trigger": "elusarca anime style",
+      "trigger_placement": "suffix",
+      "trigger_required": true,
+      "source": "https://huggingface.co/reverentelusarca/elusarca-anime-style-lora-z-image-turbo",
+      "base_model": "Tongyi-MAI/Z-Image-Turbo"
+    },
+    "St652yl3": {
+      "display_name": "Vintage Comic Style",
+      "kind": "style",
+      "trigger": "St652yl3",
+      "trigger_placement": "suffix",
+      "trigger_required": true,
+      "source": "https://huggingface.co/lovis93/vintage-comic-style-zimage-lora",
+      "base_model": "Tongyi-MAI/Z-Image-Turbo"
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - PORT=8000
       - USE_MOCK_GENERATOR=${USE_MOCK_GENERATOR:-false}
       - MOCK_MODE=${MOCK_MODE:-false}
-      - IMAGE_BACKEND=${IMAGE_BACKEND:-auto}
+      - IMAGE_BACKEND=${IMAGE_BACKEND:-zimage}
       - HF_TOKEN=${HF_TOKEN:-}
       - HF_HOME=/app/models
       - TRANSFORMERS_CACHE=/app/models

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,33 @@
 #   docker compose --env-file .env.docker up --build
 
 services:
+  mageflow:
+    build:
+      context: .
+      dockerfile: Dockerfile.mageflow
+      args:
+        - MAGEFLOW_SOURCE_SHA=${MAGEFLOW_SOURCE_SHA:-6cefeb40e4c8ecc404ecb73732a91878939f27e0}
+    container_name: imagegen-mageflow
+    gpus: all
+    ports:
+      - "127.0.0.1:${MAGEFLOW_PORT:-25801}:8001"
+    volumes:
+      - ${AI_CACHE_DIR:-./.cache}/huggingface:/models
+    environment:
+      - HF_HOME=/models
+      - MAGEFLOW_MODEL=${MAGEFLOW_MODEL:-microsoft/Mage-Flow}
+      - MAGEFLOW_MODEL_REVISION=${MAGEFLOW_MODEL_REVISION:-faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9}
+      - MAGEFLOW_ATTENTION=${MAGEFLOW_ATTENTION:-sdpa}
+      - MAGEFLOW_MIN_VRAM_GB=${MAGEFLOW_MIN_VRAM_GB:-20}
+      - MAGEFLOW_SOURCE_SHA=${MAGEFLOW_SOURCE_SHA:-6cefeb40e4c8ecc404ecb73732a91878939f27e0}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
   backend:
     build:
       context: .
@@ -16,16 +43,22 @@ services:
       - ${AI_CACHE_DIR:-./.cache}/huggingface:/app/models
       - ${AI_CACHE_DIR:-./.cache}/torch:/app/.cache/torch
       - ${OUTPUT_HOST_DIR:-./output}:/app/output
-      - ./logs:/app/logs
-      - ./ckpts:/app/ckpts
-      - ./loras:/app/loras
-      - ./ref-repos:/app/ref-repos
+      - ${LOG_HOST_DIR:-./logs}:/app/logs
+      - ${CHECKPOINT_HOST_DIR:-./ckpts}:/app/ckpts
+      - ${LORA_HOST_DIR:-./loras}:/app/loras
+      - ${REF_REPOS_HOST_DIR:-./ref-repos}:/app/ref-repos
     environment:
       - HOST=0.0.0.0
       - PORT=8000
       - USE_MOCK_GENERATOR=${USE_MOCK_GENERATOR:-false}
       - MOCK_MODE=${MOCK_MODE:-false}
-      - IMAGE_BACKEND=${IMAGE_BACKEND:-zimage}
+      - IMAGE_BACKEND=${IMAGE_BACKEND:-auto}
+      - MAGEFLOW_MODEL=${MAGEFLOW_MODEL:-microsoft/Mage-Flow}
+      - MAGEFLOW_MODEL_REVISION=${MAGEFLOW_MODEL_REVISION:-faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9}
+      - MAGEFLOW_URL=${MAGEFLOW_URL:-http://mageflow:8001}
+      - MAGEFLOW_STEPS=${MAGEFLOW_STEPS:-20}
+      - MAGEFLOW_CFG=${MAGEFLOW_CFG:-5.0}
+      - MAGEFLOW_TIMEOUT_SECONDS=${MAGEFLOW_TIMEOUT_SECONDS:-1800}
       - HF_TOKEN=${HF_TOKEN:-}
       - HF_HOME=/app/models
       - TRANSFORMERS_CACHE=/app/models
@@ -57,6 +90,8 @@ services:
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:${FRONTEND_PORT:-7860},http://127.0.0.1:${FRONTEND_PORT:-7860},http://localhost:3000,http://127.0.0.1:3000,http://localhost:3001,http://127.0.0.1:3001}
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    depends_on:
+      - mageflow
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/status"]

--- a/docs/CLOUDFLARE_SYNC.md
+++ b/docs/CLOUDFLARE_SYNC.md
@@ -116,12 +116,29 @@ and upload only assets whose publication state is `published` or `featured`.
 Mock/test placeholders are marked unpublishable by the catalog unless explicitly
 overridden through the backend API. The workflow uploads image files with matching
 `.txt` prompt sidecars and `.meta.json` metadata sidecars, reports skipped catalog
-entries with reasons, and never deletes remote objects unless a future `--prune`
-implementation is enabled.
+entries with reasons, and never deletes source or remote image objects.
+Explicit approval clears the workflow-only `draft` and `provisional` flags. Descriptive
+flags such as `nightly` remain in metadata, while safety/diagnostic flags continue to
+block publication.
 
-The publisher uses remote R2 by default through Wrangler; pass `--local` only when
-intentionally testing Wrangler's local R2 simulation. The legacy Just targets still
-work as wrappers:
+Every successful publish now finishes by writing two metadata objects **after** all
+approved assets are present:
+
+- `_dreamgen/releases/<release-id>.json` is an immutable rollback target.
+- `_dreamgen/current.json` is the pointer consumed by the Pages API.
+
+The manifest contains the exact approval-filtered order, a SHA-256-derived version for
+each asset, the catalog revision, and a pointer to the previous release. The Pages API
+does not infer the public gallery from every object left in the bucket once this
+manifest exists. That means stale objects remain recoverable without remaining eligible
+for the leading image. Versioned image and caption URLs invalidate old browser/CDN
+entries while retaining immutable caching for a specific asset version.
+
+The publisher uses remote R2 by default. `--transport auto` prefers the configured
+`r2:` rclone remote for a fast non-deleting copy and falls back to Wrangler. Use
+`--transport wrangler` to force Wrangler, or pass `--local` only when intentionally
+testing Wrangler's local R2 simulation. Wrangler can use either a scoped token or an
+existing `wrangler login` OAuth session. The legacy Just targets still work as wrappers:
 
 ```bash
 just publish-gallery-smoke
@@ -147,8 +164,8 @@ for scoped bucket object access. The R2 token must be able to write objects in t
 
 ### Gallery not updating
 ```bash
-just sync-gallery       # Force sync to gallery bucket
-just deploy-gallery     # Redeploy Pages app
+just -- publish-gallery --execute  # Publish approved assets + release manifest
+just deploy-gallery                 # Redeploy Pages code when functions/UI changed
 ```
 
 ### Latest image not updating

--- a/docs/MAGE_FLOW.md
+++ b/docs/MAGE_FLOW.md
@@ -1,0 +1,108 @@
+# Microsoft Mage-Flow evaluation
+
+DreamGen recognizes **Microsoft Mage-Flow** as a local text-to-image backend.
+It is not a Microsoft video generator. The sibling Mage-VL model understands
+images and video; Mage-Flow generates and edits images.
+
+## Verified upstream facts
+
+- Official source: <https://github.com/microsoft/Mage>
+- Official checkpoint: <https://huggingface.co/microsoft/Mage-Flow>
+- Turbo checkpoint: <https://huggingface.co/microsoft/Mage-Flow-Turbo>
+- Paper: <https://arxiv.org/abs/2607.19064>
+- Release: Microsoft lists the six generation/edit checkpoints as released on
+  July 22, 2026.
+- License: the source repository and the Hugging Face model card identify MIT.
+- Availability: `microsoft/Mage-Flow` is public and ungated. Its current
+  checkpoint is about 17.5 GB across 43 files.
+- Featured checkpoint: the 20-step RL-aligned model at revision
+  `faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9`. DreamGen pins this revision
+  instead of following a moving branch. The 4-step Turbo checkpoint remains an
+  explicit speed-oriented alternative, not the default quality probe.
+- Scope: Microsoft describes the family as research-only and not intended for
+  product or service deployment. That is compatible with DreamGen's local model
+  probing purpose, but it must remain visible to operators.
+- Tested runtime: Python 3.10+, Torch 2.13, torchvision 0.28, Diffusers 0.38,
+  Transformers 5.5, and CUDA. Microsoft's accelerated path uses FlashAttention;
+  the isolated DreamGen runtime selects upstream's slower Torch SDPA fallback.
+  Triton also needs a C compiler at runtime, so the sidecar includes and reports
+  the native build toolchain instead of claiming readiness without it.
+- Hardware: Microsoft reports about 18–20 GB peak GPU memory at 1024² on one A100.
+  DreamGen therefore uses a conservative 20 GB VRAM readiness guard.
+
+Microsoft's published text-to-image table reports Mage-Flow ahead of
+Z-Image-Turbo on GenEval, TIIF, and CVTG-2K, while Z-Image-Turbo remains stronger
+on several Chinese/long-text scores. These are author-reported results, not a
+DreamGen-controlled benchmark, so the current model identity and parameters are
+always stored with each artifact.
+
+## DreamGen backend comparison
+
+| Backend | Local role | Readiness / tradeoff |
+| --- | --- | --- |
+| Mage-Flow | Preferred research renderer when ready | Public 4B BF16 checkpoint; native 512–2048 resolution; isolated 20 GB+ CUDA runtime; upstream research-only guidance |
+| Z-Image-Turbo | Current high-quality local path and LoRA experiments | 6B, eight-step renderer; requires the complete local checkpoint and either native source or DiffSynth for LoRAs |
+| FLUX.1 Schnell | Established transformer fallback | Selected by `auto` only when cached; larger model and existing DreamGen CUDA path |
+| Small SD (`segmind/tiny-sd`) | Safe first-run fallback | Public and much lighter, capped to 512 in DreamGen; useful but substantially less capable |
+| Qwen-Image NF4 | Typography-oriented specialist | Quantized/offloaded path for text-rich and bilingual layouts; higher cache/memory cost |
+| ERNIE-Image-Turbo | Multilingual prompt-enhanced specialist | Eight-step local Diffusers path; prompt enhancement can reduce strict comparability |
+| SD Turbo | Explicit fast renderer | Four-step, 512-class output path |
+| Smoke / Mock | Diagnostics only | Clearly labeled non-production probes; never presented as Mage-Flow output |
+
+## DreamGen runtime policy
+
+Mage-Flow runs in a dedicated local Docker sidecar. This prevents its newer
+Torch and Transformers requirements from changing the established Z-Image,
+FLUX, Qwen, ERNIE, Turbo, and Small SD environment. Its optional host review
+port binds to `127.0.0.1`; other machines cannot submit generation or download
+requests through that port.
+
+`IMAGE_BACKEND=auto` selects Mage-Flow only when:
+
+1. the exact configured public checkpoint is fully present in the shared
+   Hugging Face cache;
+2. the sidecar is reachable and reports CUDA plus at least 20 GB VRAM; and
+3. the sidecar reports the same model ID and a compatible runtime.
+
+Otherwise `auto` retains the existing FLUX-then-Small fallback. An explicit
+`IMAGE_BACKEND=mageflow` request fails clearly if readiness disappears; it is
+never relabeled as a successful Mage-Flow render.
+
+The upstream content-policy gate returns a plain white image for both policy
+refusals and classifier failures. DreamGen screens before generation and turns
+that condition into an explicit error with the upstream category and reason, so
+a blank refusal cannot be cataloged as a successful render.
+
+DreamGen's **Unload** control delegates to the sidecar and serializes unload
+against generation, so the operator can truthfully release Mage-Flow's VRAM
+before switching to another heavyweight backend.
+
+## Local validation
+
+The Docker review used an RTX 4090 with 22.49 GiB VRAM, Torch
+`2.13.0+cu130`, SDPA, model revision
+`faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9`, and Microsoft source revision
+`6cefeb40e4c8ecc404ecb73732a91878939f27e0`. The Mage-Flow subtree is unchanged
+between the original evaluation commit and this latest verified upstream
+revision; the intervening commits only update Mage-VL documentation. A 512²,
+20-step warm generation
+through `ImageGenService` completed in 4.74 seconds and retained exact text in
+the test scene. The smoke request used `add_to_gallery=False`.
+
+## Configuration
+
+```dotenv
+MAGEFLOW_MODEL=microsoft/Mage-Flow
+MAGEFLOW_MODEL_REVISION=faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9
+MAGEFLOW_URL=http://mageflow:8001
+MAGEFLOW_STEPS=20
+MAGEFLOW_CFG=5.0
+MAGEFLOW_TIMEOUT_SECONDS=1800
+MAGEFLOW_ATTENTION=sdpa
+MAGEFLOW_MIN_VRAM_GB=20
+MAGEFLOW_PORT=25801
+```
+
+Download the public checkpoint from **Settings → Models**. After the card says
+`READY`, select **Mage-Flow** or **Auto**. The first render loads the model into
+the sidecar; `loaded` is reported separately from cached/runtime readiness.

--- a/docs/MAGE_FLOW.md
+++ b/docs/MAGE_FLOW.md
@@ -20,8 +20,10 @@ images and video; Mage-Flow generates and edits images.
   instead of following a moving branch. The 4-step Turbo checkpoint remains an
   explicit speed-oriented alternative, not the default quality probe.
 - Scope: Microsoft describes the family as research-only and not intended for
-  product or service deployment. That is compatible with DreamGen's local model
-  probing purpose, but it must remain visible to operators.
+  product or service deployment. DreamGen is independently operated as a local
+  research and artistic hobby project about machine "dreaming," so that guidance
+  is compatible with this use and remains visible to operators. This integration
+  does not imply Microsoft sponsorship, endorsement, or affiliation.
 - Tested runtime: Python 3.10+, Torch 2.13, torchvision 0.28, Diffusers 0.38,
   Transformers 5.5, and CUDA. Microsoft's accelerated path uses FlashAttention;
   the isolated DreamGen runtime selects upstream's slower Torch SDPA fallback.

--- a/examples/plugin_taxonomy_samples/dream_source_mixer_samples.json
+++ b/examples/plugin_taxonomy_samples/dream_source_mixer_samples.json
@@ -1,0 +1,51 @@
+{
+  "seed": 20260725,
+  "purpose": "Reviewable local prompt-plan samples; no image assets or external models used.",
+  "generation_plan_example": {
+    "resolution": "once_per_job",
+    "enabled_plugins": ["dream_source_mixer"],
+    "plugin_categories": {"dream_source_mixer": "entropy"},
+    "plugin_contributions_reference": "selections[*].prompt and selections[*].provenance"
+  },
+  "selections": [
+    {
+      "level": "calm",
+      "prompt": "A coherent dream fragment with gentle source-world continuity: place=a night market beneath an abandoned space elevator; material=oxidized copper and wet paper; light=low blue dawn filtered through mist; camera=a distant architectural wide shot; era=a forgotten 1970s field station; mood=tender dislocation. Preserve tactile detail and visual continuity.",
+      "motifs": {
+        "place": "a night market beneath an abandoned space elevator",
+        "material": "oxidized copper and wet paper",
+        "light": "low blue dawn filtered through mist",
+        "camera": "a distant architectural wide shot",
+        "era": "a forgotten 1970s field station",
+        "mood": "tender dislocation"
+      },
+      "provenance": {"plugin": "dream_source_mixer", "category": "entropy", "seed": 20260725, "level": "calm"}
+    },
+    {
+      "level": "strange",
+      "prompt": "A dream fragment assembled from a surprising but legible source-world collision: place=a moss-covered train station inside a vast greenhouse; material=charcoal wood, wax, and pearl dust; light=warm sodium lamps interrupted by moonlight; camera=a patient eye-level 50mm view; era=an age that has no agreed calendar; mood=lucid unease. Preserve tactile detail and visual continuity.",
+      "motifs": {
+        "place": "a moss-covered train station inside a vast greenhouse",
+        "material": "charcoal wood, wax, and pearl dust",
+        "light": "warm sodium lamps interrupted by moonlight",
+        "camera": "a patient eye-level 50mm view",
+        "era": "an age that has no agreed calendar",
+        "mood": "lucid unease"
+      },
+      "provenance": {"plugin": "dream_source_mixer", "category": "entropy", "seed": 20260725, "level": "strange"}
+    },
+    {
+      "level": "wild",
+      "prompt": "A volatile dream fragment where distant source-worlds collide while the subject remains readable: place=a flooded observatory at the edge of a salt desert; material=oxidized copper and wet paper; light=a thin eclipse rim with soft interior glow; camera=a high oblique view as if remembered from above; era=a forgotten 1970s field station; mood=homesick curiosity. Preserve tactile detail and visual continuity.",
+      "motifs": {
+        "place": "a flooded observatory at the edge of a salt desert",
+        "material": "oxidized copper and wet paper",
+        "light": "a thin eclipse rim with soft interior glow",
+        "camera": "a high oblique view as if remembered from above",
+        "era": "a forgotten 1970s field station",
+        "mood": "homesick curiosity"
+      },
+      "provenance": {"plugin": "dream_source_mixer", "category": "entropy", "seed": 20260725, "level": "wild"}
+    }
+  ]
+}

--- a/examples/plugin_taxonomy_samples/provenance_guard_example.json
+++ b/examples/plugin_taxonomy_samples/provenance_guard_example.json
@@ -1,0 +1,24 @@
+{
+  "purpose": "Operational guard result from a local pre/post validation example.",
+  "pre": {
+    "name": "provenance_guard",
+    "category": "operational",
+    "phase": "pre",
+    "status": "passed",
+    "details": {
+      "checks": ["resolution_once_per_job", "plugin_contribution_provenance"]
+    }
+  },
+  "post": {
+    "name": "provenance_guard",
+    "category": "operational",
+    "phase": "post",
+    "status": "warning",
+    "details": {
+      "checks": ["output_path", "prompt", "backend", "model", "generation_plan"],
+      "quality_flags": ["provenance_incomplete"],
+      "missing": ["image_path"],
+      "note": "Expected review signal for a dry-run plan with no rendered image; no asset was published."
+    }
+  }
+}

--- a/host-image/package-lock.json
+++ b/host-image/package-lock.json
@@ -8,10 +8,10 @@
 			"name": "host-image",
 			"version": "0.0.0",
 			"devDependencies": {
-				"@cloudflare/vitest-pool-workers": "^0.16.10",
+				"@cloudflare/vitest-pool-workers": "^0.18.8",
 				"typescript": "^6.0.3",
 				"vitest": "^4.1.5",
-				"wrangler": "^4.85.0"
+				"wrangler": "^4.114.0"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -41,16 +41,16 @@
 			}
 		},
 		"node_modules/@cloudflare/vitest-pool-workers": {
-			"version": "0.16.20",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.20.tgz",
-			"integrity": "sha512-buw0YgsAMT7s60wcmyxbtciEJjMJzKcWzayDMPhWaqMqfQzW+0WPLV67Lobn4C80nkNQhYocEJPnrEhLWnOf+A==",
+			"version": "0.18.8",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.18.8.tgz",
+			"integrity": "sha512-O1kOMZqapidlezNFiBZ7Lbd+8mMEpkGmWwPj+nPLvOngxSL11lmWq7xl7vxyjDxbeD/7l22KqgvRGM7XFaYd9w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cjs-module-lexer": "1.2.3",
 				"esbuild": "0.28.1",
-				"miniflare": "4.20260625.0",
-				"wrangler": "4.105.0",
+				"miniflare": "4.20260722.0",
+				"wrangler": "4.114.0",
 				"zod": "3.25.76"
 			},
 			"peerDependencies": {
@@ -60,9 +60,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260625.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260625.1.tgz",
-			"integrity": "sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A==",
+			"version": "1.20260722.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260722.1.tgz",
+			"integrity": "sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==",
 			"cpu": [
 				"x64"
 			],
@@ -77,9 +77,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260625.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260625.1.tgz",
-			"integrity": "sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw==",
+			"version": "1.20260722.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260722.1.tgz",
+			"integrity": "sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==",
 			"cpu": [
 				"arm64"
 			],
@@ -94,9 +94,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260625.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260625.1.tgz",
-			"integrity": "sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ==",
+			"version": "1.20260722.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260722.1.tgz",
+			"integrity": "sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==",
 			"cpu": [
 				"x64"
 			],
@@ -111,9 +111,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260625.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260625.1.tgz",
-			"integrity": "sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ==",
+			"version": "1.20260722.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260722.1.tgz",
+			"integrity": "sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==",
 			"cpu": [
 				"arm64"
 			],
@@ -128,9 +128,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260625.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260625.1.tgz",
-			"integrity": "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow==",
+			"version": "1.20260722.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260722.1.tgz",
+			"integrity": "sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==",
 			"cpu": [
 				"x64"
 			],
@@ -644,9 +644,9 @@
 			}
 		},
 		"node_modules/@img/sharp-darwin-arm64": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-			"integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+			"integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
 			"cpu": [
 				"arm64"
 			],
@@ -657,19 +657,19 @@
 				"darwin"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-arm64": "1.2.4"
+				"@img/sharp-libvips-darwin-arm64": "1.3.1"
 			}
 		},
 		"node_modules/@img/sharp-darwin-x64": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-			"integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+			"integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
 			"cpu": [
 				"x64"
 			],
@@ -680,19 +680,39 @@
 				"darwin"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-x64": "1.2.4"
+				"@img/sharp-libvips-darwin-x64": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-freebsd-wasm32": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+			"integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.2"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
 			}
 		},
 		"node_modules/@img/sharp-libvips-darwin-arm64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-			"integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+			"integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
 			"cpu": [
 				"arm64"
 			],
@@ -707,9 +727,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-darwin-x64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-			"integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+			"integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
 			"cpu": [
 				"x64"
 			],
@@ -724,9 +744,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-arm": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-			"integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+			"integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
 			"cpu": [
 				"arm"
 			],
@@ -741,9 +761,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-arm64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+			"integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
 			"cpu": [
 				"arm64"
 			],
@@ -758,9 +778,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-ppc64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-			"integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+			"integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
 			"cpu": [
 				"ppc64"
 			],
@@ -775,9 +795,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-riscv64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+			"integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -792,9 +812,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-s390x": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-			"integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+			"integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
 			"cpu": [
 				"s390x"
 			],
@@ -809,9 +829,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-x64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+			"integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
 			"cpu": [
 				"x64"
 			],
@@ -826,9 +846,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-			"integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+			"integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
 			"cpu": [
 				"arm64"
 			],
@@ -843,9 +863,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-			"integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+			"integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
 			"cpu": [
 				"x64"
 			],
@@ -860,9 +880,9 @@
 			}
 		},
 		"node_modules/@img/sharp-linux-arm": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+			"integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
 			"cpu": [
 				"arm"
 			],
@@ -873,19 +893,19 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm": "1.2.4"
+				"@img/sharp-libvips-linux-arm": "1.3.1"
 			}
 		},
 		"node_modules/@img/sharp-linux-arm64": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-			"integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+			"integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
 			"cpu": [
 				"arm64"
 			],
@@ -896,19 +916,19 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm64": "1.2.4"
+				"@img/sharp-libvips-linux-arm64": "1.3.1"
 			}
 		},
 		"node_modules/@img/sharp-linux-ppc64": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+			"integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -919,19 +939,19 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-ppc64": "1.2.4"
+				"@img/sharp-libvips-linux-ppc64": "1.3.1"
 			}
 		},
 		"node_modules/@img/sharp-linux-riscv64": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-			"integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+			"integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -942,19 +962,19 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-riscv64": "1.2.4"
+				"@img/sharp-libvips-linux-riscv64": "1.3.1"
 			}
 		},
 		"node_modules/@img/sharp-linux-s390x": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+			"integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
 			"cpu": [
 				"s390x"
 			],
@@ -965,19 +985,19 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-s390x": "1.2.4"
+				"@img/sharp-libvips-linux-s390x": "1.3.1"
 			}
 		},
 		"node_modules/@img/sharp-linux-x64": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-			"integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+			"integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
 			"cpu": [
 				"x64"
 			],
@@ -988,19 +1008,19 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-x64": "1.2.4"
+				"@img/sharp-libvips-linux-x64": "1.3.1"
 			}
 		},
 		"node_modules/@img/sharp-linuxmusl-arm64": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-			"integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+			"integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1011,19 +1031,19 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
 			}
 		},
 		"node_modules/@img/sharp-linuxmusl-x64": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+			"integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
 			"cpu": [
 				"x64"
 			],
@@ -1034,39 +1054,56 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.1"
 			}
 		},
 		"node_modules/@img/sharp-wasm32": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-			"integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-			"cpu": [
-				"wasm32"
-			],
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+			"integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
 			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/runtime": "^1.7.0"
+				"@emnapi/runtime": "^1.11.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-webcontainers-wasm32": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+			"integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.2"
+			},
+			"engines": {
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
 		},
 		"node_modules/@img/sharp-win32-arm64": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-			"integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+			"integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1077,16 +1114,16 @@
 				"win32"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
 		},
 		"node_modules/@img/sharp-win32-ia32": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-			"integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+			"integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
 			"cpu": [
 				"ia32"
 			],
@@ -1097,16 +1134,16 @@
 				"win32"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": "^20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
 		},
 		"node_modules/@img/sharp-win32-x64": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-			"integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+			"integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1117,7 +1154,7 @@
 				"win32"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
@@ -2119,16 +2156,16 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260625.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260625.0.tgz",
-			"integrity": "sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA==",
+			"version": "4.20260722.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.0.tgz",
+			"integrity": "sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
-				"sharp": "0.34.5",
+				"sharp": "0.35.2",
 				"undici": "7.28.0",
-				"workerd": "1.20260625.1",
+				"workerd": "1.20260722.1",
 				"ws": "8.21.0",
 				"youch": "4.1.0-beta.10"
 			},
@@ -2140,9 +2177,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2207,9 +2244,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2227,7 +2264,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -2270,9 +2307,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -2283,48 +2320,48 @@
 			}
 		},
 		"node_modules/sharp": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-			"integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+			"integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@img/colour": "^1.0.0",
+				"@img/colour": "^1.1.0",
 				"detect-libc": "^2.1.2",
-				"semver": "^7.7.3"
+				"semver": "^7.8.4"
 			},
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-darwin-arm64": "0.34.5",
-				"@img/sharp-darwin-x64": "0.34.5",
-				"@img/sharp-libvips-darwin-arm64": "1.2.4",
-				"@img/sharp-libvips-darwin-x64": "1.2.4",
-				"@img/sharp-libvips-linux-arm": "1.2.4",
-				"@img/sharp-libvips-linux-arm64": "1.2.4",
-				"@img/sharp-libvips-linux-ppc64": "1.2.4",
-				"@img/sharp-libvips-linux-riscv64": "1.2.4",
-				"@img/sharp-libvips-linux-s390x": "1.2.4",
-				"@img/sharp-libvips-linux-x64": "1.2.4",
-				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-				"@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-				"@img/sharp-linux-arm": "0.34.5",
-				"@img/sharp-linux-arm64": "0.34.5",
-				"@img/sharp-linux-ppc64": "0.34.5",
-				"@img/sharp-linux-riscv64": "0.34.5",
-				"@img/sharp-linux-s390x": "0.34.5",
-				"@img/sharp-linux-x64": "0.34.5",
-				"@img/sharp-linuxmusl-arm64": "0.34.5",
-				"@img/sharp-linuxmusl-x64": "0.34.5",
-				"@img/sharp-wasm32": "0.34.5",
-				"@img/sharp-win32-arm64": "0.34.5",
-				"@img/sharp-win32-ia32": "0.34.5",
-				"@img/sharp-win32-x64": "0.34.5"
+				"@img/sharp-darwin-arm64": "0.35.2",
+				"@img/sharp-darwin-x64": "0.35.2",
+				"@img/sharp-freebsd-wasm32": "0.35.2",
+				"@img/sharp-libvips-darwin-arm64": "1.3.1",
+				"@img/sharp-libvips-darwin-x64": "1.3.1",
+				"@img/sharp-libvips-linux-arm": "1.3.1",
+				"@img/sharp-libvips-linux-arm64": "1.3.1",
+				"@img/sharp-libvips-linux-ppc64": "1.3.1",
+				"@img/sharp-libvips-linux-riscv64": "1.3.1",
+				"@img/sharp-libvips-linux-s390x": "1.3.1",
+				"@img/sharp-libvips-linux-x64": "1.3.1",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+				"@img/sharp-linux-arm": "0.35.2",
+				"@img/sharp-linux-arm64": "0.35.2",
+				"@img/sharp-linux-ppc64": "0.35.2",
+				"@img/sharp-linux-riscv64": "0.35.2",
+				"@img/sharp-linux-s390x": "0.35.2",
+				"@img/sharp-linux-x64": "0.35.2",
+				"@img/sharp-linuxmusl-arm64": "0.35.2",
+				"@img/sharp-linuxmusl-x64": "0.35.2",
+				"@img/sharp-webcontainers-wasm32": "0.35.2",
+				"@img/sharp-win32-arm64": "0.35.2",
+				"@img/sharp-win32-ia32": "0.35.2",
+				"@img/sharp-win32-x64": "0.35.2"
 			}
 		},
 		"node_modules/siginfo": {
@@ -2643,9 +2680,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260625.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260625.1.tgz",
-			"integrity": "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA==",
+			"version": "1.20260722.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260722.1.tgz",
+			"integrity": "sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -2656,17 +2693,17 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260625.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260625.1",
-				"@cloudflare/workerd-linux-64": "1.20260625.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260625.1",
-				"@cloudflare/workerd-windows-64": "1.20260625.1"
+				"@cloudflare/workerd-darwin-64": "1.20260722.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260722.1",
+				"@cloudflare/workerd-linux-64": "1.20260722.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260722.1",
+				"@cloudflare/workerd-windows-64": "1.20260722.1"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.105.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.105.0.tgz",
-			"integrity": "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g==",
+			"version": "4.114.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.114.0.tgz",
+			"integrity": "sha512-M65P25t5UHA1TIJfgZXDcj+YzVobgKdRguM2QPz0xnxLFuOcuE3ErgllDht0iaho7MS4o0g/Bb4YK2+GT+bibg==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
@@ -2674,10 +2711,10 @@
 				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.28.1",
-				"miniflare": "4.20260625.0",
+				"miniflare": "4.20260722.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260625.1"
+				"workerd": "1.20260722.1"
 			},
 			"bin": {
 				"cf-wrangler": "bin/cf-wrangler.js",
@@ -2691,7 +2728,7 @@
 				"fsevents": "2.3.3"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260625.1"
+				"@cloudflare/workers-types": "^5.20260722.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -2700,9 +2737,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/host-image/package.json
+++ b/host-image/package.json
@@ -10,10 +10,10 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.16.10",
+		"@cloudflare/vitest-pool-workers": "^0.18.8",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.5",
-		"wrangler": "^4.85.0"
+		"wrangler": "^4.114.0"
 	},
 	"overrides": {
 		"esbuild": "^0.28.1",

--- a/host-image/test/gallery.spec.ts
+++ b/host-image/test/gallery.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { onRequestGet } from '../../cloudflare-gallery/functions/api/images/[[path]].js';
+
+function objectBody(value: string, contentType = 'application/json') {
+	const response = new Response(value, { headers: { 'Content-Type': contentType } });
+	return {
+		body: response.body,
+		httpEtag: '"test-etag"',
+		httpMetadata: { contentType },
+		text: () => Promise.resolve(value),
+	};
+}
+
+function context(bucket: unknown, path: string[] = [], url = 'https://example.com/api/images') {
+	return {
+		params: { path },
+		env: { GALLERY: bucket },
+		request: new Request(url),
+	} as never;
+}
+
+describe('manifest-driven gallery API', () => {
+	it('uses exact approved release order and ignores stale bucket listing order', async () => {
+		let listCalled = false;
+		const manifest = {
+			schema_version: 1,
+			release_id: 'release-20260731',
+			published_at: '2026-07-31T22:00:00Z',
+			items: [
+				{
+					position: 0,
+					key: '2026/week_29/image_20260714_020519_current.png',
+					asset_version: 'current-version',
+					created_at: '2026-07-14T02:05:19Z',
+					approved_at: '2026-07-15T17:22:05Z',
+					publication_state: 'published',
+					caption_key: null,
+					metadata_key: null,
+					metadata: { backend: 'mage-flow', model: 'Mage-Flow' },
+				},
+				{
+					position: 1,
+					key: '2026/week_17/image_20260425_141420_older.png',
+					asset_version: 'older-version',
+					created_at: '2026-04-25T14:14:20Z',
+					publication_state: 'published',
+					caption_key: null,
+					metadata_key: null,
+					metadata: {},
+				},
+			],
+		};
+		const bucket = {
+			async get(key: string) {
+				return key === '_dreamgen/current.json' ? objectBody(JSON.stringify(manifest)) : null;
+			},
+			async list() {
+				listCalled = true;
+				return { objects: [], truncated: false };
+			},
+		};
+
+		const response = await onRequestGet(context(bucket));
+		const images = (await response.json()) as Array<Record<string, unknown>>;
+
+		expect(response.headers.get('X-DreamGen-Release')).toBe('release-20260731');
+		expect(listCalled).toBe(false);
+		expect(images.map((item) => item.key)).toEqual([
+			'2026/week_29/image_20260714_020519_current.png',
+			'2026/week_17/image_20260425_141420_older.png',
+		]);
+		expect(images[0].imageUrl).toBe(
+			'/api/images/2026/week_29/image_20260714_020519_current.png?v=current-version',
+		);
+	});
+
+	it('makes versioned assets immutable and unversioned assets revalidate', async () => {
+		const bucket = {
+			async get(key: string) {
+				return key.endsWith('.png') ? objectBody('image', 'image/png') : null;
+			},
+		};
+
+		const versioned = await onRequestGet(
+			context(
+				bucket,
+				['approved.png'],
+				'https://example.com/api/images/approved.png?v=content-hash',
+			),
+		);
+		const unversioned = await onRequestGet(
+			context(bucket, ['approved.png'], 'https://example.com/api/images/approved.png'),
+		);
+
+		expect(versioned.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
+		expect(unversioned.headers.get('Cache-Control')).toBe(
+			'public, max-age=300, must-revalidate',
+		);
+		expect(versioned.headers.get('ETag')).toBe('"test-etag"');
+	});
+
+	it('falls back to full filename timestamps before the first manifest publish', async () => {
+		const objects = [
+			{ key: 'image_20260731_120000_a.png', uploaded: new Date('2026-07-31T22:00:00Z') },
+			{ key: 'image_20260731_130000_b.png', uploaded: new Date('2026-07-31T21:00:00Z') },
+		];
+		const bucket = {
+			async get() {
+				return null;
+			},
+			async list() {
+				return { objects, truncated: false };
+			},
+		};
+
+		const response = await onRequestGet(context(bucket));
+		const images = (await response.json()) as Array<Record<string, unknown>>;
+
+		expect(images.map((item) => item.key)).toEqual([
+			'image_20260731_130000_b.png',
+			'image_20260731_120000_a.png',
+		]);
+	});
+});

--- a/mageflow-service/app.py
+++ b/mageflow-service/app.py
@@ -1,0 +1,261 @@
+"""Small local-only HTTP adapter around Microsoft's pinned Mage-Flow source."""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import io
+import os
+import shutil
+import threading
+from pathlib import Path
+from typing import Any
+
+import torch
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+from huggingface_hub import snapshot_download
+from pydantic import BaseModel, Field
+
+MODEL_ID = os.getenv("MAGEFLOW_MODEL", "microsoft/Mage-Flow")
+MODEL_REVISION = os.getenv(
+    "MAGEFLOW_MODEL_REVISION",
+    "faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9",
+)
+SOURCE_SHA = os.getenv("MAGEFLOW_SOURCE_SHA", "unknown")
+ATTENTION = os.getenv("MAGEFLOW_ATTENTION", "sdpa")
+MIN_VRAM_GB = float(os.getenv("MAGEFLOW_MIN_VRAM_GB", "20"))
+
+app = FastAPI(title="DreamGen Mage-Flow Runtime")
+_pipeline: Any = None
+_loading = False
+_downloading = False
+_last_error: str | None = None
+_lock = threading.Lock()
+_generation_lock = threading.Lock()
+
+
+class GenerateRequest(BaseModel):
+    prompt: str = Field(min_length=1, max_length=8192)
+    model_id: str
+    height: int = Field(ge=512, le=2048, multiple_of=16)
+    width: int = Field(ge=512, le=2048, multiple_of=16)
+    steps: int = Field(ge=1, le=50)
+    guidance_scale: float = Field(ge=0, le=20)
+    seed: int = Field(ge=0, le=2**31 - 1)
+
+
+def _cached_snapshot() -> str | None:
+    try:
+        return snapshot_download(
+            repo_id=MODEL_ID,
+            revision=MODEL_REVISION,
+            local_files_only=True,
+        )
+    except Exception:
+        return None
+
+
+def _cuda_status() -> dict[str, Any]:
+    if not torch.cuda.is_available():
+        return {"available": False, "reason": "CUDA is not available in the Mage-Flow sidecar"}
+    total_gb = torch.cuda.get_device_properties(0).total_memory / 1024**3
+    return {
+        "available": True,
+        "device": torch.cuda.get_device_name(0),
+        "total_gb": round(total_gb, 2),
+        "sufficient": total_gb >= MIN_VRAM_GB,
+        "reason": (
+            None
+            if total_gb >= MIN_VRAM_GB
+            else f"{total_gb:.1f} GB VRAM is below the {MIN_VRAM_GB:.1f} GB guardrail"
+        ),
+    }
+
+
+def _health_payload() -> dict[str, Any]:
+    snapshot = _cached_snapshot()
+    cuda = _cuda_status()
+    compiler = shutil.which("cc")
+    runtime_compatible = bool(cuda.get("available") and cuda.get("sufficient") and compiler)
+    if _downloading:
+        status = "downloading"
+        reason = "The public Mage-Flow checkpoint is downloading"
+    elif _last_error:
+        status = "runtime_error"
+        reason = _last_error
+    elif not runtime_compatible:
+        status = "incompatible_runtime"
+        reason = cuda.get("reason") or "A C compiler is required for Triton kernels"
+    elif snapshot is None:
+        status = "not_downloaded"
+        reason = "The public Mage-Flow checkpoint is not fully cached"
+    else:
+        status = "ready"
+        reason = "Checkpoint and isolated CUDA runtime are ready"
+    return {
+        "status": status,
+        "reason": reason,
+        "model_id": MODEL_ID,
+        "verified_model_revision": MODEL_REVISION,
+        "model_source": f"https://huggingface.co/{MODEL_ID}",
+        "implementation_source": "https://github.com/microsoft/Mage",
+        "source_sha": SOURCE_SHA,
+        "license": "MIT",
+        "research_only": True,
+        "attention": ATTENTION,
+        "checkpoint_path": snapshot,
+        "model_revision": Path(snapshot).name if snapshot else None,
+        "loaded": _pipeline is not None,
+        "loading": _loading,
+        "downloading": _downloading,
+        "cuda": cuda,
+        "versions": {
+            "torch": torch.__version__,
+        },
+        "compiler": compiler,
+    }
+
+
+def _load_pipeline() -> Any:
+    global _pipeline, _loading, _last_error
+    if _pipeline is not None:
+        return _pipeline
+
+    with _lock:
+        if _pipeline is not None:
+            return _pipeline
+        snapshot = _cached_snapshot()
+        if snapshot is None:
+            raise RuntimeError(
+                "Mage-Flow is not cached. Download microsoft/Mage-Flow from DreamGen Settings first."
+            )
+        cuda = _cuda_status()
+        if not cuda.get("available") or not cuda.get("sufficient"):
+            raise RuntimeError(str(cuda.get("reason")))
+
+        _loading = True
+        _last_error = None
+        try:
+            # Upstream exposes an SDPA implementation but defaults its public loader
+            # to FlashAttention. Inject the selected supported backend while keeping
+            # Mage-Flow isolated from DreamGen's older Torch/Transformers stack.
+            import mage_flow.pipeline as upstream_pipeline
+            from mage_flow import MageFlowPipeline
+
+            original_config = upstream_pipeline.ModelConfig
+
+            def configured_model_config(*args: Any, **kwargs: Any):
+                kwargs.setdefault("attn_type", ATTENTION)
+                return original_config(*args, **kwargs)
+
+            upstream_pipeline.ModelConfig = configured_model_config
+            _pipeline = MageFlowPipeline.from_pretrained(snapshot, device="cuda")
+            return _pipeline
+        except Exception as exc:
+            _last_error = f"{type(exc).__name__}: {exc}"
+            raise
+        finally:
+            _loading = False
+
+
+def _run_generation(payload: GenerateRequest) -> list[Any]:
+    """Serialize generation and unload so CUDA memory cannot be freed mid-render."""
+    with _generation_lock:
+        pipeline = _load_pipeline()
+        verdict = pipeline.model.txt_enc.screen_text(payload.prompt)
+        if verdict.violates:
+            categories = ", ".join(verdict.categories) or "unspecified"
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "message": "Mage-Flow's mandatory content-policy gate blocked the prompt",
+                    "categories": categories,
+                    "reason": verdict.reason or "No reason was returned",
+                },
+            )
+        return pipeline.generate(
+            [payload.prompt],
+            heights=[payload.height],
+            widths=[payload.width],
+            seeds=[payload.seed],
+            steps=payload.steps,
+            cfg=payload.guidance_scale,
+        )
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    return _health_payload()
+
+
+@app.post("/download")
+def download() -> dict[str, Any]:
+    """Download the public checkpoint through the writable sidecar cache mount."""
+    global _downloading, _last_error
+    with _lock:
+        if _cached_snapshot() is not None:
+            return {"status": "ready", "model_id": MODEL_ID}
+        if _downloading:
+            return {"status": "downloading", "model_id": MODEL_ID}
+        _downloading = True
+        _last_error = None
+
+    try:
+        snapshot = snapshot_download(repo_id=MODEL_ID, revision=MODEL_REVISION)
+        return {
+            "status": "ready",
+            "model_id": MODEL_ID,
+            "model_revision": Path(snapshot).name,
+        }
+    except Exception as exc:
+        _last_error = f"{type(exc).__name__}: {exc}"
+        raise HTTPException(
+            status_code=503, detail=f"Mage-Flow checkpoint download failed: {exc}"
+        ) from exc
+    finally:
+        _downloading = False
+
+
+@app.post("/unload")
+def unload() -> dict[str, Any]:
+    """Release the sidecar-owned pipeline and CUDA allocator state."""
+    global _pipeline
+    with _generation_lock:
+        with _lock:
+            was_loaded = _pipeline is not None
+            _pipeline = None
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            if torch.cuda.is_initialized():
+                torch.cuda.ipc_collect()
+    return {"status": "ready", "unloaded": True, "was_loaded": was_loaded}
+
+
+@app.post("/generate")
+async def generate(payload: GenerateRequest) -> Response:
+    if payload.model_id != MODEL_ID:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Runtime is configured for {MODEL_ID}, not {payload.model_id}",
+        )
+    try:
+        images = await asyncio.to_thread(_run_generation, payload)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Mage-Flow generation failed: {exc}") from exc
+
+    buffer = io.BytesIO()
+    images[0].save(buffer, format="PNG")
+    snapshot = _cached_snapshot()
+    return Response(
+        content=buffer.getvalue(),
+        media_type="image/png",
+        headers={
+            "X-DreamGen-Model": MODEL_ID,
+            "X-DreamGen-Model-Revision": Path(snapshot).name if snapshot else "unknown",
+            "X-DreamGen-Source-SHA": SOURCE_SHA,
+        },
+    )

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -4,6 +4,7 @@ Provides REST API and WebSocket endpoints for the Next.js frontend
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -18,6 +19,7 @@ from fastapi import (
     BackgroundTasks,
     FastAPI,
     File,
+    Form,
     HTTPException,
     Query,
     UploadFile,
@@ -32,11 +34,12 @@ from pydantic import BaseModel, Field
 from src.generators.factory import backend_label, is_model_cached, resolve_image_backend
 from src.generators.prompt_generator import PromptGenerator
 from src.plugins import plugin_manager, register_lora_plugin
-from src.plugins.lora import get_available_loras
+from src.plugins.lora import get_available_loras, get_lora_metadata
 from src.services import (
     GenerationJobCreate,
     GenerationProgressEvent,
     ImageGenService,
+    SQLiteEditJobStore,
     SQLiteGenerationJobStore,
     apply_config_overrides,
     get_workflow_recipe,
@@ -46,6 +49,7 @@ from src.services import (
 from src.services.model_runtime import ModelRuntimeManager
 from src.utils.config import Config
 from src.utils.gallery_publisher import DEFAULT_BUCKET, build_publish_status
+from src.utils.observability import read_lifecycle_events, write_lifecycle_event
 from src.utils.ollama import (
     OllamaModelInfo,
     get_ollama_version,
@@ -241,6 +245,20 @@ def generation_config_payload() -> Dict[str, Any]:
         "mock": "mock generator",
     }
     image_model = image_model_by_backend.get(image_backend, image_backend)
+    available_loras = get_available_loras(config.model.lora.lora_dir)
+    lora_metadata = [
+        {
+            "name": metadata.name,
+            "display_name": metadata.display_name,
+            "kind": metadata.kind,
+            "trigger": metadata.trigger,
+            "trigger_placement": metadata.trigger_placement,
+            "trigger_required": metadata.trigger_required,
+            "source": metadata.source,
+            "base_model": metadata.base_model,
+        }
+        for metadata in (get_lora_metadata(name) for name in available_loras)
+    ]
 
     return {
         "width": config.image.width,
@@ -267,7 +285,8 @@ def generation_config_payload() -> Dict[str, Any]:
             },
         },
         "enabled_loras": config.model.lora.enabled_loras,
-        "available_loras": get_available_loras(config.model.lora.lora_dir),
+        "available_loras": available_loras,
+        "lora_metadata": lora_metadata,
         "lora_application_probability": config.model.lora.application_probability,
         "lora_dir": str(config.model.lora.lora_dir),
         "zimage_model_path": str(config.model.zimage_model_path),
@@ -370,6 +389,7 @@ def matches_gallery_filters(
     model: Optional[str] = None,
     prompt_family: Optional[str] = None,
     quality_flag: Optional[str] = None,
+    search: Optional[str] = None,
 ) -> bool:
     """Return whether a catalog entry matches operator review filters."""
     metadata = entry.get("metadata", {})
@@ -387,6 +407,17 @@ def matches_gallery_filters(
         else:
             flags.update(str(flag).strip() for flag in metadata_flags if str(flag).strip())
         if quality_flag not in flags:
+            return False
+    if search:
+        needle = search.strip().lower()
+        searchable = " ".join(
+            (
+                str(entry.get("path", "")),
+                str(entry.get("prompt", "")),
+                json.dumps(metadata, sort_keys=True, default=str),
+            )
+        ).lower()
+        if needle not in searchable:
             return False
     return True
 
@@ -524,6 +555,9 @@ class GenerateRequest(BaseModel):
     client_request_id: Optional[str] = Field(
         None, description="Client-provided request ID used to correlate progress events"
     )
+    config_overrides: Dict[str, Any] = Field(
+        default_factory=dict, description="Optional runtime settings to persist with the job"
+    )
 
 
 class GenerateResponse(BaseModel):
@@ -555,6 +589,9 @@ class JobCreateRequest(BaseModel):
         None, description="Client-provided request ID used to correlate progress events"
     )
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Extra job metadata")
+    config_overrides: Dict[str, Any] = Field(
+        default_factory=dict, description="Runtime settings to apply for this job"
+    )
 
 
 class PublicationUpdateRequest(BaseModel):
@@ -568,6 +605,15 @@ class EditRequest(BaseModel):
 
     prompt: str = Field(..., description="Edit prompt describing desired changes")
     strength: float = Field(0.8, ge=0.0, le=1.0, description="Edit strength (0.0 to 1.0)")
+    backend: str = Field("auto", description="Editing backend: auto, mock, or qwen")
+    source_path: Optional[str] = Field(None, description="Catalog path of the source image")
+
+
+class BulkPublicationRequest(BaseModel):
+    """Request model for applying one publication state to multiple catalog assets."""
+
+    image_paths: List[str] = Field(..., min_length=1)
+    state: str = Field(..., description="Publication state for all selected images")
 
 
 class PromptRequest(BaseModel):
@@ -664,6 +710,7 @@ class ConnectionManager:
 manager = ConnectionManager()
 recent_generation_events: deque[Dict[str, Any]] = deque(maxlen=MAX_RECENT_GENERATION_EVENTS)
 generation_job_store = SQLiteGenerationJobStore(OUTPUT_DIR / ".generation_jobs.sqlite3")
+edit_job_store = SQLiteEditJobStore(OUTPUT_DIR / ".edit_jobs.sqlite3")
 generation_worker_lock = asyncio.Lock()
 
 
@@ -674,6 +721,7 @@ def record_generation_event(event: Dict[str, Any]) -> Dict[str, Any]:
         **event,
     }
     recent_generation_events.appendleft(payload)
+    write_lifecycle_event(OUTPUT_DIR / "metrics", payload)
     return payload
 
 
@@ -719,6 +767,7 @@ async def emit_generation_service_event(
             "label": event.label,
             "detail": event.detail,
             "payload": event.payload,
+            "duration_ms": event.duration_ms,
         }
     )
     if event.progress is not None:
@@ -882,6 +931,7 @@ def generation_job_from_request(
     quality_flags: Optional[List[str]] = None,
     enable_plugins: Optional[bool] = None,
     recipe_id: Optional[str] = None,
+    config_overrides: Dict[str, Any] | None = None,
 ) -> GenerationJobCreate:
     """Build a job creation payload, resolving a workflow recipe when requested."""
     merged_metadata = experiment_request_metadata(
@@ -899,6 +949,7 @@ def generation_job_from_request(
             publication_state=publication_state,
             client_request_id=client_request_id,
             metadata=merged_metadata,
+            config_overrides=dict(config_overrides or {}),
         )
 
     resolution = resolve_workflow_recipe(
@@ -909,6 +960,11 @@ def generation_job_from_request(
         metadata=merged_metadata,
     )
     payload = resolution.to_job_payload(client_request_id=client_request_id)
+    if config_overrides:
+        payload["config_overrides"] = {
+            **payload.get("config_overrides", {}),
+            **config_overrides,
+        }
     return GenerationJobCreate(**payload)
 
 
@@ -1580,6 +1636,7 @@ async def generate_image(request: GenerateRequest):
                 quality_flags=request.quality_flags,
                 enable_plugins=request.enable_plugins,
                 recipe_id=request.recipe_id,
+                config_overrides=request.config_overrides,
             )
         )
     except KeyError as exc:
@@ -1626,6 +1683,7 @@ async def create_generation_job(request: JobCreateRequest, background_tasks: Bac
                 prompt_family=request.prompt_family,
                 quality_flags=request.quality_flags,
                 recipe_id=request.recipe_id,
+                config_overrides=request.config_overrides,
             )
         )
     except KeyError as exc:
@@ -1672,7 +1730,44 @@ async def get_generation_job_events(job_id: str):
 async def get_generation_events(limit: int = Query(25, ge=1, le=100)):
     """Return recent generation lifecycle events for operator dashboards."""
     events = list(recent_generation_events)[:limit]
+    if not events:
+        events = read_lifecycle_events(OUTPUT_DIR / "metrics", limit)
     return {"events": events, "total": len(recent_generation_events), "limit": limit}
+
+
+@app.get("/api/generation/metrics")
+async def get_generation_metrics(limit: int = Query(500, ge=1, le=2000)):
+    """Return aggregated phase timing and outcome metrics for operator diagnostics."""
+    events = read_lifecycle_events(OUTPUT_DIR / "metrics", limit)
+    completed = [
+        event
+        for event in events
+        if event.get("name") == "generation_completed" and isinstance(event.get("payload"), dict)
+    ]
+    phase_totals: Dict[str, Dict[str, float]] = {}
+    for event in completed:
+        payload = event["payload"]
+        key = f"{payload.get('backend', 'unknown')}::{payload.get('model', 'unknown')}"
+        bucket = phase_totals.setdefault(key, {"runs": 0.0})
+        bucket["runs"] += 1
+        for phase, duration in (payload.get("phase_durations_ms") or {}).items():
+            bucket[phase] = bucket.get(phase, 0.0) + float(duration or 0)
+
+    for bucket in phase_totals.values():
+        runs = max(bucket["runs"], 1)
+        for key in list(bucket):
+            if key not in {"runs"}:
+                bucket[key] = round(bucket[key] / runs, 2)
+
+    return {
+        "events": len(events),
+        "completed_generations": len(completed),
+        "phase_averages_ms": phase_totals,
+        "otel_enabled": os.getenv("DREAMGEN_OTEL_ENABLED", "0").lower() in {"1", "true", "yes"},
+        "jsonl_path": str(
+            (OUTPUT_DIR / "metrics" / "generation_events.jsonl").relative_to(OUTPUT_DIR)
+        ),
+    }
 
 
 @app.get("/api/gallery")
@@ -1695,6 +1790,7 @@ async def get_gallery_catalog(
     model: Optional[str] = Query(None),
     prompt_family: Optional[str] = Query(None),
     quality_flag: Optional[str] = Query(None),
+    search: Optional[str] = Query(None),
     limit: int = 100,
     offset: int = 0,
 ):
@@ -1722,6 +1818,7 @@ async def get_gallery_catalog(
             model=model,
             prompt_family=prompt_family,
             quality_flag=quality_flag,
+            search=search,
         )
     ]
 
@@ -1819,6 +1916,28 @@ async def update_image_publication(image_path: str, request: PublicationUpdateRe
     return entry
 
 
+@app.post("/api/gallery/publication/bulk")
+async def bulk_update_image_publication(request: BulkPublicationRequest):
+    """Apply one publication state to a selected set of catalog entries."""
+    updated: list[dict[str, Any]] = []
+    failures: list[dict[str, str]] = []
+    for image_path in request.image_paths:
+        key = normalize_gallery_key(image_path)
+        full_path = (OUTPUT_DIR / key).resolve()
+        if not full_path.is_relative_to(OUTPUT_DIR.resolve()):
+            failures.append({"path": key, "error": "Invalid image path"})
+            continue
+        try:
+            updated.append(
+                await asyncio.to_thread(set_publication_state, OUTPUT_DIR, key, request.state)
+            )
+        except (ValueError, PermissionError, FileNotFoundError, KeyError) as exc:
+            failures.append({"path": key, "error": str(exc)})
+    if not updated and failures:
+        raise HTTPException(status_code=409, detail={"updated": [], "failures": failures})
+    return {"updated": updated, "failures": failures, "state": request.state}
+
+
 @app.delete("/api/gallery/{image_path:path}")
 async def delete_image(image_path: str):
     """Delete an image from the gallery"""
@@ -1886,66 +2005,93 @@ async def batch_generate(count: int = 5, delay: int = 0):
 
 
 @app.post("/api/edit", response_model=EditResponse)
-async def edit_image(request: EditRequest, file: UploadFile = File(...)):
-    """Edit an uploaded image using Qwen-Image-Edit"""
-    edit_id = str(uuid.uuid4())
+async def edit_image(
+    file: UploadFile = File(...),
+    prompt: str = Form(...),
+    strength: float = Form(0.8),
+    backend: str = Form("auto"),
+    source_path: Optional[str] = Form(None),
+):
+    """Run an image edit and persist source/output lineage as a durable edit job."""
+    if not 0.0 <= strength <= 1.0:
+        raise HTTPException(status_code=422, detail="strength must be between 0 and 1")
+    requested_backend = backend.strip().lower() or "auto"
+    if requested_backend not in {"auto", "mock", "qwen"}:
+        raise HTTPException(status_code=400, detail="backend must be auto, mock, or qwen")
+    resolved_backend = "mock" if requested_backend == "mock" else "qwen-image-edit"
+    image_bytes = await file.read()
+    edit_job = edit_job_store.create_job(
+        prompt=prompt,
+        strength=strength,
+        backend=resolved_backend,
+        source_path=source_path,
+        source_filename=file.filename,
+        metadata={"operation": "edit", "source_path": source_path},
+    )
+    edit_id = edit_job["id"]
+    edit_job_store.start_job(edit_id)
+    started = datetime.now().isoformat()
+    await manager.broadcast(
+        json.dumps({"type": "edit_started", "id": edit_id, "timestamp": started})
+    )
+    record_generation_event(
+        {
+            "type": "edit_lifecycle",
+            "name": "edit_started",
+            "id": edit_id,
+            "backend": resolved_backend,
+        }
+    )
 
     try:
-        # Broadcast start event
-        await manager.broadcast(
-            json.dumps(
-                {"type": "edit_started", "id": edit_id, "timestamp": datetime.now().isoformat()}
-            )
-        )
-
-        # Read uploaded file
-        image_bytes = await file.read()
-
-        # Initialize image editor
-        from src.generators.image_editor import ImageEditor
-
-        editor = ImageEditor(config)
-
-        # Broadcast editing event
-        await manager.broadcast(
-            json.dumps({"type": "editing_image", "id": edit_id, "prompt": request.prompt})
-        )
-
-        # Edit the image
-        edited_image = await editor.edit_image(image_bytes, request.prompt, request.strength)
-
-        # Save both original and edited images
         import io
 
-        original_img = Image.open(io.BytesIO(image_bytes))
-        original_path = save_image_and_prompt(
-            original_img, f"ORIGINAL: {request.prompt}", str(OUTPUT_DIR)
-        )
+        original_img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+        if resolved_backend == "mock":
+            digest = hashlib.sha256(prompt.encode("utf-8")).digest()
+            tint = (digest[0], digest[1], digest[2])
+            overlay = Image.new("RGB", original_img.size, tint)
+            edited_image = Image.blend(original_img, overlay, 0.12 + (strength * 0.2))
+        else:
+            from src.generators.image_editor import ImageEditor
+
+            editor = ImageEditor(config)
+            edited_image = await editor.edit_image(image_bytes, prompt, strength)
+
+        lineage = {
+            "operation": "edit",
+            "edit_job_id": edit_id,
+            "source_path": source_path,
+            "source_filename": file.filename,
+            "backend": resolved_backend,
+            "strength": strength,
+        }
+        original_path = save_image_and_prompt(original_img, f"ORIGINAL: {prompt}", str(OUTPUT_DIR))
+        edited_path = save_image_and_prompt(edited_image, f"EDITED: {prompt}", str(OUTPUT_DIR))
         register_image(
             original_path,
             OUTPUT_DIR,
-            prompt=f"ORIGINAL: {request.prompt}",
-            metadata={"operation": "edit_original"},
+            prompt=f"ORIGINAL: {prompt}",
+            metadata={**lineage, "role": "source"},
             publication_state="draft",
-        )
-
-        # Save edited
-        edited_path = save_image_and_prompt(
-            edited_image, f"EDITED: {request.prompt}", str(OUTPUT_DIR)
         )
         register_image(
             edited_path,
             OUTPUT_DIR,
-            prompt=f"EDITED: {request.prompt}",
-            metadata={"operation": "edit_result"},
+            prompt=f"EDITED: {prompt}",
+            metadata={**lineage, "role": "result"},
             publication_state="draft",
         )
 
-        # Create relative paths for API response
         original_relative = f"/images/{original_path.relative_to(OUTPUT_DIR).as_posix()}"
         edited_relative = f"/images/{edited_path.relative_to(OUTPUT_DIR).as_posix()}"
-
-        # Broadcast completion event
+        completed_metadata = {**lineage, "model": resolved_backend}
+        edit_job_store.complete_job(
+            edit_id,
+            original_path=original_relative,
+            edited_path=edited_relative,
+            metadata=completed_metadata,
+        )
         await manager.broadcast(
             json.dumps(
                 {
@@ -1953,31 +2099,46 @@ async def edit_image(request: EditRequest, file: UploadFile = File(...)):
                     "id": edit_id,
                     "original_path": original_relative,
                     "edited_path": edited_relative,
-                    "prompt": request.prompt,
+                    "prompt": prompt,
                 }
             )
         )
-
+        record_generation_event(
+            {
+                "type": "edit_lifecycle",
+                "name": "edit_completed",
+                "id": edit_id,
+                "backend": resolved_backend,
+                "payload": completed_metadata,
+            }
+        )
         return EditResponse(
             id=edit_id,
-            prompt=request.prompt,
+            prompt=prompt,
             original_path=original_relative,
             edited_path=edited_relative,
-            metadata={
-                "model": "Qwen/Qwen-Image-Edit",
-                "strength": request.strength,
-                "original_filename": file.filename,
-            },
+            metadata={**completed_metadata, "job_id": edit_id},
             created_at=datetime.now().isoformat(),
         )
+    except Exception as exc:
+        logger.error("Image edit failed: %s", exc)
+        edit_job_store.fail_job(edit_id, str(exc))
+        record_generation_event(
+            {"type": "edit_lifecycle", "name": "edit_failed", "id": edit_id, "error": str(exc)}
+        )
+        await manager.broadcast(
+            json.dumps({"type": "edit_error", "id": edit_id, "error": str(exc)})
+        )
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    except Exception as e:
-        logger.error(f"Image edit failed: {str(e)}")
 
-        # Broadcast error event
-        await manager.broadcast(json.dumps({"type": "edit_error", "id": edit_id, "error": str(e)}))
-
-        raise HTTPException(status_code=500, detail=str(e))
+@app.get("/api/edit/jobs/{job_id}")
+async def get_edit_job(job_id: str):
+    """Return persisted edit state and source/output lineage."""
+    job = edit_job_store.get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Edit job not found")
+    return job
 
 
 if __name__ == "__main__":

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -86,6 +86,16 @@ ALLOWED_IMAGE_BACKENDS = {
     "mock",
 }
 MAX_RECENT_GENERATION_EVENTS = 100
+HF_TOKEN_PLACEHOLDER = "your_hugging_face_token_here"
+
+
+def configured_hf_token() -> str | None:
+    """Return a usable Hugging Face token without exposing placeholder values."""
+    token = os.getenv("HF_TOKEN", "").strip()
+    if not token or token == HF_TOKEN_PLACEHOLDER:
+        return None
+    return token
+
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -980,7 +990,11 @@ async def prefetch_default_fallback_model() -> None:
         from huggingface_hub import snapshot_download
 
         logger.info("Prefetching small fallback model: %s", config.model.small_sd_model)
-        await asyncio.to_thread(snapshot_download, repo_id=config.model.small_sd_model)
+        await asyncio.to_thread(
+            snapshot_download,
+            repo_id=config.model.small_sd_model,
+            token=configured_hf_token(),
+        )
         logger.info("Small fallback model is ready")
     except Exception as e:
         logger.warning("Small fallback prefetch failed: %s", e)
@@ -1276,15 +1290,23 @@ async def download_model(model_id: str):
 
                 # Use snapshot_download to get the entire model
                 loop = asyncio.get_event_loop()
+                download_token = configured_hf_token()
                 if local_dir is not None:
                     await loop.run_in_executor(
                         None,
-                        lambda: snapshot_download(repo_id=resolved_model_id, local_dir=local_dir),
+                        lambda: snapshot_download(
+                            repo_id=resolved_model_id,
+                            local_dir=local_dir,
+                            token=download_token,
+                        ),
                     )
                 else:
                     await loop.run_in_executor(
                         None,
-                        lambda: snapshot_download(repo_id=resolved_model_id),
+                        lambda: snapshot_download(
+                            repo_id=resolved_model_id,
+                            token=download_token,
+                        ),
                     )
 
                 logger.info(f"Download completed for model: {resolved_model_id}")
@@ -1326,7 +1348,7 @@ async def set_hf_token(token_data: dict):
     """Set HuggingFace token"""
     token = token_data.get("token", "").strip()
 
-    if not token:
+    if not token or token == HF_TOKEN_PLACEHOLDER:
         raise HTTPException(status_code=400, detail="Token is required")
 
     try:
@@ -1336,8 +1358,13 @@ async def set_hf_token(token_data: dict):
         hf_cache_dir.mkdir(parents=True, exist_ok=True)
         token_file = hf_cache_dir / "token"
 
-        with open(token_file, "w") as f:
-            f.write(token)
+        token_file.write_text(token, encoding="utf-8")
+        try:
+            token_file.chmod(0o600)
+        except OSError:
+            # Windows ACLs do not map cleanly to POSIX modes; keep the local
+            # cache behavior working while avoiding a noisy failure.
+            pass
 
         # Also set environment variable for current session
         os.environ["HF_TOKEN"] = token
@@ -1354,7 +1381,7 @@ async def set_hf_token(token_data: dict):
 async def get_hf_token_status():
     """Check if HF token is configured"""
     # Check environment variable first
-    if os.getenv("HF_TOKEN"):
+    if configured_hf_token():
         return {"configured": True, "source": "environment"}
 
     # Check token file using configured HF_HOME
@@ -1362,7 +1389,12 @@ async def get_hf_token_status():
     token_file = hf_cache_dir / "token"
 
     if token_file.exists():
-        return {"configured": True, "source": "file"}
+        try:
+            stored_token = token_file.read_text(encoding="utf-8").strip()
+        except OSError:
+            stored_token = ""
+        if stored_token and stored_token != HF_TOKEN_PLACEHOLDER:
+            return {"configured": True, "source": "file"}
 
     return {"configured": False, "source": None}
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -31,7 +31,8 @@ from fastapi.staticfiles import StaticFiles
 from PIL import Image
 from pydantic import BaseModel, Field
 
-from src.generators.factory import backend_label, is_model_cached, resolve_image_backend
+from src.generators.factory import inspect_local_zimage_model as inspect_zimage_checkpoint
+from src.generators.factory import is_model_cached, resolve_image_backend
 from src.generators.prompt_generator import PromptGenerator
 from src.plugins import plugin_manager, register_lora_plugin
 from src.plugins.lora import get_available_loras, get_lora_metadata
@@ -168,22 +169,7 @@ def zimage_native_source_path() -> Path:
 
 def inspect_local_zimage_model(model_path: Path) -> tuple[str, int]:
     """Return readiness status and size for a repo-local Z-Image checkpoint directory."""
-    if not model_path.exists():
-        return ("not_downloaded", 0)
-
-    size = sum(path.stat().st_size for path in model_path.rglob("*") if path.is_file())
-    transformer_files = list((model_path / "transformer").glob("*.safetensors"))
-    text_encoder_files = list((model_path / "text_encoder").glob("*.safetensors"))
-    required_files = [
-        model_path / "model_index.json",
-        model_path / "tokenizer" / "tokenizer.json",
-        model_path / "vae" / "diffusion_pytorch_model.safetensors",
-    ]
-
-    if transformer_files and text_encoder_files and all(path.exists() for path in required_files):
-        return ("ready", size)
-
-    return ("partial", size)
+    return inspect_zimage_checkpoint(model_path)
 
 
 def resolved_prompt_model_name() -> str:
@@ -239,6 +225,7 @@ def resolve_prompt_model_from_models(
 def generation_config_payload() -> Dict[str, Any]:
     """Serialize mutable generation/runtime settings for the frontend."""
     image_backend = config.model.image_backend
+    runtime_status = runtime_manager.status()
     configured_prompt_model = config.model.ollama_model
     prompt_model = resolved_prompt_model_name()
 
@@ -282,6 +269,12 @@ def generation_config_payload() -> Dict[str, Any]:
         "configured_prompt_model": configured_prompt_model,
         "image_backend": image_backend,
         "image_model": image_model,
+        "resolved_image_backend": runtime_status["resolved_backend"],
+        "active_image_model": runtime_status["active_model"],
+        "active_image_model_id": runtime_status["active_model_id"],
+        "preferred_image_model": runtime_status["preferred_model"],
+        "preferred_image_model_status": runtime_status["preferred_model_status"],
+        "fallback_reason": runtime_status["fallback_reason"],
         "ollama_image_model": config.model.ollama_image_model,
         "pipeline": {
             "prompt": {
@@ -694,6 +687,20 @@ class SystemStatus(BaseModel):
     active_plugins: List[str]
     gpu_available: bool
     ollama_available: bool
+    configured_backend: str
+    resolved_backend: str
+    active_backend_label: str
+    active_model: str
+    active_model_id: str
+    active_model_status: str
+    preferred_backend: str
+    preferred_model: str
+    preferred_model_id: str
+    preferred_model_status: str
+    fallback_backend: str
+    fallback_model: str
+    fallback_model_id: str
+    fallback_reason: Optional[str] = None
 
 
 # WebSocket connection manager
@@ -1050,7 +1057,8 @@ async def get_status():
     except Exception:
         ollama_available = False
 
-    backend_name = backend_label(config, resolve_image_backend(config))
+    runtime_status = runtime_manager.status()
+    backend_name = runtime_status["active_backend_label"]
 
     return SystemStatus(
         status="ready",
@@ -1059,6 +1067,20 @@ async def get_status():
         active_plugins=[name for name, info in plugin_manager.plugins.items() if info.enabled],
         gpu_available=gpu_available,
         ollama_available=ollama_available,
+        configured_backend=runtime_status["configured_backend"],
+        resolved_backend=runtime_status["resolved_backend"],
+        active_backend_label=runtime_status["active_backend_label"],
+        active_model=runtime_status["active_model"],
+        active_model_id=runtime_status["active_model_id"],
+        active_model_status=runtime_status["active_model_status"],
+        preferred_backend=runtime_status["preferred_backend"],
+        preferred_model=runtime_status["preferred_model"],
+        preferred_model_id=runtime_status["preferred_model_id"],
+        preferred_model_status=runtime_status["preferred_model_status"],
+        fallback_backend=runtime_status["fallback_backend"],
+        fallback_model=runtime_status["fallback_model"],
+        fallback_model_id=runtime_status["fallback_model_id"],
+        fallback_reason=runtime_status["fallback_reason"],
     )
 
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -299,6 +299,7 @@ def generation_config_payload() -> Dict[str, Any]:
         "lora_metadata": lora_metadata,
         "lora_application_probability": config.model.lora.application_probability,
         "lora_dir": str(config.model.lora.lora_dir),
+        "entropy_level": config.plugins.entropy_level,
         "zimage_model_path": str(config.model.zimage_model_path),
         "zimage_native_available": zimage_native_source_path().exists(),
         "qwen_image_model": config.model.qwen_image_model,
@@ -655,6 +656,9 @@ class PluginInfo(BaseModel):
     enabled: bool
     description: str
     order: int
+    category: str = "context"
+    kind: str = "prompt"
+    phase: str = "prompt"
 
 
 class PluginOrderRequest(BaseModel):
@@ -1061,20 +1065,18 @@ async def get_status():
 @app.get("/api/plugins", response_model=List[PluginInfo])
 async def get_plugins():
     """Get list of available plugins and their states"""
-    plugins = []
-    sorted_plugins = sorted(
-        plugin_manager.plugins.values(), key=lambda info: (info.order, info.name)
-    )
-    for info in sorted_plugins:
-        plugins.append(
-            PluginInfo(
-                name=info.name,
-                enabled=info.enabled,
-                description=info.description,
-                order=info.order,
-            )
+    return [
+        PluginInfo(
+            name=info.name,
+            enabled=info.enabled,
+            description=info.description,
+            order=info.order,
+            category=info.category,
+            kind=info.kind,
+            phase=info.phase,
         )
-    return plugins
+        for info in plugin_manager.registry_entries()
+    ]
 
 
 @app.get("/api/models/status")
@@ -1402,7 +1404,7 @@ async def get_hf_token_status():
 @app.post("/api/plugins/{plugin_name}/toggle")
 async def toggle_plugin(plugin_name: str):
     """Toggle a plugin on/off"""
-    if plugin_name not in plugin_manager.plugins:
+    if plugin_name not in plugin_manager.plugins and plugin_name not in plugin_manager.guards:
         raise HTTPException(status_code=404, detail=f"Plugin '{plugin_name}' not found")
 
     current_state = plugin_manager.is_enabled(plugin_name)
@@ -1565,6 +1567,11 @@ async def set_generation_config(data: dict):
             if not 0.0 <= probability <= 1.0:
                 raise ValueError("lora_application_probability must be between 0.0 and 1.0")
             config.model.lora.application_probability = probability
+        if "entropy_level" in data:
+            entropy_level = str(data["entropy_level"]).strip().lower()
+            if entropy_level not in {"calm", "strange", "wild"}:
+                raise ValueError("entropy_level must be calm, strange, or wild")
+            config.plugins.entropy_level = entropy_level
 
         runtime_manager.persist_selection()
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -76,6 +76,7 @@ logger = logging.getLogger(__name__)
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 ALLOWED_IMAGE_BACKENDS = {
     "auto",
+    "mageflow",
     "flux",
     "ollama",
     "zimage",
@@ -231,6 +232,7 @@ def generation_config_payload() -> Dict[str, Any]:
 
     image_model_by_backend = {
         "auto": "auto resolver",
+        "mageflow": config.model.mageflow_model,
         "flux": config.model.flux_model,
         "ollama": config.model.ollama_image_model,
         "zimage": str(config.model.zimage_model_path),
@@ -295,6 +297,11 @@ def generation_config_payload() -> Dict[str, Any]:
         "entropy_level": config.plugins.entropy_level,
         "zimage_model_path": str(config.model.zimage_model_path),
         "zimage_native_available": zimage_native_source_path().exists(),
+        "mageflow_model": config.model.mageflow_model,
+        "mageflow_revision": config.model.mageflow_revision,
+        "mageflow_url": config.model.mageflow_url,
+        "mageflow_steps": config.model.mageflow_steps,
+        "mageflow_cfg": config.model.mageflow_cfg,
         "qwen_image_model": config.model.qwen_image_model,
         "qwen_prompt_magic": config.model.qwen_prompt_magic,
         "qwen_device_map": config.model.qwen_device_map,
@@ -1119,7 +1126,7 @@ async def unload_model_runtime():
     return runtime_manager.unload()
 
 
-@app.post("/api/models/{model_id}/prefetch")
+@app.post("/api/models/{model_id:path}/prefetch")
 async def prefetch_model(model_id: str):
     """Prefetch alias for the existing asynchronous model download operation."""
     return await download_model(model_id)
@@ -1285,7 +1292,7 @@ async def _legacy_get_model_status():
     return {"models": models, "cache_dir": str(hf_cache_dir)}
 
 
-@app.post("/api/models/{model_id}/download")
+@app.post("/api/models/{model_id:path}/download")
 async def download_model(model_id: str):
     """Start downloading a model"""
     # URL decode the model_id
@@ -1315,7 +1322,24 @@ async def download_model(model_id: str):
                 # Use snapshot_download to get the entire model
                 loop = asyncio.get_event_loop()
                 download_token = configured_hf_token()
-                if local_dir is not None:
+                if resolved_model_id == config.model.mageflow_model:
+                    from urllib import request as urllib_request
+
+                    sidecar_request = urllib_request.Request(
+                        f"{config.model.mageflow_url.rstrip('/')}/download",
+                        data=b"",
+                        method="POST",
+                    )
+
+                    def download_mageflow():
+                        with urllib_request.urlopen(
+                            sidecar_request,
+                            timeout=config.model.mageflow_timeout_seconds,
+                        ) as response:
+                            return response.read()
+
+                    await loop.run_in_executor(None, download_mageflow)
+                elif local_dir is not None:
                     await loop.run_in_executor(
                         None,
                         lambda: snapshot_download(
@@ -1561,6 +1585,14 @@ async def set_generation_config(data: dict):
             config.model.image_backend = backend
         if "ollama_image_model" in data:
             config.model.ollama_image_model = str(data["ollama_image_model"]).strip()
+        if "mageflow_model" in data:
+            config.model.mageflow_model = (
+                str(data["mageflow_model"]).strip() or "microsoft/Mage-Flow"
+            )
+        if "mageflow_steps" in data:
+            config.model.mageflow_steps = int(data["mageflow_steps"])
+        if "mageflow_cfg" in data:
+            config.model.mageflow_cfg = float(data["mageflow_cfg"])
         if "qwen_image_model" in data:
             config.model.qwen_image_model = (
                 str(data["qwen_image_model"]).strip() or "diffusers/qwen-image-nf4"

--- a/src/generators/factory.py
+++ b/src/generators/factory.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Tuple
 
 from ..utils.config import Config
+from ..utils.mageflow_runtime import mageflow_runtime_ready
 from .mock_image_generator import MockImageGenerator
 from .stable_diffusion_image_generator import StableDiffusionImageGenerator
 
@@ -84,18 +85,27 @@ def required_model_cache_gb(model_id: str) -> int:
     return 25
 
 
-def resolve_image_backend(config: Config) -> str:
+def resolve_image_backend(config: Config, *, mageflow_ready: bool | None = None) -> str:
     backend = config.model.image_backend
     if backend == "tiny":
         backend = "smoke"
 
-    # Z-Image is the preferred local model. If it is selected but not ready,
-    # keep generation usable by resolving to the documented public fallback.
+    # An explicit unavailable Z-Image selection retains its documented fallback.
+    # Auto separately prefers the verified Mage-Flow runtime, then ready Z-Image.
     if backend == "zimage" and not is_local_zimage_ready(config):
         backend = "auto"
 
     if backend != "auto":
         return backend
+
+    if mageflow_ready is None:
+        mageflow_ready = mageflow_runtime_ready(
+            config.model.mageflow_url,
+            config.model.mageflow_model,
+            config.model.mageflow_revision,
+        )
+    if mageflow_ready:
+        return "mageflow"
 
     if is_local_zimage_ready(config):
         return "zimage"
@@ -122,6 +132,8 @@ def backend_label(config: Config, backend: str) -> str:
         return "ollama"
     if backend == "zimage":
         return "z-image"
+    if backend == "mageflow":
+        return "mage-flow"
     if backend == "qwen":
         return "qwen-image"
     if backend == "ernie":
@@ -175,6 +187,10 @@ def create_image_generator(config: Config) -> Tuple[object, str]:
         from .zimage_generator import ZImageGenerator
 
         return ZImageGenerator(config), backend_label(config, backend)
+    if backend == "mageflow":
+        from .mageflow_image_generator import MageFlowImageGenerator
+
+        return MageFlowImageGenerator(config), backend_label(config, backend)
     if backend == "qwen":
         from .qwen_image_generator import QwenImageGenerator
 

--- a/src/generators/factory.py
+++ b/src/generators/factory.py
@@ -47,6 +47,31 @@ def is_model_cached(model_id: str) -> bool:
     )
 
 
+def inspect_local_zimage_model(model_path: Path) -> tuple[str, int]:
+    """Return readiness and size for a local Z-Image-Turbo checkpoint."""
+    if not model_path.exists():
+        return ("not_downloaded", 0)
+
+    size = sum(path.stat().st_size for path in model_path.rglob("*") if path.is_file())
+    transformer_files = list((model_path / "transformer").glob("*.safetensors"))
+    text_encoder_files = list((model_path / "text_encoder").glob("*.safetensors"))
+    required_files = [
+        model_path / "model_index.json",
+        model_path / "tokenizer" / "tokenizer.json",
+        model_path / "vae" / "diffusion_pytorch_model.safetensors",
+    ]
+
+    if transformer_files and text_encoder_files and all(path.exists() for path in required_files):
+        return ("ready", size)
+
+    return ("partial", size)
+
+
+def is_local_zimage_ready(config: Config) -> bool:
+    """Return whether the local Z-Image checkpoint is complete enough to run."""
+    return inspect_local_zimage_model(config.model.zimage_model_path)[0] == "ready"
+
+
 def required_model_cache_gb(model_id: str) -> int:
     """Return a conservative free-space guardrail for model downloads."""
     normalized = model_id.lower()
@@ -63,8 +88,17 @@ def resolve_image_backend(config: Config) -> str:
     backend = config.model.image_backend
     if backend == "tiny":
         backend = "smoke"
+
+    # Z-Image is the preferred local model. If it is selected but not ready,
+    # keep generation usable by resolving to the documented public fallback.
+    if backend == "zimage" and not is_local_zimage_ready(config):
+        backend = "auto"
+
     if backend != "auto":
         return backend
+
+    if is_local_zimage_ready(config):
+        return "zimage"
 
     if is_model_cached(config.model.flux_model):
         return "flux"

--- a/src/generators/mageflow_image_generator.py
+++ b/src/generators/mageflow_image_generator.py
@@ -1,0 +1,108 @@
+"""Client backend for the isolated local Microsoft Mage-Flow runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+import time
+from pathlib import Path
+from typing import Optional
+from urllib import error, request
+
+from src.utils.config import Config
+from src.utils.mageflow_runtime import MAGEFLOW_MODEL_URL, MAGEFLOW_SOURCE_URL
+
+
+class MageFlowImageGenerator:
+    """Generate images through DreamGen's local CUDA-only Mage-Flow sidecar."""
+
+    def __init__(self, config: Config):
+        self.config = config
+        self.model_name = config.model.mageflow_model
+        self.runtime_url = config.model.mageflow_url.rstrip("/")
+        self.timeout = config.model.mageflow_timeout_seconds
+        self.height = self._dimension(config.image.height)
+        self.width = self._dimension(config.image.width)
+        self.steps = config.model.mageflow_steps
+        self.guidance_scale = config.model.mageflow_cfg
+        self.last_generation_metadata: dict = {}
+
+    @staticmethod
+    def _dimension(value: int) -> int:
+        """Clamp to Mage-Flow's documented native-resolution range and alignment."""
+        return max(512, min(2048, int(value))) // 16 * 16
+
+    def _post_generate(self, payload: dict) -> tuple[bytes, dict[str, str]]:
+        body = json.dumps(payload).encode("utf-8")
+        http_request = request.Request(
+            f"{self.runtime_url}/generate",
+            data=body,
+            headers={"Content-Type": "application/json", "Accept": "image/png"},
+            method="POST",
+        )
+        try:
+            with request.urlopen(http_request, timeout=self.timeout) as response:
+                headers = {
+                    "model_revision": response.headers.get("X-DreamGen-Model-Revision", ""),
+                    "source_sha": response.headers.get("X-DreamGen-Source-SHA", ""),
+                }
+                return response.read(), headers
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"Mage-Flow runtime rejected generation ({exc.code}): {detail}"
+            ) from exc
+        except (error.URLError, TimeoutError, OSError) as exc:
+            raise RuntimeError(
+                f"Mage-Flow runtime is unavailable at {self.runtime_url}; "
+                "the request was not relabeled as a successful fallback."
+            ) from exc
+
+    async def generate_image(
+        self,
+        prompt: str,
+        output_path: Path,
+        force_reinit: bool = False,
+        seed: Optional[int] = None,
+    ) -> tuple[Path, float, str]:
+        del force_reinit
+        resolved_seed = seed if seed is not None else secrets.randbelow(2**31 - 1)
+        payload = {
+            "prompt": prompt,
+            "model_id": self.model_name,
+            "height": self.height,
+            "width": self.width,
+            "steps": self.steps,
+            "guidance_scale": self.guidance_scale,
+            "seed": resolved_seed,
+        }
+
+        started = time.perf_counter()
+        image_bytes, provenance = await asyncio.to_thread(self._post_generate, payload)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(image_bytes)
+        output_path.with_suffix(".txt").write_text(prompt, encoding="utf-8")
+        elapsed = time.perf_counter() - started
+
+        self.last_generation_metadata = {
+            "backend": "mageflow",
+            "model": self.model_name,
+            "model_source": MAGEFLOW_MODEL_URL,
+            "implementation_source": MAGEFLOW_SOURCE_URL,
+            "model_revision": provenance["model_revision"] or None,
+            "verified_model_revision": self.config.model.mageflow_revision,
+            "implementation_revision": provenance["source_sha"] or None,
+            "runtime": self.runtime_url,
+            "seed": resolved_seed,
+            "seed_supported": True,
+            "width": self.width,
+            "height": self.height,
+            "steps": self.steps,
+            "guidance_scale": self.guidance_scale,
+            "isolated_runtime": True,
+        }
+        return output_path, elapsed, self.model_name.split("/")[-1]
+
+    def cleanup(self) -> None:
+        """The sidecar owns model memory; the client has no local CUDA state."""

--- a/src/generators/prompt_generator.py
+++ b/src/generators/prompt_generator.py
@@ -8,26 +8,24 @@ import logging
 import time
 from typing import Optional
 
-from ..plugins import get_context_with_descriptions, get_temporal_descriptor
+from ..plugins.lora import condition_prompt_for_lora
 from ..utils.config import Config
 from ..utils.error_handler import PromptError, handle_errors
+from ..utils.generation_plan import GenerationPlan, resolve_generation_plan
 from ..utils.metrics import GenerationMetrics
 from ..utils.ollama import list_ollama_models, resolve_ollama_model
 
 
 class PromptGenerator:
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, generation_plan: Optional[GenerationPlan] = None):
         """Initialize prompt generator with configuration."""
         self.config = config
+        self.generation_plan = generation_plan
         self.model_name = config.model.ollama_model
         # Regular example prompts (no Lora)
         self.regular_example_prompts = [
             "Cozy cafe: Steam from coffee cups, readers in corners, frost patterns on windows cast golden morning light, prismatic reflections dance.",
             "Futuristic market: Holographic stalls mix with traditional ones, sci-fi foods under crystal dome, rainbow light filters through.",
-        ]
-        # Lora-specific example prompts
-        self.lora_example_prompts = [
-            "Magical post office with '<lora_name>' as the postmaster: Sorting letters on floating belts, mechanical reindeer power machines, fiber-optic antlers glow."
         ]
         self.conversation_history = []
         self.logger = logging.getLogger(__name__)
@@ -62,21 +60,30 @@ class PromptGenerator:
                 self.model_name = resolved_model
                 metrics.model_name = resolved_model
 
-            # Get context with plugin descriptions
-            context_data = get_context_with_descriptions()
-            temporal_context = get_temporal_descriptor()
+            # A service job supplies an immutable plan. Standalone prompt calls
+            # resolve the same plan locally so adapter metadata is available and
+            # no plugin is executed more than once.
+            generation_plan = self.generation_plan or resolve_generation_plan(self.config)
+            context_data = {
+                "results": list(generation_plan.plugin_results),
+                "descriptions": list(generation_plan.plugin_descriptions),
+            }
+            temporal_context = generation_plan.temporal_descriptor
+            selected_lora = generation_plan.selected_lora
 
             # Log plugin contributions
             self.logger.info("Plugin contributions:")
             for result in context_data["results"]:
                 self.logger.info(f"  {result.name}: {result.value} - {result.description}")
 
-            # Extract Lora keyword if present
-            lora_keyword = None
-            for result in context_data["results"]:
-                if result.name == "lora" and result.value:
-                    lora_keyword = result.value
-                    break
+            # LoRA triggers are conditioning metadata. Style triggers must not
+            # leak into the prose Ollama drafts, where the image model may treat
+            # an opaque token as a character name or visible lettering.
+            prompt_descriptions = [
+                description
+                for description in context_data["descriptions"]
+                if not description.lower().startswith("lora:")
+            ]
 
             base_system_prompt = (
                 meta_prompt.strip()
@@ -96,38 +103,37 @@ class PromptGenerator:
             system_context_parts = [
                 base_system_prompt,
                 "\nAvailable context from plugins:",
-                *[f"- {desc}" for desc in context_data["descriptions"]],
+                *[f"- {desc}" for desc in prompt_descriptions],
                 f"\nCurrent temporal context: {temporal_context}",
                 "Begin the prompt with this temporal context, then add a concise but vivid scene description.",
                 "Keep the final combined prompt (including context) within the 77 token limit.",
                 "You may choose which context elements to incorporate based on relevance.",
             ]
 
-            # Only add Lora-specific instructions if a Lora keyword is available
-            if lora_keyword:
+            if selected_lora and selected_lora.kind == "object":
                 system_context_parts.extend(
                     [
-                        "\nIMPORTANT: You MUST make the Lora keyword a central subject or character in the scene.",
-                        "The Lora keyword should be in single quotes and be an active participant in the scene.",
-                        "Example format: '[temporal/style context]: [scene with Lora as subject]'",
-                        "For example: 'scene with '<keyword>' as the main character doing something'",
+                        "\nAn object LoRA adapter is loaded for the primary depicted subject.",
+                        "Use its exact subject token once, unquoted, as a visual entity rather than signage or written text.",
+                        f"Exact object subject token: {selected_lora.keyword}",
+                    ]
+                )
+            elif selected_lora:
+                system_context_parts.extend(
+                    [
+                        "\nA style LoRA adapter is already loaded.",
+                        "Describe only the natural visual scene and style; do not mention, quote, personify, spell, label, or render the adapter name or trigger token.",
+                        "DreamGen appends any required style trigger after drafting.",
                     ]
                 )
 
             system_context = "\n".join(system_context_parts)
 
-            if lora_keyword:
-                system_context += f"\nCurrent Lora keyword that MUST be used as a subject in single quotes: '{lora_keyword}'"
-                system_context += "\nMake sure the Lora keyword is a central character or subject in the scene, not just mentioned."
-
             self.logger.info(f"Generated temporal context: {temporal_context}")
 
             # Initialize conversation if empty
             if not self.conversation_history:
-                # Select appropriate example prompts based on whether a Lora keyword is available
                 example_prompts = self.regular_example_prompts.copy()
-                if lora_keyword:
-                    example_prompts.extend(self.lora_example_prompts)
 
                 # Create user message with examples
                 user_message_parts = [
@@ -136,10 +142,9 @@ class PromptGenerator:
                     "\nGenerate a new prompt that is different from these examples but equally creative.",
                 ]
 
-                # Add Lora-specific instruction if a Lora keyword is available
-                if lora_keyword:
+                if selected_lora and selected_lora.kind == "object":
                     user_message_parts.append(
-                        "Make the Lora keyword the central subject or character in the scene."
+                        "Depict the declared object token as the primary visual subject, unquoted and not as text."
                     )
 
                 self.conversation_history = [
@@ -169,27 +174,28 @@ class PromptGenerator:
             content = (
                 message.get("content") if isinstance(message, dict) else getattr(message, "content")
             )
-            new_prompt = content.strip()
+            draft_prompt = content.strip()
             # Clean up Unicode characters that cause Windows console issues
-            new_prompt = (
-                new_prompt.replace("\u2011", "-").replace("\u2013", "-").replace("\u2014", "--")
+            draft_prompt = (
+                draft_prompt.replace("\u2011", "-").replace("\u2013", "-").replace("\u2014", "--")
             )
-            new_prompt = (
-                new_prompt.replace("\u2018", "'")
+            draft_prompt = (
+                draft_prompt.replace("\u2018", "'")
                 .replace("\u2019", "'")
                 .replace("\u201c", '"')
                 .replace("\u201d", '"')
             )
-            self.logger.info(f"Raw generated prompt: {new_prompt}")
+            self.logger.info(f"Raw generated prompt: {draft_prompt}")
+            new_prompt = condition_prompt_for_lora(draft_prompt, selected_lora)
+            if new_prompt != draft_prompt:
+                self.logger.info(f"LoRA-conditioned prompt: {new_prompt}")
 
             # Add new prompt to conversation history
-            self.conversation_history.append({"role": "assistant", "content": new_prompt})
+            self.conversation_history.append({"role": "assistant", "content": draft_prompt})
             # Create next user message
             next_message = "Generate another unique prompt, different from previous ones."
-            if lora_keyword:
-                next_message += (
-                    " Remember to make the Lora keyword the central subject in the scene."
-                )
+            if selected_lora and selected_lora.kind == "object":
+                next_message += " Keep the declared object token as the unquoted visual subject."
 
             self.conversation_history.append({"role": "user", "content": next_message})
 

--- a/src/generators/zimage_generator.py
+++ b/src/generators/zimage_generator.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from ..plugins import plugin_manager, register_lora_plugin
 from ..plugins.lora import get_lora_path
+from ..utils.generation_plan import GenerationPlan, lora_provenance
 from .base_generator import GenerationResult, ImageGenerator
 
 
@@ -49,7 +50,10 @@ class ZImageGenerator(ImageGenerator):
         self.compile_model = config.model.zimage_compile
         self.components = None  # Will hold transformer, vae, text_encoder, tokenizer, scheduler
         self.using_diffsynth = False
+        self.generation_plan: Optional[GenerationPlan] = None
         self.selected_lora_name: Optional[str] = None
+        self.selected_lora_path: Optional[Path] = None
+        self.selected_lora_keyword: Optional[str] = None
         self.last_generation_metadata: dict = {}
 
         # Register LoRA plugin so Z-Image can consume the same selection flow as Flux.
@@ -67,8 +71,41 @@ class ZImageGenerator(ImageGenerator):
             "Clone Z-Image repo: git clone https://github.com/Tongyi-MAI/Z-Image ref-repos/Z-Image"
         )
 
+    def set_generation_plan(self, generation_plan: GenerationPlan) -> None:
+        """Lock this renderer to the job's already-resolved plugin choices."""
+        next_path = (
+            generation_plan.selected_lora.path.resolve()
+            if generation_plan.selected_lora is not None
+            else None
+        )
+        if self.pipe is not None and self.selected_lora_path != next_path:
+            self.cleanup()
+        self.generation_plan = generation_plan
+
     def _get_selected_lora_path(self) -> Optional[Path]:
         """Return the currently selected LoRA path, if any."""
+        if self.generation_plan is not None:
+            selection = self.generation_plan.selected_lora
+            if selection is None:
+                self.selected_lora_name = None
+                self.selected_lora_path = None
+                self.selected_lora_keyword = None
+                return None
+            lora_path = selection.path.resolve()
+            if not lora_path.is_file():
+                raise FileNotFoundError(
+                    f"Resolved LoRA disappeared before Z-Image rendering: {lora_path}"
+                )
+            self.selected_lora_name = selection.name
+            self.selected_lora_path = lora_path
+            self.selected_lora_keyword = selection.keyword
+            logger.info(
+                "Using job-locked Z-Image LoRA '{}' from {}",
+                selection.name,
+                lora_path,
+            )
+            return lora_path
+
         try:
             plugin_results = plugin_manager.execute_plugins()
         except Exception as exc:
@@ -80,9 +117,13 @@ class ZImageGenerator(ImageGenerator):
                 lora_path = get_lora_path(result.value, self.config)
                 if lora_path:
                     self.selected_lora_name = result.value
+                    self.selected_lora_path = lora_path.resolve()
+                    self.selected_lora_keyword = result.value
                     logger.info(f"Selected Z-Image LoRA '{result.value}' from {lora_path}")
                 return lora_path
         self.selected_lora_name = None
+        self.selected_lora_path = None
+        self.selected_lora_keyword = None
         return None
 
     def _build_diffsynth_model_configs(self) -> list[DiffSynthModelConfigSpec]:
@@ -197,8 +238,8 @@ class ZImageGenerator(ImageGenerator):
 
     def load_model(self):
         """Load Z-Image model components into memory."""
-        lora_path = self._get_selected_lora_path()
         self.cleanup()
+        lora_path = self._get_selected_lora_path()
         # DiffSynth fits the full Z-Image pipeline within the practical WDDM
         # memory budget on 24 GB cards. The native loader can exhaust the
         # available allocation even at 512x512 before an image is persisted.
@@ -311,6 +352,13 @@ class ZImageGenerator(ImageGenerator):
         output_path = self._save_image(image, prompt, seed)
 
         # Create metadata
+        selected_lora_provenance = None
+        if self.generation_plan is not None and self.generation_plan.selected_lora is not None:
+            selected_lora_provenance = lora_provenance(
+                self.generation_plan.selected_lora,
+                backend="diffsynth",
+            )
+
         metadata = {
             "model": "Z-Image-Turbo",
             "model_path": str(self.model_path),
@@ -324,6 +372,24 @@ class ZImageGenerator(ImageGenerator):
             "lora_backend": "diffsynth" if self.selected_lora_name else None,
             "using_diffsynth": self.using_diffsynth,
             "selected_lora": self.selected_lora_name if self.using_diffsynth else None,
+            "selected_lora_path": (
+                str(self.selected_lora_path) if self.selected_lora_path is not None else None
+            ),
+            "selected_lora_keyword": self.selected_lora_keyword,
+            "selected_lora_kind": (
+                selected_lora_provenance.get("kind") if selected_lora_provenance else None
+            ),
+            "selected_lora_trigger_placement": (
+                selected_lora_provenance.get("trigger_placement")
+                if selected_lora_provenance
+                else None
+            ),
+            "selected_lora_trigger_required": (
+                selected_lora_provenance.get("trigger_required")
+                if selected_lora_provenance
+                else None
+            ),
+            "lora_provenance": selected_lora_provenance,
         }
         self.last_generation_metadata = metadata
 
@@ -416,6 +482,8 @@ class ZImageGenerator(ImageGenerator):
 
         self.using_diffsynth = False
         self.selected_lora_name = None
+        self.selected_lora_path = None
+        self.selected_lora_keyword = None
         self.last_generation_metadata = {}
         super().cleanup()
 

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -9,9 +9,11 @@ from ..utils.config import Config
 from ..utils.plugin_manager import PluginManager
 from ..utils.plugin_manager import PluginResult as PluginResult
 from .art_style import get_art_style
+from .dream_source_mixer import get_dream_source_mixer
 from .holiday_fact import get_holiday_fact
 from .lora import apply_lora
 from .nearest_holiday import get_nearest_holiday
+from .provenance_guard import provenance_guard_post, provenance_guard_pre
 from .time_of_day import get_time_of_day
 
 # Initialize plugin manager
@@ -28,6 +30,7 @@ def register_base_plugins():
         "Provides temporal context based on the current time of day",
         get_time_of_day,
         order=1,
+        category="context",
     )
 
     plugin_manager.register(
@@ -35,6 +38,7 @@ def register_base_plugins():
         "Adds context about upcoming or current holidays",
         get_nearest_holiday,
         order=2,
+        category="context",
     )
 
     plugin_manager.register(
@@ -42,10 +46,30 @@ def register_base_plugins():
         "Enriches holiday context with interesting facts",
         get_holiday_fact,
         order=3,
+        category="context",
     )
 
     plugin_manager.register(
-        "art_style", "Suggests an artistic style for the image", get_art_style, order=4
+        "art_style",
+        "Suggests an artistic style for the image",
+        get_art_style,
+        order=4,
+        category="style",
+    )
+
+    plugin_manager.register(
+        "dream_source_mixer",
+        "Mixes bounded place, material, light, camera, era, and mood motifs",
+        get_dream_source_mixer,
+        enabled=False,
+        order=6,
+        category="entropy",
+    )
+    plugin_manager.register_guard(
+        "provenance_guard",
+        "Checks that generation plans and saved outputs retain reviewable provenance",
+        pre_hook=provenance_guard_pre,
+        post_hook=provenance_guard_post,
     )
 
 
@@ -78,6 +102,7 @@ def register_lora_plugin(config: Config):
         lora_plugin,
         enabled=enabled,
         order=order,
+        category="style",
     )
 
 

--- a/src/plugins/dream_source_mixer.py
+++ b/src/plugins/dream_source_mixer.py
@@ -1,0 +1,80 @@
+"""Deterministic, bounded dream-source variation for prompt generation."""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+LEVELS = ("calm", "strange", "wild")
+_MOTIFS_PATH = Path(__file__).resolve().parents[2] / "data" / "dream_source_motifs.json"
+
+
+@dataclass(frozen=True)
+class DreamSourceSelection:
+    """One source-world mix resolved once for a generation job."""
+
+    level: str
+    seed: int | None
+    motifs: dict[str, str]
+    prompt: str
+
+    def to_provenance(self) -> dict[str, Any]:
+        return {
+            "plugin": "dream_source_mixer",
+            "category": "entropy",
+            "selection_source": (
+                "seeded_local_motif_bank" if self.seed is not None else "local_motif_bank"
+            ),
+            "seed": self.seed,
+            "level": self.level,
+            "motifs": dict(self.motifs),
+        }
+
+
+def _load_motifs() -> dict[str, list[str]]:
+    with _MOTIFS_PATH.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return {str(key): [str(value) for value in values] for key, values in payload.items()}
+
+
+def select_dream_source_mix(
+    seed: int | None = None, entropy_level: str = "strange"
+) -> DreamSourceSelection:
+    """Select one bounded source-world mix, reproducibly when ``seed`` is provided."""
+    level = str(entropy_level).strip().lower()
+    if level not in LEVELS:
+        raise ValueError(f"entropy_level must be one of {', '.join(LEVELS)}")
+    # The requested seed remains the provenance identity. Wild mode uses a
+    # deterministic offset so the same seed can intentionally explore a
+    # different source-world branch than calm/strange.
+    rng_seed = seed + 7919 if seed is not None and level == "wild" else seed
+    rng = random.Random(rng_seed)
+    motifs = _load_motifs()
+    selection = {
+        axis: rng.choice(options[:2] if level == "calm" else options)
+        for axis, options in motifs.items()
+    }
+    prefix = {
+        "calm": "A coherent dream fragment with gentle source-world continuity:",
+        "strange": (
+            "A dream fragment assembled from a surprising but legible source-world collision:"
+        ),
+        "wild": (
+            "A volatile dream fragment where distant source-worlds collide while the subject "
+            "remains readable:"
+        ),
+    }[level]
+    prompt = (
+        f"{prefix} place={selection['place']}; material={selection['material']}; "
+        f"light={selection['light']}; camera={selection['camera']}; era={selection['era']}; "
+        f"mood={selection['mood']}. Preserve tactile detail and visual continuity."
+    )
+    return DreamSourceSelection(level=level, seed=seed, motifs=selection, prompt=prompt)
+
+
+def get_dream_source_mixer() -> str:
+    """Legacy-compatible zero-argument plugin entry point."""
+    return select_dream_source_mix().prompt

--- a/src/plugins/lora.py
+++ b/src/plugins/lora.py
@@ -2,14 +2,37 @@
 Plugin for loading and managing Lora models.
 """
 
+import json
 import logging
+import os
 import random
+import re
+from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
-from typing import List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional
 
 from ..utils.config import Config
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_LORA_METADATA_PATH = Path(__file__).resolve().parents[2] / "data" / "lora_metadata.json"
+VALID_LORA_KINDS = {"style", "object"}
+VALID_TRIGGER_PLACEMENTS = {"suffix", "subject"}
+
+
+@dataclass(frozen=True)
+class LoraMetadata:
+    """Prompt semantics and provenance for one local LoRA adapter."""
+
+    name: str
+    kind: str
+    trigger: str
+    trigger_placement: str
+    trigger_required: bool
+    display_name: str
+    source: str | None = None
+    base_model: str | None = None
 
 
 class SelectedLora(NamedTuple):
@@ -18,6 +41,117 @@ class SelectedLora(NamedTuple):
     name: str
     path: Path
     keyword: str  # The keyword that must be used in the prompt
+    kind: str = "style"
+    trigger_placement: str = "suffix"
+    trigger_required: bool = True
+    display_name: str | None = None
+    source: str | None = None
+    base_model: str | None = None
+
+
+@lru_cache(maxsize=8)
+def _load_lora_metadata_file(path: str) -> dict[str, Any]:
+    metadata_path = Path(path)
+    if not metadata_path.is_file():
+        logger.warning("LoRA metadata file not found: %s", metadata_path)
+        return {}
+    try:
+        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Unable to read LoRA metadata from %s: %s", metadata_path, exc)
+        return {}
+    loras = payload.get("loras", {})
+    if not isinstance(loras, dict):
+        logger.warning("LoRA metadata file %s has no valid 'loras' mapping", metadata_path)
+        return {}
+    return loras
+
+
+def get_lora_metadata(lora_name: str, metadata_path: Path | None = None) -> LoraMetadata:
+    """Load explicit prompt semantics, using a safe style-suffix fallback."""
+    resolved_path = metadata_path or Path(
+        os.getenv("LORA_METADATA_PATH", str(DEFAULT_LORA_METADATA_PATH))
+    )
+    raw = _load_lora_metadata_file(str(resolved_path.resolve())).get(lora_name, {})
+    if not isinstance(raw, dict):
+        raw = {}
+
+    kind = str(raw.get("kind", "style")).strip().lower()
+    if kind not in VALID_LORA_KINDS:
+        logger.warning("Unknown LoRA kind %r for %s; defaulting to style", kind, lora_name)
+        kind = "style"
+
+    default_placement = "suffix" if kind == "style" else "subject"
+    trigger_placement = str(raw.get("trigger_placement", default_placement)).strip().lower()
+    if trigger_placement not in VALID_TRIGGER_PLACEMENTS:
+        logger.warning(
+            "Unknown trigger placement %r for %s; defaulting to %s",
+            trigger_placement,
+            lora_name,
+            default_placement,
+        )
+        trigger_placement = default_placement
+
+    return LoraMetadata(
+        name=lora_name,
+        kind=kind,
+        trigger=str(raw.get("trigger", lora_name)).strip(),
+        trigger_placement=trigger_placement,
+        trigger_required=bool(raw.get("trigger_required", True)),
+        display_name=str(raw.get("display_name", lora_name)).strip(),
+        source=str(raw["source"]).strip() if raw.get("source") else None,
+        base_model=str(raw["base_model"]).strip() if raw.get("base_model") else None,
+    )
+
+
+def condition_prompt_for_lora(prompt: str, selection: SelectedLora | None) -> str:
+    """Apply a LoRA trigger according to its declared prompt role.
+
+    Style triggers are deterministic, unquoted suffixes and never become the
+    scene subject. Object triggers identify the visual subject and are placed
+    at the front when the draft omitted them.
+    """
+    clean_prompt = prompt.strip()
+    if selection is None or not selection.trigger_required or not selection.keyword.strip():
+        return clean_prompt
+
+    trigger = selection.keyword.strip()
+    escaped = re.escape(trigger)
+    trigger_pattern = re.compile(rf"(?<!\w){escaped}(?!\w)", re.IGNORECASE)
+
+    if selection.kind == "object" or selection.trigger_placement == "subject":
+        # Quotes invite text rendering. Normalize an existing object token, or
+        # place a missing token before the natural-language scene description.
+        normalized = re.sub(
+            rf"(['\"]){escaped}\1",
+            trigger,
+            clean_prompt,
+            flags=re.IGNORECASE,
+        )
+        if trigger_pattern.search(normalized):
+            return normalized
+        return f"{trigger}, {normalized}" if normalized else trigger
+
+    # Normalize any already-present terminal trigger and append the canonical
+    # `, trigger` suffix recommended by style-LoRA model cards.
+    terminal_trigger = re.compile(
+        rf"(?:,\s*|\s+)(?:['\"])?{escaped}(?:['\"])?[.!]?\s*$",
+        re.IGNORECASE,
+    )
+    scene_prompt = terminal_trigger.sub("", clean_prompt).rstrip(" ,.;:")
+    inline_style_trigger = re.compile(
+        rf"(?<!\w)(?:['\"])?{escaped}(?:['\"])?(?!\w)",
+        re.IGNORECASE,
+    )
+    if inline_style_trigger.search(scene_prompt):
+        logger.warning(
+            "Removed inline style trigger %r before appending its conditioning suffix",
+            trigger,
+        )
+        scene_prompt = inline_style_trigger.sub("", scene_prompt)
+        scene_prompt = re.sub(r"\s+([,.;:])", r"\1", scene_prompt)
+        scene_prompt = re.sub(r"\s{2,}", " ", scene_prompt).strip(" ,;:")
+    return f"{scene_prompt}, {trigger}" if scene_prompt else trigger
 
 
 def get_available_loras(lora_dir: Path) -> List[str]:
@@ -62,9 +196,7 @@ def get_lora_path(lora_name: str, config: Config) -> Optional[Path]:
 
 def get_lora_keyword(lora_name: str) -> str:
     """Get the keyword that must be used in the prompt for this Lora."""
-    # For v4skin, the keyword is "v4skin"
-    # You can add more mappings here if needed
-    return lora_name
+    return get_lora_metadata(lora_name).trigger
 
 
 def select_random_lora(config: Config) -> Optional[SelectedLora]:
@@ -93,10 +225,27 @@ def select_random_lora(config: Config) -> Optional[SelectedLora]:
     selected_path = get_lora_path(selected_name, config)
 
     if selected_path:
-        keyword = get_lora_keyword(selected_name)
+        metadata = get_lora_metadata(selected_name)
+        keyword = metadata.trigger
         logger.info(f"Selected Lora: {selected_name} at path: {selected_path}")
-        logger.info(f"Required keyword for prompt: {keyword}")
-        return SelectedLora(name=selected_name, path=selected_path, keyword=keyword)
+        logger.info(
+            "LoRA prompt metadata: kind=%s trigger=%r placement=%s required=%s",
+            metadata.kind,
+            keyword,
+            metadata.trigger_placement,
+            metadata.trigger_required,
+        )
+        return SelectedLora(
+            name=selected_name,
+            path=selected_path,
+            keyword=keyword,
+            kind=metadata.kind,
+            trigger_placement=metadata.trigger_placement,
+            trigger_required=metadata.trigger_required,
+            display_name=metadata.display_name,
+            source=metadata.source,
+            base_model=metadata.base_model,
+        )
 
     return None
 

--- a/src/plugins/provenance_guard.py
+++ b/src/plugins/provenance_guard.py
@@ -1,0 +1,46 @@
+"""Operational provenance checks kept outside prompt composition."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def provenance_guard_pre(context: dict[str, Any]) -> dict[str, Any]:
+    """Validate the locked plan before a renderer is invoked."""
+    plan = context.get("generation_plan")
+    checks: list[str] = []
+    if not isinstance(plan, dict):
+        return {"status": "failed", "checks": [], "missing": ["generation_plan"]}
+    if plan.get("resolution") != "once_per_job":
+        return {"status": "failed", "checks": [], "missing": ["resolution"]}
+    checks.append("resolution_once_per_job")
+    contributions = plan.get("plugin_contributions")
+    if not isinstance(contributions, list):
+        return {"status": "failed", "checks": checks, "missing": ["plugin_contributions"]}
+    for contribution in contributions:
+        if not all(key in contribution for key in ("name", "category", "provenance")):
+            return {
+                "status": "failed",
+                "checks": checks,
+                "missing": ["plugin_contribution_provenance"],
+            }
+    checks.append("plugin_contribution_provenance")
+    return {"status": "passed", "checks": checks}
+
+
+def provenance_guard_post(context: dict[str, Any]) -> dict[str, Any]:
+    """Check that the output can be reviewed without requiring secrets or external state."""
+    missing: list[str] = []
+    image_path = context.get("image_path")
+    if not image_path or not Path(image_path).exists():
+        missing.append("image_path")
+    for key in ("final_prompt", "backend", "model_name", "generation_plan"):
+        if context.get(key) in (None, ""):
+            missing.append(key)
+    return {
+        "status": "warning" if missing else "passed",
+        "checks": ["output_path", "prompt", "backend", "model", "generation_plan"],
+        "quality_flags": ["provenance_incomplete"] if missing else [],
+        "missing": missing,
+    }

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,5 +1,6 @@
 """Application service boundaries for DreamGen workflows."""
 
+from .edit_jobs import SQLiteEditJobStore
 from .generation_jobs import (
     GenerationJobCreate,
     SQLiteGenerationJobStore,
@@ -22,6 +23,7 @@ from .workflow_recipes import (
 
 __all__ = [
     "GenerationJobCreate",
+    "SQLiteEditJobStore",
     "GenerationProgressEvent",
     "GenerationServiceRequest",
     "GenerationServiceResult",

--- a/src/services/edit_jobs.py
+++ b/src/services/edit_jobs.py
@@ -1,0 +1,168 @@
+"""Durable local state for image-edit workflows."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def utc_now() -> str:
+    return datetime.utcnow().isoformat(timespec="seconds") + "Z"
+
+
+class SQLiteEditJobStore:
+    """Persist image-edit requests and their source/output lineage."""
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self._initialized = False
+
+    def initialize(self) -> None:
+        if self._initialized:
+            return
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS image_edit_jobs (
+                    id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    prompt TEXT NOT NULL,
+                    strength REAL NOT NULL,
+                    backend TEXT NOT NULL,
+                    source_path TEXT,
+                    source_filename TEXT,
+                    original_path TEXT,
+                    edited_path TEXT,
+                    metadata_json TEXT NOT NULL DEFAULT '{}',
+                    error TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    completed_at TEXT
+                )
+                """
+            )
+        self._initialized = True
+
+    def create_job(
+        self,
+        *,
+        prompt: str,
+        strength: float,
+        backend: str,
+        source_path: str | None = None,
+        source_filename: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        job_id: str | None = None,
+    ) -> dict[str, Any]:
+        self.initialize()
+        resolved_id = job_id or str(uuid.uuid4())
+        now = utc_now()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO image_edit_jobs (
+                    id, status, prompt, strength, backend, source_path,
+                    source_filename, metadata_json, created_at, updated_at
+                ) VALUES (?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    resolved_id,
+                    prompt,
+                    strength,
+                    backend,
+                    source_path,
+                    source_filename,
+                    json.dumps(metadata or {}, sort_keys=True, default=str),
+                    now,
+                    now,
+                ),
+            )
+        return self.get_job(resolved_id) or {}
+
+    def start_job(self, job_id: str) -> dict[str, Any]:
+        self.initialize()
+        now = utc_now()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                """
+                UPDATE image_edit_jobs
+                SET status = 'running', updated_at = ?
+                WHERE id = ? AND status = 'queued'
+                """,
+                (now, job_id),
+            )
+        return self.get_job(job_id) or {}
+
+    def complete_job(
+        self,
+        job_id: str,
+        *,
+        original_path: str,
+        edited_path: str,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.initialize()
+        now = utc_now()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                """
+                UPDATE image_edit_jobs
+                SET status = 'succeeded', original_path = ?, edited_path = ?,
+                    metadata_json = ?, updated_at = ?, completed_at = ?, error = NULL
+                WHERE id = ?
+                """,
+                (
+                    original_path,
+                    edited_path,
+                    json.dumps(metadata, sort_keys=True, default=str),
+                    now,
+                    now,
+                    job_id,
+                ),
+            )
+        return self.get_job(job_id) or {}
+
+    def fail_job(self, job_id: str, error: str) -> dict[str, Any]:
+        self.initialize()
+        now = utc_now()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                """
+                UPDATE image_edit_jobs
+                SET status = 'failed', error = ?, updated_at = ?, completed_at = ?
+                WHERE id = ?
+                """,
+                (error, now, now, job_id),
+            )
+        return self.get_job(job_id) or {}
+
+    def get_job(self, job_id: str) -> dict[str, Any] | None:
+        self.initialize()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.row_factory = sqlite3.Row
+            row = connection.execute(
+                "SELECT * FROM image_edit_jobs WHERE id = ?", (job_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "status": row["status"],
+            "prompt": row["prompt"],
+            "strength": row["strength"],
+            "backend": row["backend"],
+            "source_path": row["source_path"],
+            "source_filename": row["source_filename"],
+            "original_path": row["original_path"],
+            "edited_path": row["edited_path"],
+            "metadata": json.loads(row["metadata_json"] or "{}"),
+            "error": row["error"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "completed_at": row["completed_at"],
+        }

--- a/src/services/generation_jobs.py
+++ b/src/services/generation_jobs.py
@@ -422,6 +422,9 @@ class SQLiteGenerationJobStore:
         job_id: str,
         event: GenerationProgressEvent,
     ) -> None:
+        payload = dict(event.payload)
+        if event.duration_ms is not None:
+            payload["duration_ms"] = round(event.duration_ms, 2)
         connection.execute(
             """
             INSERT INTO generation_job_events (
@@ -436,7 +439,7 @@ class SQLiteGenerationJobStore:
                 event.progress,
                 event.label,
                 event.detail,
-                json.dumps(event.payload, sort_keys=True, default=str),
+                json.dumps(payload, sort_keys=True, default=str),
             ),
         )
 
@@ -465,6 +468,7 @@ class SQLiteGenerationJobStore:
         }
 
     def _row_to_event(self, row: sqlite3.Row) -> dict[str, Any]:
+        payload = json.loads(row["payload_json"] or "{}")
         return {
             "id": row["id"],
             "job_id": row["job_id"],
@@ -473,7 +477,8 @@ class SQLiteGenerationJobStore:
             "progress": row["progress"],
             "label": row["label"],
             "detail": row["detail"],
-            "payload": json.loads(row["payload_json"] or "{}"),
+            "payload": payload,
+            "duration_ms": payload.get("duration_ms"),
         }
 
 

--- a/src/services/image_generation.py
+++ b/src/services/image_generation.py
@@ -169,6 +169,7 @@ def loading_message_for_backend(backend_name: str) -> str:
         "ollama": "Requesting an image from the configured Ollama host.",
         "qwen-image": "Loading Qwen-Image typography model.",
         "ernie-image": "Loading ERNIE-Image Turbo prompt-enhanced model.",
+        "mage-flow": "Loading Microsoft Mage-Flow in the isolated local CUDA runtime.",
     }.get(backend_name, "Loading Flux model (this may take several minutes on first run)...")
 
 

--- a/src/services/image_generation.py
+++ b/src/services/image_generation.py
@@ -196,11 +196,27 @@ class ImageGenService:
         operational_guards: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Capture the reproducibility envelope for one local model probe."""
-        width = _metadata_scalar(_config_value(self.config, "image", "width"))
-        height = _metadata_scalar(_config_value(self.config, "image", "height"))
-        steps = _metadata_scalar(_config_value(self.config, "image", "num_inference_steps"))
-        guidance_scale = _metadata_scalar(_config_value(self.config, "image", "guidance_scale"))
-        true_cfg_scale = _metadata_scalar(_config_value(self.config, "image", "true_cfg_scale"))
+        width = _metadata_scalar(
+            generation_metadata.get("width", _config_value(self.config, "image", "width"))
+        )
+        height = _metadata_scalar(
+            generation_metadata.get("height", _config_value(self.config, "image", "height"))
+        )
+        steps = _metadata_scalar(
+            generation_metadata.get(
+                "steps", _config_value(self.config, "image", "num_inference_steps")
+            )
+        )
+        guidance_scale = _metadata_scalar(
+            generation_metadata.get(
+                "guidance_scale", _config_value(self.config, "image", "guidance_scale")
+            )
+        )
+        true_cfg_scale = _metadata_scalar(
+            generation_metadata.get(
+                "true_cfg_scale", _config_value(self.config, "image", "true_cfg_scale")
+            )
+        )
         configured_backend = _metadata_scalar(
             _config_value(self.config, "model", "image_backend", default=backend_name)
         )
@@ -256,6 +272,9 @@ class ImageGenService:
                 "configured_backend": configured_backend,
                 "resolved_backend": backend_name,
                 "model": model_name,
+                "model_revision": generation_metadata.get("model_revision"),
+                "verified_model_revision": generation_metadata.get("verified_model_revision"),
+                "implementation_revision": generation_metadata.get("implementation_revision"),
                 "prompt_model": prompt_model,
                 "configured_prompt_model": configured_prompt_model,
             },

--- a/src/services/image_generation.py
+++ b/src/services/image_generation.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import hashlib
 import inspect
 import shutil
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, Protocol, cast, runtime_checkable
 
 from src.generators.factory import create_image_generator
 from src.generators.prompt_generator import PromptGenerator
-from src.plugins import plugin_manager
+from src.plugins.lora import condition_prompt_for_lora
 from src.utils.config import Config
+from src.utils.generation_plan import GenerationPlan, resolve_generation_plan
 from src.utils.publication_catalog import register_image
 from src.utils.storage import StorageManager, read_image_metadata, write_image_metadata
 
@@ -35,6 +37,14 @@ class ImageBackend(Protocol):
 
     def cleanup(self) -> None:
         """Release backend resources."""
+
+
+@runtime_checkable
+class PlannedImageBackend(Protocol):
+    """Optional backend capability for consuming a locked generation plan."""
+
+    def set_generation_plan(self, generation_plan: GenerationPlan) -> None:
+        """Lock plugin and adapter choices for the next render."""
 
 
 @dataclass(frozen=True)
@@ -61,6 +71,7 @@ class GenerationProgressEvent:
     label: str | None = None
     detail: str | None = None
     payload: dict[str, Any] = field(default_factory=dict)
+    duration_ms: float | None = None
 
 
 @dataclass(frozen=True)
@@ -179,6 +190,7 @@ class ImageGenService:
         resolved_seed: int | None,
         active_plugins: list[str],
         prompt_model: str | None,
+        generation_plan_metadata: dict[str, Any],
     ) -> dict[str, Any]:
         """Capture the reproducibility envelope for one local model probe."""
         width = _metadata_scalar(_config_value(self.config, "image", "width"))
@@ -251,6 +263,9 @@ class ImageGenService:
                 "plugins": active_plugins,
                 "loras": enabled_loras,
                 "lora_application_probability": lora_probability,
+                "plugin_contributions": generation_plan_metadata["plugin_contributions"],
+                "selected_lora": generation_plan_metadata["selected_lora"],
+                "resolution": generation_plan_metadata["resolution"],
             },
             "timing": {
                 "generation_seconds": generation_time,
@@ -274,8 +289,14 @@ class ImageGenService:
         self,
         request: GenerationServiceRequest,
         callback: ProgressCallback | None,
+        generation_plan: GenerationPlan,
     ) -> PromptResolution:
+        phase_started = time.perf_counter()
         if request.prompt:
+            final_prompt = condition_prompt_for_lora(
+                request.prompt,
+                generation_plan.selected_lora,
+            )
             await self._emit(
                 callback,
                 GenerationProgressEvent(
@@ -283,10 +304,11 @@ class ImageGenService:
                     progress=24,
                     label="Prompt ready",
                     detail="Using the prompt you provided directly.",
-                    payload={"prompt": request.prompt},
+                    payload={"prompt": final_prompt},
+                    duration_ms=(time.perf_counter() - phase_started) * 1000,
                 ),
             )
-            return PromptResolution(prompt=request.prompt)
+            return PromptResolution(prompt=final_prompt)
 
         await self._emit(
             callback,
@@ -297,8 +319,9 @@ class ImageGenService:
                 detail="Building a fresh prompt from Ollama and the active plugins.",
             ),
         )
-        prompt_generator = PromptGenerator(self.config)
+        prompt_generator = PromptGenerator(self.config, generation_plan=generation_plan)
         prompt = await prompt_generator.generate_prompt(meta_prompt=request.meta_prompt)
+        prompt = condition_prompt_for_lora(prompt, generation_plan.selected_lora)
         await self._emit(
             callback,
             GenerationProgressEvent(
@@ -307,6 +330,7 @@ class ImageGenService:
                 label="Prompt ready",
                 detail="The prompt is assembled. Preparing the image backend next.",
                 payload={"prompt": prompt},
+                duration_ms=(time.perf_counter() - phase_started) * 1000,
             ),
         )
         return PromptResolution(prompt=prompt, prompt_model=prompt_generator.model_name)
@@ -329,8 +353,27 @@ class ImageGenService:
             ),
         )
 
-        prompt_resolution = await self._resolve_prompt(request, callback)
+        plugins_enabled = request.metadata.get("plugins_enabled_requested") is not False
+        generation_plan = resolve_generation_plan(
+            self.config,
+            plugins_enabled=plugins_enabled,
+        )
+        await self._emit(
+            callback,
+            GenerationProgressEvent(
+                name="generation_plan_resolved",
+                progress=16,
+                label="Generation plan ready",
+                detail="Plugin and LoRA choices are locked for this job.",
+                payload=generation_plan.to_metadata(),
+            ),
+        )
+
+        prompt_started = time.perf_counter()
+        prompt_resolution = await self._resolve_prompt(request, callback, generation_plan)
+        prompt_duration_ms = (time.perf_counter() - prompt_started) * 1000
         final_prompt = prompt_resolution.prompt
+        backend_started = time.perf_counter()
         if backend is None:
             image_gen_raw, backend_name = create_image_generator(self.config)
             image_gen = cast(ImageBackend, image_gen_raw)
@@ -338,6 +381,11 @@ class ImageGenService:
             if backend_name is None:
                 raise ValueError("backend_name is required when passing a reusable backend")
             image_gen = backend
+        if isinstance(image_gen, PlannedImageBackend):
+            image_gen.set_generation_plan(generation_plan)
+        elif backend_name == "z-image":
+            raise RuntimeError("The Z-Image backend does not support job-locked generation plans")
+        backend_duration_ms = (time.perf_counter() - backend_started) * 1000
         await self._emit(
             callback,
             GenerationProgressEvent(
@@ -346,9 +394,9 @@ class ImageGenService:
                 label="Backend ready",
                 detail="The selected image backend is loaded and ready to render.",
                 payload={"backend": backend_name},
+                duration_ms=backend_duration_ms,
             ),
         )
-
         loading_message = loading_message_for_backend(backend_name)
         await self._emit(
             callback,
@@ -370,6 +418,8 @@ class ImageGenService:
                 payload={"output_path": requested_output_path},
             ),
         )
+        render_started = time.perf_counter()
+        generation_metadata: dict[str, Any] = {}
         try:
             image_path, generation_time, model_name = await image_gen.generate_image(
                 final_prompt,
@@ -388,30 +438,52 @@ class ImageGenService:
                             str(requested_output_path.with_suffix(suffix)),
                         )
                 image_path = requested_output_path
+            # Snapshot mutable backend provenance before optional cleanup.
+            generation_metadata = dict(getattr(image_gen, "last_generation_metadata", {}) or {})
         finally:
             if request.cleanup:
                 image_gen.cleanup()
+        render_duration_ms = (time.perf_counter() - render_started) * 1000
+        finalizing_started = time.perf_counter()
 
-        await self._emit(
-            callback,
-            GenerationProgressEvent(
-                name="finalizing_output",
-                progress=92,
-                label="Finalizing output",
-                detail=(
-                    "Saving metadata and writing the finished image to the gallery."
-                    if request.add_to_gallery
-                    else "Saving metadata for the ad-hoc output."
-                ),
-            ),
+        if backend_name == "z-image" and generation_plan.selected_lora is not None:
+            expected_lora = generation_plan.selected_lora
+            actual_lora = generation_metadata.get("selected_lora")
+            if actual_lora not in {None, expected_lora.name}:
+                raise RuntimeError(
+                    "Z-Image rendered with a LoRA that differs from the locked generation plan: "
+                    f"expected {expected_lora.name!r}, got {actual_lora!r}"
+                )
+            actual_path = generation_metadata.get("selected_lora_path")
+            expected_path = expected_lora.path.resolve()
+            if actual_path is not None and Path(actual_path).resolve() != expected_path:
+                raise RuntimeError(
+                    "Z-Image rendered with a LoRA path that differs from the locked generation "
+                    f"plan: expected {expected_path}, got {actual_path}"
+                )
+            generation_metadata.update(
+                {
+                    "selected_lora": expected_lora.name,
+                    "selected_lora_path": str(expected_path),
+                    "selected_lora_keyword": expected_lora.keyword,
+                    "selected_lora_kind": expected_lora.kind,
+                    "selected_lora_trigger_placement": expected_lora.trigger_placement,
+                    "selected_lora_trigger_required": expected_lora.trigger_required,
+                    "lora_backend": "diffsynth",
+                }
+            )
+
+        generation_plan_metadata = generation_plan.to_metadata(
+            lora_backend=generation_metadata.get("lora_backend")
         )
-
-        generation_metadata = getattr(image_gen, "last_generation_metadata", {}) or {}
+        generation_metadata["generation_plan"] = generation_plan_metadata
+        if generation_plan_metadata["selected_lora"] is not None:
+            generation_metadata["lora_provenance"] = generation_plan_metadata["selected_lora"]
         seed_supported = generation_metadata.get("seed_supported", True)
         resolved_seed = generation_metadata.get("seed")
         if resolved_seed is None and request.seed is not None and seed_supported:
             resolved_seed = request.seed
-        active_plugins = [name for name, info in plugin_manager.plugins.items() if info.enabled]
+        active_plugins = list(generation_plan.enabled_plugins)
         experiment_metadata = self._build_experiment_metadata(
             request=request,
             final_prompt=final_prompt,
@@ -422,6 +494,7 @@ class ImageGenService:
             resolved_seed=resolved_seed,
             active_plugins=active_plugins,
             prompt_model=prompt_resolution.prompt_model,
+            generation_plan_metadata=generation_plan_metadata,
         )
 
         existing_metadata = read_image_metadata(image_path)
@@ -451,6 +524,41 @@ class ImageGenService:
             relative_image_path = f"/images/{image_path.relative_to(self.output_dir).as_posix()}"
         else:
             relative_image_path = str(image_path.resolve())
+        phase_durations_ms = {
+            "prompt": round(prompt_duration_ms, 2),
+            "backend": round(backend_duration_ms, 2),
+            "render": round(render_duration_ms, 2),
+            "finalize": round((time.perf_counter() - finalizing_started) * 1000, 2),
+        }
+        experiment_metadata["timing"]["phase_durations_ms"] = phase_durations_ms
+        saved_metadata["experiment"] = experiment_metadata
+        write_image_metadata(image_path, saved_metadata)
+        await self._emit(
+            callback,
+            GenerationProgressEvent(
+                name="finalizing_output",
+                progress=92,
+                label="Finalizing output",
+                detail=(
+                    "Saving metadata and writing the finished image to the gallery."
+                    if request.add_to_gallery
+                    else "Saving metadata for the ad-hoc output."
+                ),
+                payload={
+                    "phase_durations_ms": phase_durations_ms,
+                    "catalog": (
+                        {
+                            "id": publication_entry["id"],
+                            "state": publication_entry["publication_state"],
+                            "publishable": publication_entry["publishable"],
+                        }
+                        if publication_entry
+                        else None
+                    ),
+                },
+                duration_ms=phase_durations_ms["finalize"],
+            ),
+        )
         response_metadata = {
             **request.metadata,
             **generation_metadata,
@@ -485,6 +593,11 @@ class ImageGenService:
                     "image_path": relative_image_path,
                     "prompt": final_prompt,
                     "backend": backend_name,
+                    "model": model_name,
+                    "generation_time": generation_time,
+                    "phase_durations_ms": phase_durations_ms,
+                    "selected_lora": generation_metadata.get("selected_lora"),
+                    "lora_backend": generation_metadata.get("lora_backend"),
                 },
             ),
         )

--- a/src/services/image_generation.py
+++ b/src/services/image_generation.py
@@ -14,6 +14,7 @@ from typing import Any, Protocol, cast, runtime_checkable
 
 from src.generators.factory import create_image_generator
 from src.generators.prompt_generator import PromptGenerator
+from src.plugins import plugin_manager
 from src.plugins.lora import condition_prompt_for_lora
 from src.utils.config import Config
 from src.utils.generation_plan import GenerationPlan, resolve_generation_plan
@@ -191,6 +192,7 @@ class ImageGenService:
         active_plugins: list[str],
         prompt_model: str | None,
         generation_plan_metadata: dict[str, Any],
+        operational_guards: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Capture the reproducibility envelope for one local model probe."""
         width = _metadata_scalar(_config_value(self.config, "image", "width"))
@@ -222,6 +224,11 @@ class ImageGenService:
         )
         if diagnostic and "diagnostic" not in quality_flags:
             quality_flags.append("diagnostic")
+        for guard in operational_guards or []:
+            if guard.get("status") in {"warning", "failed"}:
+                for flag in guard.get("details", {}).get("quality_flags", []):
+                    if flag not in quality_flags:
+                        quality_flags.append(flag)
 
         return {
             "id": _prompt_fingerprint(
@@ -266,6 +273,7 @@ class ImageGenService:
                 "plugin_contributions": generation_plan_metadata["plugin_contributions"],
                 "selected_lora": generation_plan_metadata["selected_lora"],
                 "resolution": generation_plan_metadata["resolution"],
+                "operational_guards": operational_guards or [],
             },
             "timing": {
                 "generation_seconds": generation_time,
@@ -357,7 +365,20 @@ class ImageGenService:
         generation_plan = resolve_generation_plan(
             self.config,
             plugins_enabled=plugins_enabled,
+            seed=request.seed,
         )
+        plan_metadata = generation_plan.to_metadata()
+        pre_guards = plugin_manager.execute_guards(
+            "pre",
+            {
+                "request": request,
+                "seed": request.seed,
+                "generation_plan": plan_metadata,
+            },
+        )
+        failed_pre_guards = [guard for guard in pre_guards if guard["status"] == "failed"]
+        if failed_pre_guards:
+            raise RuntimeError(f"Generation blocked by operational guard: {failed_pre_guards}")
         await self._emit(
             callback,
             GenerationProgressEvent(
@@ -365,7 +386,7 @@ class ImageGenService:
                 progress=16,
                 label="Generation plan ready",
                 detail="Plugin and LoRA choices are locked for this job.",
-                payload=generation_plan.to_metadata(),
+                payload={**plan_metadata, "operational_guards": pre_guards},
             ),
         )
 
@@ -476,6 +497,19 @@ class ImageGenService:
         generation_plan_metadata = generation_plan.to_metadata(
             lora_backend=generation_metadata.get("lora_backend")
         )
+        post_guards = plugin_manager.execute_guards(
+            "post",
+            {
+                "image_path": image_path,
+                "final_prompt": final_prompt,
+                "backend": backend_name,
+                "model_name": model_name,
+                "generation_plan": generation_plan_metadata,
+                "generation_metadata": generation_metadata,
+            },
+        )
+        operational_guards = pre_guards + post_guards
+        generation_metadata["operational_guards"] = operational_guards
         generation_metadata["generation_plan"] = generation_plan_metadata
         if generation_plan_metadata["selected_lora"] is not None:
             generation_metadata["lora_provenance"] = generation_plan_metadata["selected_lora"]
@@ -495,6 +529,7 @@ class ImageGenService:
             active_plugins=active_plugins,
             prompt_model=prompt_resolution.prompt_model,
             generation_plan_metadata=generation_plan_metadata,
+            operational_guards=operational_guards,
         )
 
         existing_metadata = read_image_metadata(image_path)

--- a/src/services/model_runtime.py
+++ b/src/services/model_runtime.py
@@ -7,6 +7,7 @@ import json
 import os
 from pathlib import Path
 from typing import Any
+from urllib import error, request
 
 import psutil
 
@@ -19,6 +20,11 @@ from src.generators.factory import (
     resolve_image_backend,
 )
 from src.utils.config import Config
+from src.utils.mageflow_runtime import (
+    MAGEFLOW_MODEL_URL,
+    MAGEFLOW_SOURCE_URL,
+    probe_mageflow_runtime,
+)
 
 
 class ModelRuntimeManager:
@@ -84,6 +90,46 @@ class ModelRuntimeManager:
             "path": str(path) if path.exists() else None,
         }
 
+    def _mageflow(self) -> dict[str, Any]:
+        checkpoint = self._hf_model(self.config.model.mageflow_model)
+        runtime = probe_mageflow_runtime(self.config.model.mageflow_url)
+        checkpoint_status = checkpoint["status"]
+        if checkpoint_status in {"not_downloaded", "downloading", "partial"}:
+            status = checkpoint_status
+            reason = "Download the public Mage-Flow checkpoint before enabling the isolated runtime"
+        elif (
+            runtime.get("ready")
+            and runtime.get("model_id") == self.config.model.mageflow_model
+            and runtime.get("model_revision") == self.config.model.mageflow_revision
+        ):
+            status = "ready"
+            reason = runtime.get("reason") or "Checkpoint and isolated CUDA runtime are ready"
+        else:
+            status = str(runtime.get("status") or "runtime_unavailable")
+            if (
+                runtime.get("ready")
+                and runtime.get("model_revision") != self.config.model.mageflow_revision
+            ):
+                status = "revision_mismatch"
+                reason = (
+                    "Mage-Flow runtime revision "
+                    f"{runtime.get('model_revision') or 'unknown'} does not match verified revision "
+                    f"{self.config.model.mageflow_revision}"
+                )
+            else:
+                reason = runtime.get("reason") or "The isolated Mage-Flow runtime is not ready"
+        return {
+            **checkpoint,
+            "status": status,
+            "reason": reason,
+            "runtime": runtime,
+            "verified_revision": self.config.model.mageflow_revision,
+            "source_url": MAGEFLOW_MODEL_URL,
+            "implementation_url": MAGEFLOW_SOURCE_URL,
+            "license": "MIT",
+            "research_only": True,
+        }
+
     def memory(self) -> dict[str, Any]:
         vm = psutil.virtual_memory()
         result: dict[str, Any] = {
@@ -111,14 +157,21 @@ class ModelRuntimeManager:
             pass
         return result
 
-    def recommended(self) -> dict[str, Any]:
+    def recommended(self, mageflow_status: dict[str, Any] | None = None) -> dict[str, Any]:
         memory = self.memory()
         vram = memory["cuda"].get("total_gb", 0)
+        mageflow_status = mageflow_status or self._mageflow()
         backend = (
-            "zimage"
-            if self._local_zimage()["status"] == "ready" and vram >= 16
+            "mageflow"
+            if mageflow_status["status"] == "ready" and vram >= 20
             else (
-                "flux" if is_model_cached(self.config.model.flux_model) and vram >= 20 else "small"
+                "zimage"
+                if self._local_zimage()["status"] == "ready" and vram >= 16
+                else (
+                    "flux"
+                    if is_model_cached(self.config.model.flux_model) and vram >= 20
+                    else "small"
+                )
             )
         )
         return {
@@ -133,6 +186,7 @@ class ModelRuntimeManager:
         }
 
     def status(self) -> dict[str, Any]:
+        mageflow_status = self._mageflow()
         specs = [
             ("flux", self.config.model.flux_model, "FLUX"),
             ("small", self.config.model.small_sd_model, "Small Stable Diffusion"),
@@ -140,6 +194,16 @@ class ModelRuntimeManager:
             ("smoke", self.config.model.smoke_test_model, "Smoke Test SD"),
         ]
         backends = []
+        backends.append(
+            {
+                "backend": "mageflow",
+                "id": self.config.model.mageflow_model,
+                "name": "Microsoft Mage-Flow",
+                "type": "text-to-image",
+                "downloadable": True,
+                **mageflow_status,
+            }
+        )
         for backend, model_id, name in specs:
             backends.append(
                 {
@@ -190,27 +254,34 @@ class ModelRuntimeManager:
                 },
             ]
         )
-        resolved_backend = resolve_image_backend(self.config)
+        resolved_backend = resolve_image_backend(
+            self.config,
+            mageflow_ready=mageflow_status["status"] == "ready",
+        )
         active_model = next(
             (item for item in backends if item["backend"] == resolved_backend),
             None,
         )
-        preferred_model = next(item for item in backends if item["backend"] == "zimage")
-        fallback_model = next(item for item in backends if item["backend"] == "small")
+        preferred_model = next(item for item in backends if item["backend"] == "mageflow")
+        zimage_model = next(item for item in backends if item["backend"] == "zimage")
+        flux_model = next(item for item in backends if item["backend"] == "flux")
+        small_model = next(item for item in backends if item["backend"] == "small")
+        fallback_model = (
+            zimage_model
+            if zimage_model["status"] == "ready"
+            else flux_model if flux_model["status"] == "ready" else small_model
+        )
+        resolved_fallback = active_model or fallback_model
         fallback_reason = None
-        if (
-            preferred_model["status"] != "ready"
-            and resolved_backend == "small"
-            and self.config.model.image_backend in {"auto", "zimage"}
-        ):
-            detail = (
-                f"checkpoint not downloaded at {preferred_model['path']}"
-                if preferred_model["status"] == "not_downloaded"
-                else f"checkpoint is incomplete at {preferred_model['path']}"
-            )
+        if preferred_model["status"] != "ready" and self.config.model.image_backend == "auto":
             fallback_reason = (
-                f"Z-Image-Turbo unavailable: {detail}. "
-                f"Using {fallback_model['name']} ({fallback_model['id']}) instead."
+                f"Mage-Flow unavailable: {preferred_model.get('reason') or preferred_model['status']}. "
+                f"Using {resolved_fallback['name']} ({resolved_fallback['id']}) instead."
+            )
+        elif self.config.model.image_backend == "zimage" and resolved_backend != "zimage":
+            fallback_reason = (
+                f"Z-Image-Turbo unavailable at {zimage_model['path']}. "
+                f"Using {resolved_fallback['name']} ({resolved_fallback['id']}) instead."
             )
 
         return {
@@ -221,11 +292,11 @@ class ModelRuntimeManager:
             "active_model": active_model["name"] if active_model else resolved_backend,
             "active_model_id": active_model["id"] if active_model else resolved_backend,
             "active_model_status": active_model["status"] if active_model else "unknown",
-            "preferred_backend": "zimage",
+            "preferred_backend": "mageflow",
             "preferred_model": preferred_model["name"],
             "preferred_model_id": preferred_model["id"],
             "preferred_model_status": preferred_model["status"],
-            "fallback_backend": "small",
+            "fallback_backend": fallback_model["backend"],
             "fallback_model": fallback_model["name"],
             "fallback_model_id": fallback_model["id"],
             "fallback_reason": fallback_reason,
@@ -233,11 +304,27 @@ class ModelRuntimeManager:
             "models": backends,
             "cache_dir": str(model_cache_path("x").parent),
             "memory": self.memory(),
-            "recommended": self.recommended(),
+            "recommended": self.recommended(mageflow_status),
             "selection_path": str(self.state_path),
         }
 
     def unload(self) -> dict[str, Any]:
+        sidecar: dict[str, Any]
+        unload_request = request.Request(
+            f"{self.config.model.mageflow_url.rstrip('/')}/unload",
+            data=b"",
+            method="POST",
+        )
+        try:
+            with request.urlopen(unload_request, timeout=5.0) as response:
+                sidecar = json.loads(response.read().decode("utf-8"))
+        except (error.HTTPError, error.URLError, TimeoutError, OSError, ValueError) as exc:
+            sidecar = {
+                "status": "unavailable",
+                "unloaded": False,
+                "reason": f"Mage-Flow sidecar unload failed: {exc}",
+            }
+
         gc.collect()
         try:
             import torch
@@ -248,4 +335,13 @@ class ModelRuntimeManager:
                     torch.cuda.ipc_collect()
         except Exception:
             pass
-        return {"message": "Runtime caches released", "memory": self.memory()}
+        message = (
+            "Runtime caches and Mage-Flow sidecar released"
+            if sidecar.get("unloaded")
+            else "Backend caches released; Mage-Flow sidecar was unavailable"
+        )
+        return {
+            "message": message,
+            "memory": self.memory(),
+            "mageflow": sidecar,
+        }

--- a/src/services/model_runtime.py
+++ b/src/services/model_runtime.py
@@ -11,7 +11,9 @@ from typing import Any
 import psutil
 
 from src.generators.factory import (
+    backend_label,
     incomplete_model_downloads,
+    inspect_local_zimage_model,
     is_model_cached,
     model_cache_path,
     resolve_image_backend,
@@ -55,20 +57,9 @@ class ModelRuntimeManager:
 
     def _local_zimage(self) -> dict[str, Any]:
         path = self.config.model.zimage_model_path
-        complete = (
-            (
-                (path / "model_index.json").exists()
-                and (path / "tokenizer" / "tokenizer.json").exists()
-                and (path / "vae" / "diffusion_pytorch_model.safetensors").exists()
-                and any((path / "transformer").glob("*.safetensors"))
-                and any((path / "text_encoder").glob("*.safetensors"))
-            )
-            if path.exists()
-            else False
-        )
-        size = sum(p.stat().st_size for p in path.rglob("*") if p.is_file()) if path.exists() else 0
+        status, size = inspect_local_zimage_model(path)
         return {
-            "status": "ready" if complete else ("partial" if path.exists() else "not_downloaded"),
+            "status": status,
             "size": size,
             "path": str(path),
         }
@@ -199,9 +190,45 @@ class ModelRuntimeManager:
                 },
             ]
         )
+        resolved_backend = resolve_image_backend(self.config)
+        active_model = next(
+            (item for item in backends if item["backend"] == resolved_backend),
+            None,
+        )
+        preferred_model = next(item for item in backends if item["backend"] == "zimage")
+        fallback_model = next(item for item in backends if item["backend"] == "small")
+        fallback_reason = None
+        if (
+            preferred_model["status"] != "ready"
+            and resolved_backend == "small"
+            and self.config.model.image_backend in {"auto", "zimage"}
+        ):
+            detail = (
+                f"checkpoint not downloaded at {preferred_model['path']}"
+                if preferred_model["status"] == "not_downloaded"
+                else f"checkpoint is incomplete at {preferred_model['path']}"
+            )
+            fallback_reason = (
+                f"Z-Image-Turbo unavailable: {detail}. "
+                f"Using {fallback_model['name']} ({fallback_model['id']}) instead."
+            )
+
         return {
             "configured_backend": self.config.model.image_backend,
-            "resolved_backend": resolve_image_backend(self.config),
+            "resolved_backend": resolved_backend,
+            "active_backend": resolved_backend,
+            "active_backend_label": backend_label(self.config, resolved_backend),
+            "active_model": active_model["name"] if active_model else resolved_backend,
+            "active_model_id": active_model["id"] if active_model else resolved_backend,
+            "active_model_status": active_model["status"] if active_model else "unknown",
+            "preferred_backend": "zimage",
+            "preferred_model": preferred_model["name"],
+            "preferred_model_id": preferred_model["id"],
+            "preferred_model_status": preferred_model["status"],
+            "fallback_backend": "small",
+            "fallback_model": fallback_model["name"],
+            "fallback_model_id": fallback_model["id"],
+            "fallback_reason": fallback_reason,
             "backends": backends,
             "models": backends,
             "cache_dir": str(model_cache_path("x").parent),

--- a/src/services/model_runtime.py
+++ b/src/services/model_runtime.py
@@ -10,7 +10,12 @@ from typing import Any
 
 import psutil
 
-from src.generators.factory import incomplete_model_downloads, is_model_cached, model_cache_path, resolve_image_backend
+from src.generators.factory import (
+    incomplete_model_downloads,
+    is_model_cached,
+    model_cache_path,
+    resolve_image_backend,
+)
 from src.utils.config import Config
 
 
@@ -51,30 +56,66 @@ class ModelRuntimeManager:
     def _local_zimage(self) -> dict[str, Any]:
         path = self.config.model.zimage_model_path
         complete = (
-            (path / "model_index.json").exists()
-            and (path / "tokenizer" / "tokenizer.json").exists()
-            and (path / "vae" / "diffusion_pytorch_model.safetensors").exists()
-            and any((path / "transformer").glob("*.safetensors"))
-            and any((path / "text_encoder").glob("*.safetensors"))
-        ) if path.exists() else False
+            (
+                (path / "model_index.json").exists()
+                and (path / "tokenizer" / "tokenizer.json").exists()
+                and (path / "vae" / "diffusion_pytorch_model.safetensors").exists()
+                and any((path / "transformer").glob("*.safetensors"))
+                and any((path / "text_encoder").glob("*.safetensors"))
+            )
+            if path.exists()
+            else False
+        )
         size = sum(p.stat().st_size for p in path.rglob("*") if p.is_file()) if path.exists() else 0
-        return {"status": "ready" if complete else ("partial" if path.exists() else "not_downloaded"), "size": size, "path": str(path)}
+        return {
+            "status": "ready" if complete else ("partial" if path.exists() else "not_downloaded"),
+            "size": size,
+            "path": str(path),
+        }
 
     def _hf_model(self, model_id: str) -> dict[str, Any]:
         path = model_cache_path(model_id)
         incomplete = incomplete_model_downloads(model_id)
-        status = "downloading" if incomplete else ("ready" if is_model_cached(model_id) else ("partial" if path.exists() else "not_downloaded"))
+        status = (
+            "downloading"
+            if incomplete
+            else (
+                "ready"
+                if is_model_cached(model_id)
+                else ("partial" if path.exists() else "not_downloaded")
+            )
+        )
         size = sum(p.stat().st_size for p in path.rglob("*") if p.is_file()) if path.exists() else 0
-        return {"status": status, "size": size, "incomplete_files": len(incomplete), "path": str(path) if path.exists() else None}
+        return {
+            "status": status,
+            "size": size,
+            "incomplete_files": len(incomplete),
+            "path": str(path) if path.exists() else None,
+        }
 
     def memory(self) -> dict[str, Any]:
         vm = psutil.virtual_memory()
-        result: dict[str, Any] = {"system": {"total_gb": round(vm.total / 1024**3, 2), "available_gb": round(vm.available / 1024**3, 2), "percent_used": vm.percent}, "cuda": {"available": False}}
+        result: dict[str, Any] = {
+            "system": {
+                "total_gb": round(vm.total / 1024**3, 2),
+                "available_gb": round(vm.available / 1024**3, 2),
+                "percent_used": vm.percent,
+            },
+            "cuda": {"available": False},
+        }
         try:
             import torch
+
             if torch.cuda.is_available():
                 free, total = torch.cuda.mem_get_info()
-                result["cuda"] = {"available": True, "device": torch.cuda.get_device_name(0), "total_gb": round(total / 1024**3, 2), "free_gb": round(free / 1024**3, 2), "allocated_gb": round(torch.cuda.memory_allocated() / 1024**3, 2), "reserved_gb": round(torch.cuda.memory_reserved() / 1024**3, 2)}
+                result["cuda"] = {
+                    "available": True,
+                    "device": torch.cuda.get_device_name(0),
+                    "total_gb": round(total / 1024**3, 2),
+                    "free_gb": round(free / 1024**3, 2),
+                    "allocated_gb": round(torch.cuda.memory_allocated() / 1024**3, 2),
+                    "reserved_gb": round(torch.cuda.memory_reserved() / 1024**3, 2),
+                }
         except Exception:
             pass
         return result
@@ -82,8 +123,23 @@ class ModelRuntimeManager:
     def recommended(self) -> dict[str, Any]:
         memory = self.memory()
         vram = memory["cuda"].get("total_gb", 0)
-        backend = "zimage" if self._local_zimage()["status"] == "ready" and vram >= 16 else ("flux" if is_model_cached(self.config.model.flux_model) and vram >= 20 else "small")
-        return {"backend": backend, "width": 1024 if vram >= 20 else 512, "height": 1024 if vram >= 20 else 512, "reason": f"Selected for {vram:.1f} GB VRAM" if vram else "Selected from local cache availability"}
+        backend = (
+            "zimage"
+            if self._local_zimage()["status"] == "ready" and vram >= 16
+            else (
+                "flux" if is_model_cached(self.config.model.flux_model) and vram >= 20 else "small"
+            )
+        )
+        return {
+            "backend": backend,
+            "width": 1024 if vram >= 20 else 512,
+            "height": 1024 if vram >= 20 else 512,
+            "reason": (
+                f"Selected for {vram:.1f} GB VRAM"
+                if vram
+                else "Selected from local cache availability"
+            ),
+        }
 
     def status(self) -> dict[str, Any]:
         specs = [
@@ -94,18 +150,71 @@ class ModelRuntimeManager:
         ]
         backends = []
         for backend, model_id, name in specs:
-            backends.append({"backend": backend, "id": model_id, "name": name, "type": "text-to-image", "downloadable": True, **self._hf_model(model_id)})
-        backends.append({"backend": "zimage", "id": "local:zimage", "name": "Z-Image-Turbo", "type": "text-to-image", "downloadable": True, "incomplete_files": 0, **self._local_zimage()})
-        backends.extend([
-            {"backend": "ollama", "id": self.config.model.ollama_image_model or "ollama:image", "name": "Ollama Image", "type": "text-to-image", "status": "configured" if self.config.model.ollama_image_model else "not_configured", "downloadable": False, "size": 0, "incomplete_files": 0, "path": None},
-            {"backend": "mock", "id": "builtin:mock", "name": "Mock", "type": "text-to-image", "status": "ready", "downloadable": False, "size": 0, "incomplete_files": 0, "path": None},
-        ])
-        return {"configured_backend": self.config.model.image_backend, "resolved_backend": resolve_image_backend(self.config), "backends": backends, "models": backends, "cache_dir": str(model_cache_path("x").parent), "memory": self.memory(), "recommended": self.recommended(), "selection_path": str(self.state_path)}
+            backends.append(
+                {
+                    "backend": backend,
+                    "id": model_id,
+                    "name": name,
+                    "type": "text-to-image",
+                    "downloadable": True,
+                    **self._hf_model(model_id),
+                }
+            )
+        backends.append(
+            {
+                "backend": "zimage",
+                "id": "local:zimage",
+                "name": "Z-Image-Turbo",
+                "type": "text-to-image",
+                "downloadable": True,
+                "incomplete_files": 0,
+                **self._local_zimage(),
+            }
+        )
+        backends.extend(
+            [
+                {
+                    "backend": "ollama",
+                    "id": self.config.model.ollama_image_model or "ollama:image",
+                    "name": "Ollama Image",
+                    "type": "text-to-image",
+                    "status": (
+                        "configured" if self.config.model.ollama_image_model else "not_configured"
+                    ),
+                    "downloadable": False,
+                    "size": 0,
+                    "incomplete_files": 0,
+                    "path": None,
+                },
+                {
+                    "backend": "mock",
+                    "id": "builtin:mock",
+                    "name": "Mock",
+                    "type": "text-to-image",
+                    "status": "ready",
+                    "downloadable": False,
+                    "size": 0,
+                    "incomplete_files": 0,
+                    "path": None,
+                },
+            ]
+        )
+        return {
+            "configured_backend": self.config.model.image_backend,
+            "resolved_backend": resolve_image_backend(self.config),
+            "backends": backends,
+            "models": backends,
+            "cache_dir": str(model_cache_path("x").parent),
+            "memory": self.memory(),
+            "recommended": self.recommended(),
+            "selection_path": str(self.state_path),
+        }
 
     def unload(self) -> dict[str, Any]:
         gc.collect()
         try:
             import torch
+
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
                 if torch.cuda.is_initialized():

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -148,6 +148,7 @@ def validate_generation_config(config: Config, resolved_backend: str) -> list[st
     errors = config.validate()
     valid_backends = {
         "auto",
+        "mageflow",
         "flux",
         "ollama",
         "zimage",
@@ -162,7 +163,8 @@ def validate_generation_config(config: Config, resolved_backend: str) -> list[st
     if resolved_backend not in valid_backends:
         errors.append(
             f"Invalid image backend: {resolved_backend} "
-            "(must be one of auto, flux, ollama, zimage, qwen, ernie, small, turbo, smoke, mock)"
+            "(must be one of auto, mageflow, flux, ollama, zimage, qwen, ernie, "
+            "small, turbo, smoke, mock)"
         )
 
     if (
@@ -420,7 +422,7 @@ def generate(
         None,
         "--backend",
         "--model",
-        help="Override the image backend for this run (flux, ollama, zimage, qwen, ernie, small, turbo, smoke, mock)",
+        help="Override the image backend for this run (mageflow, flux, ollama, zimage, qwen, ernie, small, turbo, smoke, mock)",
     ),
     recipe: Optional[str] = typer.Option(
         None,
@@ -780,7 +782,7 @@ def loop(
         None,
         "--backend",
         "--model",
-        help="Override the image backend for this run (flux, ollama, zimage, qwen, ernie, small, turbo, smoke, mock)",
+        help="Override the image backend for this run (mageflow, flux, ollama, zimage, qwen, ernie, small, turbo, smoke, mock)",
     ),
     mock: bool = typer.Option(
         False,

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -28,6 +28,12 @@ class ModelConfig:
     smoke_test_model: str
     small_sd_model: str
     turbo_model: str
+    mageflow_model: str
+    mageflow_revision: str
+    mageflow_url: str
+    mageflow_steps: int
+    mageflow_cfg: float
+    mageflow_timeout_seconds: float
     zimage_model_path: Path
     zimage_attention: str
     zimage_compile: bool
@@ -161,6 +167,15 @@ class Config:
         )
         small_sd_model = os.getenv("SMALL_SD_MODEL", "segmind/tiny-sd")
         turbo_model = os.getenv("TURBO_MODEL", "stabilityai/sd-turbo")
+        mageflow_model = os.getenv("MAGEFLOW_MODEL", "microsoft/Mage-Flow")
+        mageflow_revision = os.getenv(
+            "MAGEFLOW_MODEL_REVISION",
+            "faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9",
+        )
+        mageflow_url = os.getenv("MAGEFLOW_URL", "http://localhost:25801").rstrip("/")
+        mageflow_steps = int(os.getenv("MAGEFLOW_STEPS", "20"))
+        mageflow_cfg = float(os.getenv("MAGEFLOW_CFG", "5.0"))
+        mageflow_timeout_seconds = float(os.getenv("MAGEFLOW_TIMEOUT_SECONDS", "1800"))
         zimage_model_path = Path(os.getenv("ZIMAGE_MODEL_PATH", "ckpts/Z-Image-Turbo"))
         zimage_attention = os.getenv("ZIMAGE_ATTENTION", "_sdpa")
         zimage_compile = os.getenv("ZIMAGE_COMPILE", "false").lower() in (
@@ -225,6 +240,12 @@ class Config:
             smoke_test_model=smoke_test_model,
             small_sd_model=small_sd_model,
             turbo_model=turbo_model,
+            mageflow_model=mageflow_model,
+            mageflow_revision=mageflow_revision,
+            mageflow_url=mageflow_url,
+            mageflow_steps=mageflow_steps,
+            mageflow_cfg=mageflow_cfg,
+            mageflow_timeout_seconds=mageflow_timeout_seconds,
             zimage_model_path=zimage_model_path,
             zimage_attention=zimage_attention,
             zimage_compile=zimage_compile,
@@ -358,6 +379,7 @@ class Config:
         # Validate model parameters
         if self.model.image_backend not in {
             "auto",
+            "mageflow",
             "flux",
             "ollama",
             "zimage",
@@ -370,7 +392,16 @@ class Config:
         }:
             errors.append(
                 f"Invalid image backend: {self.model.image_backend} "
-                "(must be one of auto, flux, ollama, zimage, qwen, ernie, small, turbo, smoke, mock)"
+                "(must be one of auto, mageflow, flux, ollama, zimage, qwen, ernie, "
+                "small, turbo, smoke, mock)"
+            )
+        if not (1 <= self.model.mageflow_steps <= 50):
+            errors.append(
+                f"Invalid Mage-Flow steps: {self.model.mageflow_steps} (must be between 1 and 50)"
+            )
+        if not (0.0 <= self.model.mageflow_cfg <= 20.0):
+            errors.append(
+                f"Invalid Mage-Flow CFG: {self.model.mageflow_cfg} (must be between 0.0 and 20.0)"
             )
         if not (1 <= self.image.num_inference_steps <= 150):
             errors.append(

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -151,7 +151,7 @@ class Config:
         elif legacy_image_model in {"flux", "ollama", "zimage", "qwen", "ernie"}:
             image_backend = legacy_image_model
         else:
-            image_backend = "auto"
+            image_backend = "zimage"
 
         if image_backend == "tiny":
             image_backend = "smoke"

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -64,6 +64,7 @@ class PluginConfig:
 
     enabled_plugins: List[str]
     plugin_order: Dict[str, int]
+    entropy_level: str = "strange"
 
 
 @dataclass
@@ -106,7 +107,16 @@ class Config:
         if not plugin_order and enabled_plugins:
             plugin_order = {name: index for index, name in enumerate(enabled_plugins, start=1)}
 
-        self.plugins = PluginConfig(enabled_plugins=enabled_plugins, plugin_order=plugin_order)
+        entropy_level = os.getenv("DREAM_ENTROPY_LEVEL", os.getenv("ENTROPY_LEVEL", "strange"))
+        entropy_level = entropy_level.strip().lower()
+        if entropy_level not in {"calm", "strange", "wild"}:
+            entropy_level = "strange"
+
+        self.plugins = PluginConfig(
+            enabled_plugins=enabled_plugins,
+            plugin_order=plugin_order,
+            entropy_level=entropy_level,
+        )
 
         # Lora configuration
         enabled_loras_str = os.getenv("ENABLED_LORAS")

--- a/src/utils/gallery_publisher.py
+++ b/src/utils/gallery_publisher.py
@@ -3,22 +3,29 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import os
 import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from src.utils.publication_catalog import (
     IMAGE_EXTENSIONS,
     PUBLIC_GALLERY_STATES,
+    PUBLICATION_BLOCKING_QUALITY_FLAGS,
     catalog_path_for,
     load_catalog,
 )
 
 DEFAULT_BUCKET = "dreamgen-gallery"
+CURRENT_MANIFEST_KEY = "_dreamgen/current.json"
+RELEASE_MANIFEST_PREFIX = "_dreamgen/releases"
+MANIFEST_SCHEMA_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -50,6 +57,22 @@ class PublishPlan:
     @property
     def file_count(self) -> int:
         return len(self.assets)
+
+
+@dataclass(frozen=True)
+class PublishRelease:
+    """An ordered, rollback-linked public gallery release."""
+
+    manifest: dict[str, Any]
+    current_key: str = CURRENT_MANIFEST_KEY
+
+    @property
+    def release_id(self) -> str:
+        return str(self.manifest["release_id"])
+
+    @property
+    def release_key(self) -> str:
+        return f"{RELEASE_MANIFEST_PREFIX}/{self.release_id}.json"
 
 
 def parse_args() -> argparse.Namespace:
@@ -105,6 +128,23 @@ def parse_args() -> argparse.Namespace:
         default="wrangler@4",
         help="Package passed to npx, for example wrangler@4.",
     )
+    parser.add_argument(
+        "--transport",
+        choices=("auto", "rclone", "wrangler"),
+        default="auto",
+        help="Upload transport. Auto prefers rclone and falls back to Wrangler.",
+    )
+    parser.add_argument(
+        "--rclone-remote",
+        default="r2",
+        help="Configured rclone remote name used by the rclone transport.",
+    )
+    parser.add_argument(
+        "--transfers",
+        type=int,
+        default=8,
+        help="Parallel file transfers used by rclone.",
+    )
     return parser.parse_args()
 
 
@@ -132,6 +172,28 @@ def _add_sidecar(
         assets.append(PublishAsset(sidecar_path, object_key(sidecar_path, output_dir), reason))
 
 
+def _entry_sort_key(entry: dict[str, Any]) -> tuple[str, str]:
+    """Return a stable newest-first ordering key with a path tie-breaker."""
+    return (str(entry.get("created_at", "")), str(entry.get("path", "")))
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_hash(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
 def build_publish_plan(
     output_dir: Path,
     since: float | None,
@@ -155,11 +217,7 @@ def build_publish_plan(
     skipped: list[SkippedAsset] = []
     included_images = 0
 
-    entries = sorted(
-        catalog["assets"].values(),
-        key=lambda entry: str(entry.get("created_at", "")),
-        reverse=True,
-    )
+    entries = sorted(catalog["assets"].values(), key=_entry_sort_key, reverse=True)
 
     for entry in entries:
         key = str(entry.get("path", ""))
@@ -172,8 +230,10 @@ def build_publish_plan(
         if not bool(entry.get("publishable", True)):
             skipped.append(SkippedAsset(key, "not publishable"))
             continue
-        if entry.get("quality_flags"):
-            skipped.append(SkippedAsset(key, f"quality_flags={','.join(entry['quality_flags'])}"))
+        quality_flags = {str(flag) for flag in entry.get("quality_flags", [])}
+        blocking_flags = sorted(quality_flags & PUBLICATION_BLOCKING_QUALITY_FLAGS)
+        if blocking_flags:
+            skipped.append(SkippedAsset(key, f"quality_flags={','.join(blocking_flags)}"))
             continue
         if image_path.suffix.lower() not in IMAGE_EXTENSIONS or not image_path.exists():
             skipped.append(SkippedAsset(key, "missing image file"))
@@ -192,6 +252,113 @@ def build_publish_plan(
             break
 
     return PublishPlan(assets=assets, skipped=skipped, image_count=included_images, delete_count=0)
+
+
+def build_release_manifest(
+    output_dir: Path,
+    plan: PublishPlan,
+    *,
+    published_at: str | None = None,
+    previous_release: dict[str, Any] | None = None,
+) -> PublishRelease:
+    """Build the exact ordered public view represented by a publish plan."""
+    catalog = load_catalog(output_dir)
+    entries = catalog["assets"]
+    image_assets = [asset for asset in plan.assets if asset.path.suffix.lower() in IMAGE_EXTENSIONS]
+    items: list[dict[str, Any]] = []
+
+    for position, asset in enumerate(image_assets):
+        entry = entries.get(asset.key)
+        if not isinstance(entry, dict):
+            raise SystemExit(f"Catalog entry disappeared while building release: {asset.key}")
+        digest = _sha256(asset.path)
+        caption_path = asset.path.with_suffix(".txt")
+        metadata_path = asset.path.with_suffix(".meta.json")
+        caption_version = _sha256(caption_path)[:20] if caption_path.exists() else None
+        metadata_version = _sha256(metadata_path)[:20] if metadata_path.exists() else None
+        state = str(entry.get("publication_state", "published"))
+        metadata = entry.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+        metadata = {
+            **metadata,
+            "publication": {
+                "state": state,
+                "approved_at": entry.get("published_at") or entry.get("updated_at"),
+            },
+        }
+        items.append(
+            {
+                "position": position,
+                "key": asset.key,
+                "asset_version": digest[:20],
+                "sha256": digest,
+                "size": asset.path.stat().st_size,
+                "created_at": entry.get("created_at"),
+                "approved_at": entry.get("published_at") or entry.get("updated_at"),
+                "publication_state": state,
+                "featured": state == "featured",
+                "caption_key": (
+                    object_key(caption_path, output_dir) if caption_path.exists() else None
+                ),
+                "caption_version": caption_version,
+                "metadata_key": (
+                    object_key(metadata_path, output_dir) if metadata_path.exists() else None
+                ),
+                "metadata_version": metadata_version,
+                "metadata": metadata,
+            }
+        )
+
+    release_time = published_at or utc_now()
+    previous_id = None
+    previous_key = None
+    if isinstance(previous_release, dict):
+        previous_id = previous_release.get("release_id")
+        previous_key = previous_release.get("release_key")
+        if not previous_key and previous_id:
+            previous_key = f"{RELEASE_MANIFEST_PREFIX}/{previous_id}.json"
+
+    source_catalog = {
+        "version": catalog.get("version"),
+        "updated_at": catalog.get("updated_at"),
+        "sha256": _sha256(catalog_path_for(output_dir)),
+    }
+    identity = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "published_at": release_time,
+        "source_catalog": source_catalog,
+        "items": [
+            {
+                "position": item["position"],
+                "key": item["key"],
+                "asset_version": item["asset_version"],
+                "caption_version": item["caption_version"],
+                "metadata_version": item["metadata_version"],
+                "publication_state": item["publication_state"],
+                "created_at": item["created_at"],
+                "approved_at": item["approved_at"],
+            }
+            for item in items
+        ],
+    }
+    release_id = f"{release_time[:10].replace('-', '')}-{_json_hash(identity)[:16]}"
+    release_key = f"{RELEASE_MANIFEST_PREFIX}/{release_id}.json"
+    manifest = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "release_id": release_id,
+        "release_key": release_key,
+        "published_at": release_time,
+        "image_count": len(items),
+        "leading_key": items[0]["key"] if items else None,
+        "source_catalog": source_catalog,
+        "rollback": {
+            "previous_release_id": previous_id,
+            "previous_release_key": previous_key,
+        },
+        "items": items,
+    }
+    return PublishRelease(manifest=manifest)
 
 
 def build_publish_status(
@@ -306,6 +473,24 @@ def run_wrangler(args: list[str], *, bucket: str, key: str) -> None:
         )
 
 
+def try_get_wrangler_object(
+    package: str,
+    bucket: str,
+    key: str,
+    destination: Path,
+    remote: bool,
+) -> bool:
+    args = [*wrangler_base_args(package), "get", f"{bucket}/{key}", "--file", str(destination)]
+    if remote:
+        args.append("--remote")
+    env = os.environ.copy()
+    r2_token = env.get("CLOUDFLARE_R2_API_TOKEN")
+    if r2_token:
+        env["CLOUDFLARE_API_TOKEN"] = r2_token
+    result = subprocess.run(args, check=False, text=True, capture_output=True, env=env)
+    return result.returncode == 0 and destination.exists()
+
+
 def put_object(package: str, bucket: str, asset: PublishAsset, remote: bool) -> None:
     args = [
         *wrangler_base_args(package),
@@ -326,6 +511,144 @@ def delete_object(package: str, bucket: str, key: str, remote: bool) -> None:
     run_wrangler(args, bucket=bucket, key=key)
 
 
+def resolve_transport(transport: str, *, remote: bool) -> str:
+    if transport != "auto":
+        if transport == "rclone" and not remote:
+            raise SystemExit("The rclone transport is only available for remote publishing.")
+        return transport
+    if remote and shutil.which("rclone"):
+        return "rclone"
+    return "wrangler"
+
+
+def rclone_target(remote_name: str, bucket: str, key: str | None = None) -> str:
+    base = f"{remote_name.rstrip(':')}:{bucket}"
+    return f"{base}/{key}" if key else base
+
+
+def run_rclone(args: list[str], *, target: str) -> None:
+    rclone = shutil.which("rclone")
+    if not rclone:
+        raise SystemExit("rclone is required for the selected publish transport.")
+    result = subprocess.run([rclone, *args], check=False, text=True)
+    if result.returncode != 0:
+        raise SystemExit(f"rclone gallery publishing failed for {target}.")
+
+
+def rclone_copy_assets(
+    plan: PublishPlan,
+    *,
+    output_dir: Path,
+    bucket: str,
+    remote_name: str,
+    transfers: int,
+) -> None:
+    """Copy exactly the approved plan without mirroring or deleting remote objects."""
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as file:
+        for asset in plan.assets:
+            file.write(f"{asset.key}\n")
+        files_from = Path(file.name)
+    try:
+        target = rclone_target(remote_name, bucket)
+        run_rclone(
+            [
+                "copy",
+                str(output_dir),
+                target,
+                "--files-from",
+                str(files_from),
+                "--no-traverse",
+                "--transfers",
+                str(max(1, transfers)),
+                "--checkers",
+                str(max(2, transfers * 2)),
+            ],
+            target=target,
+        )
+    finally:
+        try:
+            files_from.unlink()
+        except OSError:
+            pass
+
+
+def rclone_put_object(path: Path, *, bucket: str, key: str, remote_name: str) -> None:
+    target = rclone_target(remote_name, bucket, key)
+    run_rclone(["copyto", str(path), target], target=target)
+
+
+def try_get_rclone_object(*, bucket: str, key: str, destination: Path, remote_name: str) -> bool:
+    rclone = shutil.which("rclone")
+    if not rclone:
+        return False
+    target = rclone_target(remote_name, bucket, key)
+    result = subprocess.run(
+        [rclone, "copyto", target, str(destination)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return result.returncode == 0 and destination.exists()
+
+
+def load_previous_release(
+    *,
+    transport: str,
+    package: str,
+    bucket: str,
+    remote: bool,
+    remote_name: str,
+    temp_dir: Path,
+) -> dict[str, Any] | None:
+    destination = temp_dir / "previous-current.json"
+    if transport == "rclone":
+        found = try_get_rclone_object(
+            bucket=bucket,
+            key=CURRENT_MANIFEST_KEY,
+            destination=destination,
+            remote_name=remote_name,
+        )
+    else:
+        found = try_get_wrangler_object(
+            package,
+            bucket,
+            CURRENT_MANIFEST_KEY,
+            destination,
+            remote,
+        )
+    if not found:
+        return None
+    try:
+        payload = json.loads(destination.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def publish_release_manifests(
+    release: PublishRelease,
+    *,
+    transport: str,
+    package: str,
+    bucket: str,
+    remote: bool,
+    remote_name: str,
+    temp_dir: Path,
+) -> None:
+    """Publish the immutable release first and move the current pointer last."""
+    release_path = temp_dir / "release.json"
+    current_path = temp_dir / "current.json"
+    payload = json.dumps(release.manifest, indent=2, sort_keys=True)
+    release_path.write_text(payload, encoding="utf-8")
+    current_path.write_text(payload, encoding="utf-8")
+
+    for path, key in ((release_path, release.release_key), (current_path, release.current_key)):
+        if transport == "rclone":
+            rclone_put_object(path, bucket=bucket, key=key, remote_name=remote_name)
+        else:
+            put_object(package, bucket, PublishAsset(path, key, "release manifest"), remote)
+
+
 def smoke_test(package: str, bucket: str, remote: bool) -> None:
     key = f".smoke/publish-validation-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}.txt"
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as file:
@@ -342,14 +665,9 @@ def smoke_test(package: str, bucket: str, remote: bool) -> None:
             pass
 
 
-def validate_remote_environment(remote: bool) -> None:
-    if not remote:
+def validate_remote_environment(remote: bool, transport: str) -> None:
+    if not remote or transport == "rclone":
         return
-    if not (os.getenv("CLOUDFLARE_R2_API_TOKEN") or os.getenv("CLOUDFLARE_API_TOKEN")):
-        raise SystemExit(
-            "CLOUDFLARE_R2_API_TOKEN or CLOUDFLARE_API_TOKEN is required "
-            "for remote R2 publishing."
-        )
     if not os.getenv("CLOUDFLARE_ACCOUNT_ID"):
         raise SystemExit("CLOUDFLARE_ACCOUNT_ID is required for remote R2 publishing.")
 
@@ -364,6 +682,7 @@ def print_plan(plan: PublishPlan, *, bucket: str, remote: bool, execute: bool, p
     print(f"skipped_assets={len(plan.skipped)}")
     print(f"delete_objects={plan.delete_count if prune else 0}")
     print(f"prune={'enabled' if prune else 'disabled'}")
+    print(f"release_manifest={CURRENT_MANIFEST_KEY}")
 
     for asset in plan.assets[:50]:
         action = "UPLOAD" if execute else "DRY-RUN UPLOAD"
@@ -391,6 +710,9 @@ def publish_gallery(
     smoke_only: bool = False,
     local: bool = False,
     wrangler_package: str = "wrangler@4",
+    transport: str = "auto",
+    rclone_remote: str = "r2",
+    transfers: int = 8,
 ) -> PublishPlan:
     """Build and optionally execute the gallery publishing workflow."""
     since_timestamp = parse_since(since)
@@ -403,18 +725,66 @@ def publish_gallery(
         prune=prune,
     )
     print_plan(plan, bucket=bucket, remote=remote, execute=execute, prune=prune)
+    selected_transport = resolve_transport(transport, remote=remote)
+    print(f"transport={selected_transport}")
 
     if not execute:
+        preview = build_release_manifest(output_dir, plan)
+        print(f"release_id={preview.release_id}")
+        print(f"release_images={preview.manifest['image_count']}")
+        print(f"leading_key={preview.manifest['leading_key']}")
         return plan
 
-    validate_remote_environment(remote)
+    validate_remote_environment(remote, selected_transport)
     if smoke:
         smoke_test(wrangler_package, bucket, remote)
         if smoke_only:
             return plan
 
-    for asset in plan.assets:
-        put_object(wrangler_package, bucket, asset, remote)
+    with tempfile.TemporaryDirectory(prefix="dreamgen-gallery-release-") as temp_name:
+        temp_dir = Path(temp_name)
+        previous_release = load_previous_release(
+            transport=selected_transport,
+            package=wrangler_package,
+            bucket=bucket,
+            remote=remote,
+            remote_name=rclone_remote,
+            temp_dir=temp_dir,
+        )
+
+        if selected_transport == "rclone":
+            rclone_copy_assets(
+                plan,
+                output_dir=output_dir,
+                bucket=bucket,
+                remote_name=rclone_remote,
+                transfers=transfers,
+            )
+        else:
+            for asset in plan.assets:
+                put_object(wrangler_package, bucket, asset, remote)
+
+        release = build_release_manifest(
+            output_dir,
+            plan,
+            previous_release=previous_release,
+        )
+        publish_release_manifests(
+            release,
+            transport=selected_transport,
+            package=wrangler_package,
+            bucket=bucket,
+            remote=remote,
+            remote_name=rclone_remote,
+            temp_dir=temp_dir,
+        )
+        print(f"release_id={release.release_id}")
+        print(f"release_key={release.release_key}")
+        print(f"leading_key={release.manifest['leading_key']}")
+        print(
+            "previous_release_id="
+            f"{release.manifest['rollback']['previous_release_id'] or 'none'}"
+        )
 
     return plan
 
@@ -433,4 +803,7 @@ def main() -> None:
         smoke_only=args.smoke_test_only,
         local=args.local,
         wrangler_package=args.wrangler_package,
+        transport=args.transport,
+        rclone_remote=args.rclone_remote,
+        transfers=args.transfers,
     )

--- a/src/utils/gallery_publisher.py
+++ b/src/utils/gallery_publisher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import hashlib
 import json
 import os
@@ -462,12 +463,15 @@ def run_wrangler(args: list[str], *, bucket: str, key: str) -> None:
     if r2_token:
         env["CLOUDFLARE_API_TOKEN"] = r2_token
 
-    result = subprocess.run(args, check=False, text=True, env=env)
+    result = subprocess.run(args, check=False, text=True, capture_output=True, env=env)
     if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        detail_line = detail[-1] if detail else "unknown Wrangler error"
         raise SystemExit(
             "Wrangler R2 command failed.\n"
             f"Bucket: {bucket}\n"
             f"Key: {key}\n"
+            f"Detail: {detail_line}\n"
             "Confirm CLOUDFLARE_R2_API_TOKEN has Workers R2 Storage Write or "
             "Workers R2 Storage Bucket Item Write for this bucket, then rerun."
         )
@@ -502,6 +506,34 @@ def put_object(package: str, bucket: str, asset: PublishAsset, remote: bool) -> 
     if remote:
         args.append("--remote")
     run_wrangler(args, bucket=bucket, key=asset.key)
+
+
+def wrangler_put_assets(
+    plan: PublishPlan,
+    *,
+    package: str,
+    bucket: str,
+    remote: bool,
+    transfers: int,
+) -> None:
+    """Upload the exact approved plan with bounded Wrangler concurrency."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, transfers)) as executor:
+        futures = {
+            executor.submit(put_object, package, bucket, asset, remote): asset
+            for asset in plan.assets
+        }
+        for future in concurrent.futures.as_completed(futures):
+            asset = futures[future]
+            try:
+                future.result()
+            except BaseException as exc:
+                for pending in futures:
+                    pending.cancel()
+                raise SystemExit(
+                    "Wrangler gallery publishing failed. The release pointer was not updated.\n"
+                    f"Bucket: {bucket}\n"
+                    f"Key: {asset.key}"
+                ) from exc
 
 
 def delete_object(package: str, bucket: str, key: str, remote: bool) -> None:
@@ -753,16 +785,43 @@ def publish_gallery(
         )
 
         if selected_transport == "rclone":
-            rclone_copy_assets(
+            try:
+                rclone_copy_assets(
+                    plan,
+                    output_dir=output_dir,
+                    bucket=bucket,
+                    remote_name=rclone_remote,
+                    transfers=transfers,
+                )
+            except SystemExit:
+                if transport != "auto":
+                    raise
+                selected_transport = "wrangler"
+                print("rclone_write_failed=fallback_to_wrangler")
+                validate_remote_environment(remote, selected_transport)
+                previous_release = load_previous_release(
+                    transport=selected_transport,
+                    package=wrangler_package,
+                    bucket=bucket,
+                    remote=remote,
+                    remote_name=rclone_remote,
+                    temp_dir=temp_dir,
+                )
+                wrangler_put_assets(
+                    plan,
+                    package=wrangler_package,
+                    bucket=bucket,
+                    remote=remote,
+                    transfers=transfers,
+                )
+        else:
+            wrangler_put_assets(
                 plan,
-                output_dir=output_dir,
+                package=wrangler_package,
                 bucket=bucket,
-                remote_name=rclone_remote,
+                remote=remote,
                 transfers=transfers,
             )
-        else:
-            for asset in plan.assets:
-                put_object(wrangler_package, bucket, asset, remote)
 
         release = build_release_manifest(
             output_dir,

--- a/src/utils/gallery_publisher.py
+++ b/src/utils/gallery_publisher.py
@@ -463,7 +463,15 @@ def run_wrangler(args: list[str], *, bucket: str, key: str) -> None:
     if r2_token:
         env["CLOUDFLARE_API_TOKEN"] = r2_token
 
-    result = subprocess.run(args, check=False, text=True, capture_output=True, env=env)
+    result = subprocess.run(
+        args,
+        check=False,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        env=env,
+    )
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip().splitlines()
         detail_line = detail[-1] if detail else "unknown Wrangler error"

--- a/src/utils/generation_plan.py
+++ b/src/utils/generation_plan.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from ..plugins import plugin_manager, register_lora_plugin
+from ..plugins.dream_source_mixer import select_dream_source_mix
 from ..plugins.lora import SelectedLora, select_random_lora
 from .config import Config
 from .plugin_manager import PluginResult
@@ -97,9 +98,12 @@ class GenerationPlan:
                     "name": result.name,
                     "value": result.value,
                     "description": result.description,
+                    "category": result.category,
+                    "provenance": dict(result.provenance),
                 }
                 for result in self.plugin_results
             ],
+            "plugin_categories": {result.name: result.category for result in self.plugin_results},
             "temporal_descriptor": self.temporal_descriptor,
             "selected_lora": (
                 lora_provenance(self.selected_lora, backend=lora_backend)
@@ -109,7 +113,12 @@ class GenerationPlan:
         }
 
 
-def resolve_generation_plan(config: Config, *, plugins_enabled: bool = True) -> GenerationPlan:
+def resolve_generation_plan(
+    config: Config,
+    *,
+    plugins_enabled: bool = True,
+    seed: int | None = None,
+) -> GenerationPlan:
     """Resolve every enabled plugin and the optional LoRA exactly once."""
     register_lora_plugin(config)
     ordered_plugins = sorted(
@@ -122,6 +131,7 @@ def resolve_generation_plan(config: Config, *, plugins_enabled: bool = True) -> 
 
     selected_lora: SelectedLora | None = None
     overrides: dict[str, Any] = {}
+    override_provenance: dict[str, dict[str, Any]] = {}
     if "lora" in enabled_plugins:
         try:
             selected_lora = select_random_lora(config)
@@ -129,7 +139,18 @@ def resolve_generation_plan(config: Config, *, plugins_enabled: bool = True) -> 
             logger.warning("Unable to resolve LoRA selection from this config: %s", exc)
         overrides["lora"] = selected_lora.keyword if selected_lora else None
 
-    results = tuple(plugin_manager.execute_plugins(overrides=overrides))
+    if "dream_source_mixer" in enabled_plugins:
+        entropy_level = getattr(getattr(config, "plugins", None), "entropy_level", "strange")
+        selection = select_dream_source_mix(seed=seed, entropy_level=entropy_level)
+        overrides["dream_source_mixer"] = selection.prompt
+        override_provenance["dream_source_mixer"] = selection.to_provenance()
+
+    results = tuple(
+        plugin_manager.execute_plugins(
+            overrides=overrides,
+            override_provenance=override_provenance,
+        )
+    )
     descriptions = tuple(plugin_manager.get_plugin_descriptions())
     return GenerationPlan(
         plugin_results=results,

--- a/src/utils/generation_plan.py
+++ b/src/utils/generation_plan.py
@@ -1,0 +1,140 @@
+"""Resolve random plugin and LoRA choices exactly once for a generation run."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable
+
+from ..plugins import plugin_manager, register_lora_plugin
+from ..plugins.lora import SelectedLora, select_random_lora
+from .config import Config
+from .plugin_manager import PluginResult
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=64)
+def _sha256_for_file(path: str, size: int, mtime_ns: int) -> str:
+    """Hash an immutable file identity, caching by path, size, and mtime."""
+    del size, mtime_ns
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def lora_provenance(selection: SelectedLora, *, backend: str | None = None) -> dict[str, Any]:
+    """Return portable-enough local provenance for one resolved LoRA file."""
+    path = selection.path.resolve()
+    stat = path.stat()
+    return {
+        "name": selection.name,
+        "display_name": selection.display_name or selection.name,
+        "keyword": selection.keyword,
+        "kind": selection.kind,
+        "trigger_placement": selection.trigger_placement,
+        "trigger_required": selection.trigger_required,
+        "source": selection.source,
+        "base_model": selection.base_model,
+        "path": str(path),
+        "filename": path.name,
+        "size_bytes": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+        "sha256": _sha256_for_file(str(path), stat.st_size, stat.st_mtime_ns),
+        "backend": backend,
+        "selection_source": "job_generation_plan",
+    }
+
+
+def temporal_descriptor_from_results(results: Iterable[PluginResult]) -> str:
+    """Build one descriptor without executing any plugin a second time."""
+    parts: list[str] = []
+    holiday_fact: Any = None
+    art_style: Any = None
+
+    for result in results:
+        if result.name == "holiday_fact":
+            holiday_fact = result.value
+        elif result.name == "art_style":
+            art_style = result.value
+        elif result.name == "lora":
+            # A LoRA trigger is conditioning metadata, not temporal or scene
+            # prose. Prompt placement is handled from adapter metadata.
+            continue
+        elif result.value:
+            parts.append(str(result.value))
+
+    descriptor = ", ".join(parts)
+    if holiday_fact:
+        descriptor = f"{descriptor} ({holiday_fact})" if descriptor else f"({holiday_fact})"
+    if art_style:
+        descriptor = f"{descriptor}, {art_style}" if descriptor else str(art_style)
+    return descriptor
+
+
+@dataclass(frozen=True)
+class GenerationPlan:
+    """Immutable plugin and adapter choices shared across one generation job."""
+
+    plugin_results: tuple[PluginResult, ...]
+    plugin_descriptions: tuple[str, ...]
+    enabled_plugins: tuple[str, ...]
+    temporal_descriptor: str
+    selected_lora: SelectedLora | None = None
+
+    def to_metadata(self, *, lora_backend: str | None = None) -> dict[str, Any]:
+        """Serialize the resolved plan for events, jobs, sidecars, and catalog entries."""
+        return {
+            "resolution": "once_per_job",
+            "enabled_plugins": list(self.enabled_plugins),
+            "plugin_contributions": [
+                {
+                    "name": result.name,
+                    "value": result.value,
+                    "description": result.description,
+                }
+                for result in self.plugin_results
+            ],
+            "temporal_descriptor": self.temporal_descriptor,
+            "selected_lora": (
+                lora_provenance(self.selected_lora, backend=lora_backend)
+                if self.selected_lora
+                else None
+            ),
+        }
+
+
+def resolve_generation_plan(config: Config, *, plugins_enabled: bool = True) -> GenerationPlan:
+    """Resolve every enabled plugin and the optional LoRA exactly once."""
+    register_lora_plugin(config)
+    ordered_plugins = sorted(
+        (plugin for plugin in plugin_manager.plugins.values() if plugin.enabled),
+        key=lambda plugin: plugin.order,
+    )
+    enabled_plugins = tuple(plugin.name for plugin in ordered_plugins) if plugins_enabled else ()
+    if not plugins_enabled:
+        return GenerationPlan((), (), (), "", None)
+
+    selected_lora: SelectedLora | None = None
+    overrides: dict[str, Any] = {}
+    if "lora" in enabled_plugins:
+        try:
+            selected_lora = select_random_lora(config)
+        except (AttributeError, TypeError) as exc:
+            logger.warning("Unable to resolve LoRA selection from this config: %s", exc)
+        overrides["lora"] = selected_lora.keyword if selected_lora else None
+
+    results = tuple(plugin_manager.execute_plugins(overrides=overrides))
+    descriptions = tuple(plugin_manager.get_plugin_descriptions())
+    return GenerationPlan(
+        plugin_results=results,
+        plugin_descriptions=descriptions,
+        enabled_plugins=enabled_plugins,
+        temporal_descriptor=temporal_descriptor_from_results(results),
+        selected_lora=selected_lora,
+    )

--- a/src/utils/mageflow_runtime.py
+++ b/src/utils/mageflow_runtime.py
@@ -1,0 +1,50 @@
+"""Read-only readiness probes for the isolated local Mage-Flow runtime."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib import error, request
+
+MAGEFLOW_SOURCE_URL = "https://github.com/microsoft/Mage"
+MAGEFLOW_MODEL_URL = "https://huggingface.co/microsoft/Mage-Flow"
+MAGEFLOW_MODEL_REVISION = "faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9"
+
+
+def probe_mageflow_runtime(url: str, timeout: float = 0.75) -> dict[str, Any]:
+    """Return the sidecar health payload without raising network errors."""
+    health_url = f"{url.rstrip('/')}/health"
+    try:
+        with request.urlopen(health_url, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (error.HTTPError, error.URLError, TimeoutError, OSError, ValueError) as exc:
+        return {
+            "reachable": False,
+            "status": "runtime_unavailable",
+            "ready": False,
+            "loaded": False,
+            "reason": f"Mage-Flow sidecar is unavailable at {health_url}: {exc}",
+        }
+
+    status = str(payload.get("status") or "runtime_unavailable")
+    payload.update(
+        {
+            "reachable": True,
+            "status": status,
+            "ready": status == "ready",
+            "loaded": bool(payload.get("loaded")),
+        }
+    )
+    return payload
+
+
+def mageflow_runtime_ready(
+    url: str,
+    model_id: str,
+    model_revision: str | None = None,
+    timeout: float = 0.75,
+) -> bool:
+    """Return whether the requested public checkpoint is locally runnable."""
+    status = probe_mageflow_runtime(url, timeout=timeout)
+    revision_matches = model_revision is None or status.get("model_revision") == model_revision
+    return bool(status["ready"] and status.get("model_id") == model_id and revision_matches)

--- a/src/utils/observability.py
+++ b/src/utils/observability.py
@@ -1,0 +1,55 @@
+"""Durable lifecycle event export with optional OpenTelemetry hooks."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def write_lifecycle_event(metrics_dir: Path, event: dict[str, Any]) -> None:
+    """Append one JSON event to the local operator metrics stream."""
+    metrics_dir.mkdir(parents=True, exist_ok=True)
+    path = metrics_dir / "generation_events.jsonl"
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(event, sort_keys=True, default=str) + "\n")
+    _export_otel(event)
+
+
+def read_lifecycle_events(metrics_dir: Path, limit: int = 100) -> list[dict[str, Any]]:
+    path = metrics_dir / "generation_events.jsonl"
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines()[-limit:]:
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            events.append(value)
+    return list(reversed(events))
+
+
+def _export_otel(event: dict[str, Any]) -> None:
+    """Export spans only when explicitly enabled and the optional dependency exists."""
+    if os.getenv("DREAMGEN_OTEL_ENABLED", "0").lower() not in {"1", "true", "yes"}:
+        return
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        logger.warning("DREAMGEN_OTEL_ENABLED is set but OpenTelemetry is not installed")
+        return
+
+    tracer = trace.get_tracer("dreamgen")
+    with tracer.start_as_current_span(
+        str(event.get("name") or event.get("type") or "event")
+    ) as span:
+        for key in ("id", "backend", "model", "duration_ms", "generation_time"):
+            value = event.get(key)
+            if value is not None:
+                span.set_attribute(f"dreamgen.{key}", value)

--- a/src/utils/plugin_manager.py
+++ b/src/utils/plugin_manager.py
@@ -3,8 +3,16 @@ Plugin management system for controlling and logging plugin execution.
 """
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List
+
+PLUGIN_CATEGORIES = frozenset({"entropy", "context", "style", "operational"})
+
+
+def normalize_plugin_category(category: str) -> str:
+    """Keep category metadata bounded while preserving legacy registrations."""
+    normalized = str(category).strip().lower()
+    return normalized if normalized in PLUGIN_CATEGORIES else "context"
 
 
 @dataclass
@@ -16,6 +24,9 @@ class PluginInfo:
     function: Callable
     enabled: bool = True
     order: int = 999  # Default to end of list
+    category: str = "context"
+    kind: str = "prompt"
+    phase: str = "prompt"
 
 
 @dataclass
@@ -25,11 +36,27 @@ class PluginResult:
     name: str
     value: Any
     description: str
+    category: str = "context"
+    provenance: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GuardInfo:
+    """Operational hook metadata kept separate from prompt plugins."""
+
+    name: str
+    description: str
+    pre_hook: Callable[[Dict[str, Any]], Dict[str, Any] | None] | None = None
+    post_hook: Callable[[Dict[str, Any]], Dict[str, Any] | None] | None = None
+    enabled: bool = True
+    category: str = "operational"
+    phase: str = "pre+post"
 
 
 class PluginManager:
     def __init__(self):
         self.plugins: Dict[str, PluginInfo] = {}
+        self.guards: Dict[str, GuardInfo] = {}
         self.logger = logging.getLogger(__name__)
 
     def register(
@@ -39,6 +66,7 @@ class PluginManager:
         function: Callable,
         enabled: bool = True,
         order: int = 999,
+        category: str = "context",
     ):
         """Register a new plugin with the system."""
         self.plugins[name] = PluginInfo(
@@ -47,6 +75,7 @@ class PluginManager:
             function=function,
             enabled=enabled,
             order=order,
+            category=normalize_plugin_category(category),
         )
         self.logger.debug(
             "Registered plugin: %s (enabled=%s, order=%s)",
@@ -55,22 +84,49 @@ class PluginManager:
             order,
         )
 
+    def register_guard(
+        self,
+        name: str,
+        description: str,
+        *,
+        pre_hook: Callable[[Dict[str, Any]], Dict[str, Any] | None] | None = None,
+        post_hook: Callable[[Dict[str, Any]], Dict[str, Any] | None] | None = None,
+        enabled: bool = True,
+    ) -> None:
+        """Register an operational hook without making it a prompt modifier."""
+        self.guards[name] = GuardInfo(
+            name=name,
+            description=description,
+            pre_hook=pre_hook,
+            post_hook=post_hook,
+            enabled=enabled,
+        )
+        self.logger.debug("Registered guard: %s (enabled=%s)", name, enabled)
+
     def enable_plugin(self, name: str):
         """Enable a specific plugin."""
         if name in self.plugins:
             self.plugins[name].enabled = True
             self.logger.debug("Enabled plugin: %s", name)
+        elif name in self.guards:
+            self.guards[name].enabled = True
+            self.logger.debug("Enabled guard: %s", name)
 
     def disable_plugin(self, name: str):
         """Disable a specific plugin."""
         if name in self.plugins:
             self.plugins[name].enabled = False
             self.logger.debug("Disabled plugin: %s", name)
+        elif name in self.guards:
+            self.guards[name].enabled = False
+            self.logger.debug("Disabled guard: %s", name)
 
     def is_enabled(self, name: str) -> bool:
         """Check if a plugin is enabled."""
         if name in self.plugins:
             return self.plugins[name].enabled
+        if name in self.guards:
+            return self.guards[name].enabled
         return False
 
     def set_plugin_order(self, name: str, order: int):
@@ -79,7 +135,11 @@ class PluginManager:
             self.plugins[name].order = order
             self.logger.debug("Set order for plugin %s: %s", name, order)
 
-    def execute_plugins(self, overrides: Dict[str, Any] | None = None) -> List[PluginResult]:
+    def execute_plugins(
+        self,
+        overrides: Dict[str, Any] | None = None,
+        override_provenance: Dict[str, Dict[str, Any]] | None = None,
+    ) -> List[PluginResult]:
         """
         Execute all enabled plugins in their specified order.
         Values supplied in ``overrides`` are used without calling that plugin.
@@ -89,6 +149,7 @@ class PluginManager:
         """
         results = []
         resolved_overrides = overrides or {}
+        resolved_provenance = override_provenance or {}
 
         # Sort plugins by order
         sorted_plugins = sorted(
@@ -105,7 +166,11 @@ class PluginManager:
                 )
                 if value is not None:
                     result = PluginResult(
-                        name=plugin.name, value=value, description=plugin.description
+                        name=plugin.name,
+                        value=value,
+                        description=plugin.description,
+                        category=plugin.category,
+                        provenance=dict(resolved_provenance.get(plugin.name, {})),
                     )
                     results.append(result)
                     self.logger.info(
@@ -115,6 +180,60 @@ class PluginManager:
                 self.logger.error(f"Error executing plugin {plugin.name}: {str(e)}")
 
         return results
+
+    def execute_guards(self, phase: str, context: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Run operational hooks and return structured, sidecar-safe results."""
+        results: List[Dict[str, Any]] = []
+        for guard in self.guards.values():
+            if not guard.enabled:
+                continue
+            hook = (
+                guard.pre_hook if phase == "pre" else guard.post_hook if phase == "post" else None
+            )
+            if hook is None:
+                continue
+            try:
+                details = hook(context) or {}
+                status = str(details.pop("status", "passed"))
+                results.append(
+                    {
+                        "name": guard.name,
+                        "category": guard.category,
+                        "phase": phase,
+                        "status": status,
+                        "details": details,
+                    }
+                )
+            except Exception as exc:  # pragma: no cover - defensive guard boundary
+                self.logger.error("Guard %s failed during %s phase: %s", guard.name, phase, exc)
+                results.append(
+                    {
+                        "name": guard.name,
+                        "category": guard.category,
+                        "phase": phase,
+                        "status": "failed",
+                        "details": {"error": str(exc)},
+                    }
+                )
+        return results
+
+    def registry_entries(self) -> List[PluginInfo]:
+        """Return prompt plugins and operational guards for API/UI discovery."""
+        entries = list(self.plugins.values())
+        entries.extend(
+            PluginInfo(
+                name=guard.name,
+                description=guard.description,
+                function=lambda: None,
+                enabled=guard.enabled,
+                order=999,
+                category=guard.category,
+                kind="guard",
+                phase=guard.phase,
+            )
+            for guard in self.guards.values()
+        )
+        return sorted(entries, key=lambda info: (info.order, info.name))
 
     def get_plugin_descriptions(self) -> List[str]:
         """Get descriptions of all enabled plugins."""

--- a/src/utils/plugin_manager.py
+++ b/src/utils/plugin_manager.py
@@ -79,12 +79,16 @@ class PluginManager:
             self.plugins[name].order = order
             self.logger.debug("Set order for plugin %s: %s", name, order)
 
-    def execute_plugins(self) -> List[PluginResult]:
+    def execute_plugins(self, overrides: Dict[str, Any] | None = None) -> List[PluginResult]:
         """
         Execute all enabled plugins in their specified order.
+        Values supplied in ``overrides`` are used without calling that plugin.
+        This lets a generation plan resolve a random choice once and replay it
+        through prompt and renderer consumers without another random draw.
         Returns a list of plugin results with their contributions.
         """
         results = []
+        resolved_overrides = overrides or {}
 
         # Sort plugins by order
         sorted_plugins = sorted(
@@ -94,7 +98,11 @@ class PluginManager:
         for plugin in sorted_plugins:
             try:
                 self.logger.debug(f"Executing plugin: {plugin.name}")
-                value = plugin.function()
+                value = (
+                    resolved_overrides[plugin.name]
+                    if plugin.name in resolved_overrides
+                    else plugin.function()
+                )
                 if value is not None:
                     result = PluginResult(
                         name=plugin.name, value=value, description=plugin.description

--- a/src/utils/publication_catalog.py
+++ b/src/utils/publication_catalog.py
@@ -13,9 +13,18 @@ from PIL import Image
 from src.utils.storage import read_image_metadata
 
 CATALOG_FILENAME = ".gallery_catalog.json"
-CATALOG_VERSION = 1
+CATALOG_VERSION = 2
 PUBLICATION_STATES = {"draft", "published", "hidden", "featured", "rejected"}
 PUBLIC_GALLERY_STATES = {"published", "featured"}
+PUBLICATION_BLOCKING_QUALITY_FLAGS = {
+    "corrupt",
+    "diagnostic",
+    "draft",
+    "placeholder",
+    "provisional",
+    "rejected",
+    "unsafe",
+}
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 
 
@@ -150,14 +159,17 @@ def build_catalog_entry(
     if placeholder:
         quality_flags = sorted({*quality_flags, "placeholder"})
 
+    now = utc_now()
     return {
         "id": image_id_for(key),
         "path": key,
         "prompt": prompt if prompt is not None else prompt_for(image_path),
         "metadata": metadata,
         "created_at": created_at_for(image_path),
-        "updated_at": utc_now(),
+        "updated_at": now,
         "publication_state": state,
+        "published_at": now if state in PUBLIC_GALLERY_STATES else None,
+        "publication_history": [],
         "publishable": not placeholder,
         "quality_flags": quality_flags,
     }
@@ -191,6 +203,11 @@ def register_image(
         metadata=metadata,
         publication_state=state,
     )
+    if existing:
+        entry["published_at"] = existing.get("published_at") or (
+            existing.get("updated_at") if state in PUBLIC_GALLERY_STATES else None
+        )
+        entry["publication_history"] = list(existing.get("publication_history") or [])
     catalog["assets"][key] = entry
     save_catalog(output_dir, catalog)
     return entry
@@ -245,13 +262,19 @@ def backfill_catalog(
         if placeholder:
             state = existing.get("publication_state", "rejected") if existing else "rejected"
 
-        catalog["assets"][key] = build_catalog_entry(
+        refreshed_entry = build_catalog_entry(
             image_path,
             output_dir,
             prompt=prompt_for(image_path),
             metadata=metadata,
             publication_state=state,
         )
+        if existing:
+            refreshed_entry["published_at"] = existing.get("published_at") or (
+                existing.get("updated_at") if state in PUBLIC_GALLERY_STATES else None
+            )
+            refreshed_entry["publication_history"] = list(existing.get("publication_history") or [])
+        catalog["assets"][key] = refreshed_entry
         if existing:
             refreshed += 1
         else:
@@ -288,9 +311,23 @@ def set_publication_state(
     if placeholder and state in PUBLIC_GALLERY_STATES:
         raise PermissionError("Placeholder images cannot be published.")
 
+    previous_state = str(entry.get("publication_state", "draft"))
+    changed_at = utc_now()
     entry["publication_state"] = state
-    entry["updated_at"] = utc_now()
+    entry["updated_at"] = changed_at
+    history = list(entry.get("publication_history") or [])
+    if previous_state != state:
+        history.append({"from": previous_state, "to": state, "changed_at": changed_at})
+    entry["publication_history"] = history
+    if state in PUBLIC_GALLERY_STATES and previous_state not in PUBLIC_GALLERY_STATES:
+        entry["published_at"] = changed_at
+    elif state not in PUBLIC_GALLERY_STATES and previous_state in PUBLIC_GALLERY_STATES:
+        entry["unpublished_at"] = changed_at
     entry["publishable"] = not placeholder
+    if state in PUBLIC_GALLERY_STATES:
+        flags = set(entry.get("quality_flags", []))
+        flags.difference_update({"draft", "provisional"})
+        entry["quality_flags"] = sorted(flags)
     if placeholder:
         flags = set(entry.get("quality_flags", []))
         flags.add("placeholder")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,6 +72,11 @@ def test_status_endpoint(client):
     assert "status" in data
     assert "backend" in data
     assert data["status"] == "ready"
+    assert data["active_model"]
+    assert data["active_model_id"]
+    assert data["preferred_model"] == "Z-Image-Turbo"
+    assert data["preferred_model_status"] in {"ready", "partial", "not_downloaded"}
+    assert data["fallback_model"] == "Small Stable Diffusion"
     assert data["backend"] in [
         "mock",
         "smoke-test",
@@ -81,6 +86,7 @@ def test_status_endpoint(client):
         "flux-dev",
         "qwen-image",
         "ernie-image",
+        "z-image",
     ]
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,7 +74,7 @@ def test_status_endpoint(client):
     assert data["status"] == "ready"
     assert data["active_model"]
     assert data["active_model_id"]
-    assert data["preferred_model"] == "Z-Image-Turbo"
+    assert data["preferred_model"] == "Microsoft Mage-Flow"
     assert data["preferred_model_status"] in {"ready", "partial", "not_downloaded"}
     assert data["fallback_model"] == "Small Stable Diffusion"
     assert data["backend"] in [
@@ -87,6 +87,7 @@ def test_status_endpoint(client):
         "qwen-image",
         "ernie-image",
         "z-image",
+        "mage-flow",
     ]
 
 
@@ -100,13 +101,24 @@ def test_hf_token_status_ignores_placeholder_environment_value(client, monkeypat
     assert response.json() == {"configured": False, "source": None}
 
 
-def test_model_runtime_status_and_cleanup_endpoints(client):
+def test_model_runtime_status_and_cleanup_endpoints(client, monkeypatch):
+    class FakeUnloadResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"status":"ready","unloaded":true}'
+
     status = client.get("/api/models/status")
     assert status.status_code == 200
     payload = status.json()
     assert payload["configured_backend"]
     assert payload["resolved_backend"]
     assert {item["backend"] for item in payload["backends"]} >= {
+        "mageflow",
         "flux",
         "small",
         "turbo",
@@ -119,11 +131,38 @@ def test_model_runtime_status_and_cleanup_endpoints(client):
 
     recommended = client.get("/api/models/recommended")
     assert recommended.status_code == 200
-    assert recommended.json()["backend"] in {"zimage", "flux", "small"}
+    assert recommended.json()["backend"] in {"mageflow", "zimage", "flux", "small"}
 
+    monkeypatch.setattr(
+        "src.services.model_runtime.request.urlopen",
+        lambda *_args, **_kwargs: FakeUnloadResponse(),
+    )
     unloaded = client.post("/api/models/unload")
     assert unloaded.status_code == 200
-    assert unloaded.json()["message"] == "Runtime caches released"
+    assert unloaded.json()["message"] == "Runtime caches and Mage-Flow sidecar released"
+    assert unloaded.json()["mageflow"]["unloaded"] is True
+
+
+def test_model_download_route_accepts_encoded_hugging_face_repo_ids(client, monkeypatch):
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"status":"ready"}'
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+
+    response = client.post("/api/models/microsoft%2FMage-Flow/download")
+
+    assert response.status_code == 200
+    assert response.json()["model_id"] == "microsoft/Mage-Flow"
 
 
 def test_cors_allows_local_review_ports(client):
@@ -456,6 +495,8 @@ def test_generation_config_endpoint(client, monkeypatch):
         assert all("trigger_placement" in item for item in data["lora_metadata"])
     assert "lora_application_probability" in data
     assert "zimage_model_path" in data
+    assert data["mageflow_model"] == "microsoft/Mage-Flow"
+    assert data["mageflow_revision"] == "faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9"
     assert data["qwen_image_model"] == "diffusers/qwen-image-nf4"
     assert data["qwen_prompt_magic"] is True
     assert data["qwen_device_map"] == "balanced"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,6 +141,10 @@ def test_plugins_endpoint(client):
 
     data = response.json()
     assert isinstance(data, list)
+    assert any(
+        item["name"] == "dream_source_mixer" and item["category"] == "entropy" for item in data
+    )
+    assert any(item["name"] == "provenance_guard" and item["kind"] == "guard" for item in data)
 
 
 def test_generate_endpoint(client):
@@ -316,7 +320,7 @@ def test_api_job_and_catalog_persist_locked_lora_provenance(client, monkeypatch,
     backend = ApiZImageBackend()
     monkeypatch.setattr(
         "src.services.image_generation.resolve_generation_plan",
-        lambda config, plugins_enabled=True: plan,
+        lambda config, plugins_enabled=True, seed=None: plan,
     )
     monkeypatch.setattr(
         "src.services.image_generation.create_image_generator",
@@ -432,6 +436,7 @@ def test_generation_config_endpoint(client, monkeypatch):
 
     data = response.json()
     assert data["image_backend"] == "mock"
+    assert data["entropy_level"] in {"calm", "strange", "wild"}
     assert data["prompt_model"] == "llama3.2:3b"
     assert data["configured_prompt_model"] == "llama3.2:3b"
     assert data["image_model"] == "mock generator"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -84,6 +84,16 @@ def test_status_endpoint(client):
     ]
 
 
+def test_hf_token_status_ignores_placeholder_environment_value(client, monkeypatch, tmp_path):
+    """A template value must not make the authentication page report a token."""
+    monkeypatch.setenv("HF_TOKEN", "your_hugging_face_token_here")
+    monkeypatch.setenv("HF_HOME", str(tmp_path))
+    response = client.get("/api/config/hf-token-status")
+
+    assert response.status_code == 200
+    assert response.json() == {"configured": False, "source": None}
+
+
 def test_model_runtime_status_and_cleanup_endpoints(client):
     status = client.get("/api/models/status")
     assert status.status_code == 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,10 @@ import pytest
 from fastapi.testclient import TestClient
 from PIL import Image, ImageDraw
 
+from src.plugins.lora import SelectedLora
+from src.utils.generation_plan import GenerationPlan
 from src.utils.ollama import OllamaModelInfo
+from src.utils.plugin_manager import PluginResult
 from src.utils.publication_catalog import load_catalog
 from src.utils.storage import metadata_path_for, write_image_metadata
 
@@ -88,7 +91,13 @@ def test_model_runtime_status_and_cleanup_endpoints(client):
     assert payload["configured_backend"]
     assert payload["resolved_backend"]
     assert {item["backend"] for item in payload["backends"]} >= {
-        "flux", "small", "turbo", "zimage", "ollama", "smoke", "mock"
+        "flux",
+        "small",
+        "turbo",
+        "zimage",
+        "ollama",
+        "smoke",
+        "mock",
     }
     assert "system" in payload["memory"]
 
@@ -257,6 +266,86 @@ def test_generate_endpoint_records_durable_job(client):
     assert any(event["name"] == "generation_completed" for event in job["events"])
 
 
+def test_api_job_and_catalog_persist_locked_lora_provenance(client, monkeypatch, tmp_path):
+    """One resolved LoRA should survive API response, job state, and catalog persistence."""
+    lora_path = tmp_path / "loras" / "api-style" / "epoch-1.safetensors"
+    lora_path.parent.mkdir(parents=True)
+    lora_path.write_bytes(b"api locked lora")
+    plan = GenerationPlan(
+        plugin_results=(PluginResult("lora", "api-trigger", "API adapter"),),
+        plugin_descriptions=("lora: API adapter",),
+        enabled_plugins=("lora",),
+        temporal_descriptor="",
+        selected_lora=SelectedLora("api-style", lora_path, "api-trigger"),
+    )
+
+    class ApiZImageBackend:
+        def __init__(self):
+            self.plan = None
+            self.last_generation_metadata = {}
+
+        def set_generation_plan(self, received_plan):
+            self.plan = received_plan
+
+        async def generate_image(self, prompt, output_path, force_reinit=False, seed=None):
+            assert self.plan is plan
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            Image.new("RGB", (16, 16), color=(20, 50, 90)).save(output_path)
+            self.last_generation_metadata = {
+                "selected_lora": "api-style",
+                "selected_lora_path": str(lora_path.resolve()),
+                "selected_lora_keyword": "api-trigger",
+                "lora_backend": "diffsynth",
+                "seed": seed,
+            }
+            return output_path, 0.25, "Z-Image-Turbo"
+
+        def cleanup(self):
+            self.last_generation_metadata = {}
+
+    backend = ApiZImageBackend()
+    monkeypatch.setattr(
+        "src.services.image_generation.resolve_generation_plan",
+        lambda config, plugins_enabled=True: plan,
+    )
+    monkeypatch.setattr(
+        "src.services.image_generation.create_image_generator",
+        lambda config: (backend, "z-image"),
+    )
+
+    response = client.post(
+        "/api/generate",
+        json={"prompt": "A blue model lab with floating geometric instruments", "seed": 88},
+    )
+    assert response.status_code == 200
+    generation = response.json()
+    response_metadata = generation["metadata"]
+    provenance = response_metadata["lora_provenance"]
+    assert response_metadata["selected_lora"] == "api-style"
+    assert response_metadata["lora_backend"] == "diffsynth"
+    assert response_metadata["selected_lora_kind"] == "style"
+    assert generation["prompt"].endswith(", api-trigger")
+    assert "'api-trigger'" not in generation["prompt"]
+    assert provenance["path"] == str(lora_path.resolve())
+    assert provenance["kind"] == "style"
+    assert provenance["sha256"]
+
+    job_response = client.get(f"/api/jobs/{generation['id']}")
+    assert job_response.status_code == 200
+    job = job_response.json()
+    assert job["metadata"]["lora_provenance"] == provenance
+    plan_event = next(
+        event for event in job["events"] if event["name"] == "generation_plan_resolved"
+    )
+    assert plan_event["payload"]["selected_lora"]["name"] == "api-style"
+
+    catalog = load_catalog(Path(_TEST_OUTPUT_DIR))
+    relative_key = generation["image_path"].replace("/images/", "")
+    catalog_metadata = catalog["assets"][relative_key]["metadata"]
+    assert catalog_metadata["generation_plan"]["resolution"] == "once_per_job"
+    assert catalog_metadata["lora_provenance"] == provenance
+
+
 def test_jobs_endpoint_creates_and_lists_generation_job(client):
     """Durable job endpoints should create, run, fetch, and list jobs."""
     response = client.post(
@@ -340,6 +429,10 @@ def test_generation_config_endpoint(client, monkeypatch):
     assert data["pipeline"]["image"]["backend"] == "mock"
     assert isinstance(data["enabled_loras"], list)
     assert isinstance(data["available_loras"], list)
+    assert isinstance(data["lora_metadata"], list)
+    if data["lora_metadata"]:
+        assert {item["kind"] for item in data["lora_metadata"]} <= {"style", "object"}
+        assert all("trigger_placement" in item for item in data["lora_metadata"])
     assert "lora_application_probability" in data
     assert "zimage_model_path" in data
     assert data["qwen_image_model"] == "diffusers/qwen-image-nf4"

--- a/tests/test_cli_generation_progress.py
+++ b/tests/test_cli_generation_progress.py
@@ -16,6 +16,17 @@ from src.utils.publication_catalog import load_catalog
 runner = CliRunner()
 
 
+def test_generation_validation_accepts_resolved_mageflow():
+    """Auto may resolve to the already-supported Mage-Flow backend."""
+
+    class ValidConfig:
+        @staticmethod
+        def validate():
+            return []
+
+    assert cli.validate_generation_config(ValidConfig(), "mageflow") == []
+
+
 def test_generate_mock_prints_lifecycle_status(tmp_path, monkeypatch):
     """Mock generation should still expose the lifecycle messages users rely on."""
     monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))

--- a/tests/test_dream_source_mixer.py
+++ b/tests/test_dream_source_mixer.py
@@ -1,0 +1,32 @@
+"""Tests for bounded and reproducible Dream Source Mixer selection."""
+
+from src.plugins.dream_source_mixer import select_dream_source_mix
+
+
+def test_dream_source_mixer_is_deterministic_for_seed():
+    first = select_dream_source_mix(seed=42, entropy_level="strange")
+    second = select_dream_source_mix(seed=42, entropy_level="strange")
+
+    assert first == second
+    assert first.to_provenance()["category"] == "entropy"
+    assert first.to_provenance()["seed"] == 42
+    assert set(first.motifs) == {"place", "material", "light", "camera", "era", "mood"}
+
+
+def test_dream_source_mixer_exposes_calm_strange_wild_levels():
+    selections = [
+        select_dream_source_mix(seed=7, entropy_level=level)
+        for level in ("calm", "strange", "wild")
+    ]
+
+    assert [selection.level for selection in selections] == ["calm", "strange", "wild"]
+    assert all("dream fragment" in selection.prompt for selection in selections)
+
+
+def test_dream_source_mixer_rejects_unknown_level():
+    try:
+        select_dream_source_mix(seed=1, entropy_level="unknown")
+    except ValueError as exc:
+        assert "entropy_level" in str(exc)
+    else:
+        raise AssertionError("invalid entropy levels must fail closed")

--- a/tests/test_edit_jobs.py
+++ b/tests/test_edit_jobs.py
@@ -1,0 +1,30 @@
+from src.services.edit_jobs import SQLiteEditJobStore
+
+
+def test_edit_job_store_persists_lineage_and_lifecycle(tmp_path):
+    store = SQLiteEditJobStore(tmp_path / "edit-jobs.sqlite3")
+
+    created = store.create_job(
+        prompt="make the sky warmer",
+        strength=0.65,
+        backend="mock",
+        source_path="/images/source.png",
+        source_filename="source.png",
+        metadata={"operation": "edit"},
+    )
+    assert created["status"] == "queued"
+
+    store.start_job(created["id"])
+    store.complete_job(
+        created["id"],
+        original_path="/images/original.png",
+        edited_path="/images/edited.png",
+        metadata={"edit_job_id": created["id"], "role": "result"},
+    )
+
+    result = store.get_job(created["id"])
+    assert result is not None
+    assert result["status"] == "succeeded"
+    assert result["original_path"] == "/images/original.png"
+    assert result["edited_path"] == "/images/edited.png"
+    assert result["metadata"]["edit_job_id"] == created["id"]

--- a/tests/test_factory_imports.py
+++ b/tests/test_factory_imports.py
@@ -16,6 +16,12 @@ def make_config(image_backend: str = "small"):
     config.model.small_sd_model = "segmind/tiny-sd"
     config.model.smoke_test_model = "hf-internal-testing/tiny-stable-diffusion-torch"
     config.model.turbo_model = "stabilityai/sd-turbo"
+    config.model.mageflow_model = "microsoft/Mage-Flow"
+    config.model.mageflow_revision = "faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9"
+    config.model.mageflow_url = "http://localhost:25801"
+    config.model.mageflow_steps = 20
+    config.model.mageflow_cfg = 5.0
+    config.model.mageflow_timeout_seconds = 30
     config.model.zimage_model_path = Path("/tmp/fake_zimage_model")
     config.model.zimage_attention = "_sdpa"
     config.model.zimage_compile = False
@@ -138,3 +144,22 @@ def test_factory_imports_ernie_when_requested():
 
     assert generator.backend_name == "ernie"
     assert backend_name == "ernie-image"
+
+
+def test_auto_prefers_mageflow_only_when_runtime_is_ready(monkeypatch):
+    from src.generators import factory
+
+    config = make_config("auto")
+    monkeypatch.setattr(factory, "mageflow_runtime_ready", lambda *_args: True)
+
+    assert factory.resolve_image_backend(config) == "mageflow"
+
+
+def test_auto_safely_falls_back_when_mageflow_is_not_ready(monkeypatch):
+    from src.generators import factory
+
+    config = make_config("auto")
+    monkeypatch.setattr(factory, "mageflow_runtime_ready", lambda *_args: False)
+    monkeypatch.setattr(factory, "is_model_cached", lambda _model_id: False)
+
+    assert factory.resolve_image_backend(config) == "small"

--- a/tests/test_generation_plan.py
+++ b/tests/test_generation_plan.py
@@ -1,0 +1,63 @@
+"""Tests for immutable per-job plugin and LoRA resolution."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.plugins import plugin_manager
+from src.plugins.lora import SelectedLora
+from src.utils.generation_plan import resolve_generation_plan
+
+
+def test_generation_plan_resolves_lora_once_and_hashes_provenance(monkeypatch, tmp_path):
+    original_plugins = dict(plugin_manager.plugins)
+    lora_path = tmp_path / "loras" / "locked-style" / "epoch-1.safetensors"
+    lora_path.parent.mkdir(parents=True)
+    lora_path.write_bytes(b"locked lora weights")
+
+    config = MagicMock()
+    config.plugins.enabled_plugins = ["time_of_day", "lora"]
+    config.plugins.plugin_order = {"time_of_day": 1, "lora": 5}
+    config.model.lora.lora_dir = tmp_path / "loras"
+    config.model.lora.enabled_loras = ["locked-style"]
+    config.model.lora.application_probability = 1.0
+
+    selection_calls = 0
+
+    def select_once(_config):
+        nonlocal selection_calls
+        selection_calls += 1
+        return SelectedLora("locked-style", lora_path, "locked-trigger")
+
+    def unexpected_lora_plugin_call(_config):
+        raise AssertionError("the LoRA plugin was executed after its job-level override")
+
+    try:
+        plugin_manager.plugins.clear()
+        plugin_manager.register(
+            "time_of_day",
+            "time context",
+            lambda: "night",
+            enabled=True,
+            order=1,
+        )
+        monkeypatch.setattr("src.utils.generation_plan.select_random_lora", select_once)
+        monkeypatch.setattr("src.plugins.apply_lora", unexpected_lora_plugin_call)
+
+        plan = resolve_generation_plan(config)
+        metadata = plan.to_metadata(lora_backend="diffsynth")
+
+        assert selection_calls == 1
+        assert [result.value for result in plan.plugin_results] == ["night", "locked-trigger"]
+        assert plan.temporal_descriptor == "night"
+        assert plan.selected_lora == SelectedLora("locked-style", lora_path, "locked-trigger")
+        assert metadata["resolution"] == "once_per_job"
+        assert metadata["selected_lora"]["backend"] == "diffsynth"
+        assert metadata["selected_lora"]["kind"] == "style"
+        assert metadata["selected_lora"]["trigger_placement"] == "suffix"
+        assert metadata["selected_lora"]["trigger_required"] is True
+        assert metadata["selected_lora"]["display_name"] == "locked-style"
+        assert metadata["selected_lora"]["path"] == str(lora_path.resolve())
+        assert metadata["selected_lora"]["sha256"]
+    finally:
+        plugin_manager.plugins.clear()
+        plugin_manager.plugins.update(original_plugins)

--- a/tests/test_generation_plan.py
+++ b/tests/test_generation_plan.py
@@ -17,6 +17,7 @@ def test_generation_plan_resolves_lora_once_and_hashes_provenance(monkeypatch, t
     config = MagicMock()
     config.plugins.enabled_plugins = ["time_of_day", "lora"]
     config.plugins.plugin_order = {"time_of_day": 1, "lora": 5}
+    config.plugins.entropy_level = "strange"
     config.model.lora.lora_dir = tmp_path / "loras"
     config.model.lora.enabled_loras = ["locked-style"]
     config.model.lora.application_probability = 1.0
@@ -58,6 +59,38 @@ def test_generation_plan_resolves_lora_once_and_hashes_provenance(monkeypatch, t
         assert metadata["selected_lora"]["display_name"] == "locked-style"
         assert metadata["selected_lora"]["path"] == str(lora_path.resolve())
         assert metadata["selected_lora"]["sha256"]
+    finally:
+        plugin_manager.plugins.clear()
+        plugin_manager.plugins.update(original_plugins)
+
+
+def test_generation_plan_records_seeded_entropy_provenance(monkeypatch):
+    original_plugins = dict(plugin_manager.plugins)
+    config = MagicMock()
+    config.plugins.enabled_plugins = ["dream_source_mixer"]
+    config.plugins.plugin_order = {"dream_source_mixer": 1}
+    config.plugins.entropy_level = "wild"
+
+    try:
+        plugin_manager.plugins.clear()
+        from src.plugins.dream_source_mixer import get_dream_source_mixer
+
+        plugin_manager.register(
+            "dream_source_mixer",
+            "dream source",
+            get_dream_source_mixer,
+            enabled=True,
+            order=1,
+            category="entropy",
+        )
+        first = resolve_generation_plan(config, seed=123)
+        second = resolve_generation_plan(config, seed=123)
+
+        assert first.to_metadata() == second.to_metadata()
+        contribution = first.to_metadata()["plugin_contributions"][0]
+        assert contribution["category"] == "entropy"
+        assert contribution["provenance"]["seed"] == 123
+        assert contribution["provenance"]["level"] == "wild"
     finally:
         plugin_manager.plugins.clear()
         plugin_manager.plugins.update(original_plugins)

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -52,6 +52,16 @@ class ReusableBackend:
         self.calls += 1
         self.last_generation_metadata["force_reinit"] = force_reinit
         self.last_generation_metadata["seed"] = seed
+        self.last_generation_metadata.update(
+            {
+                "width": 512,
+                "height": 768,
+                "steps": 20,
+                "guidance_scale": 5.0,
+                "model_revision": "verified-model-revision",
+                "implementation_revision": "verified-source-revision",
+            }
+        )
         Image.new("RGB", (8, 8), color=(20, 40, 60)).save(output_path)
         return output_path, 0.25, "reusable-test-backend"
 
@@ -147,6 +157,19 @@ async def test_service_can_reuse_caller_owned_backend(mock_service_config, tmp_p
     assert result.metadata["backend_double"] is True
     assert result.metadata["force_reinit"] is True
     assert result.metadata["seed"] == 99
+    assert result.metadata["experiment"]["parameters"] == {
+        "seed": 99,
+        "width": 512,
+        "height": 768,
+        "steps": 20,
+        "guidance_scale": 5.0,
+        "true_cfg_scale": None,
+    }
+    assert result.metadata["experiment"]["pipeline"]["model_revision"] == "verified-model-revision"
+    assert (
+        result.metadata["experiment"]["pipeline"]["implementation_revision"]
+        == "verified-source-revision"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -217,7 +217,7 @@ async def test_service_shares_locked_lora_and_snapshots_metadata_before_cleanup(
 
     monkeypatch.setattr(
         "src.services.image_generation.resolve_generation_plan",
-        lambda config, plugins_enabled=True: plan,
+        lambda config, plugins_enabled=True, seed=None: plan,
     )
 
     async def generate_locked_prompt(self, meta_prompt=None):
@@ -281,6 +281,10 @@ async def test_service_shares_locked_lora_and_snapshots_metadata_before_cleanup(
     assert provenance["path"] == str(lora_path.resolve())
     assert provenance["sha256"]
     assert result.metadata["generation_plan"]["resolution"] == "once_per_job"
+    assert {guard["phase"] for guard in result.metadata["operational_guards"]} == {"pre", "post"}
+    assert all(
+        guard["category"] == "operational" for guard in result.metadata["operational_guards"]
+    )
     assert result.metadata["experiment"]["enhancers"]["selected_lora"] == provenance
 
     catalog = load_catalog(tmp_path)

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -6,7 +6,10 @@ from unittest.mock import MagicMock
 import pytest
 from PIL import Image
 
+from src.plugins.lora import SelectedLora
 from src.services import GenerationServiceRequest, ImageGenService
+from src.utils.generation_plan import GenerationPlan
+from src.utils.plugin_manager import PluginResult
 from src.utils.publication_catalog import load_catalog
 from src.utils.storage import read_image_metadata
 
@@ -18,6 +21,12 @@ def mock_service_config(tmp_path):
     config.model.image_backend = "mock"
     config.model.flux_model = "black-forest-labs/FLUX.1-schnell"
     config.model.small_sd_model = "segmind/tiny-sd"
+    config.model.ollama_model = "prompt-model"
+    config.model.lora.lora_dir = tmp_path / "loras"
+    config.model.lora.enabled_loras = []
+    config.model.lora.application_probability = 0.0
+    config.plugins.enabled_plugins = []
+    config.plugins.plugin_order = {}
     config.image.width = 64
     config.image.height = 64
     config.system.output_dir = tmp_path
@@ -104,6 +113,7 @@ async def test_service_emits_generation_lifecycle_events(mock_service_config, tm
     event_names = [event.name for event in events]
     assert event_names == [
         "generation_preparing",
+        "generation_plan_resolved",
         "prompt_ready",
         "backend_ready",
         "model_loading",
@@ -111,7 +121,7 @@ async def test_service_emits_generation_lifecycle_events(mock_service_config, tm
         "finalizing_output",
         "generation_completed",
     ]
-    assert events[4].payload["output_path"].suffix == ".png"
+    assert events[5].payload["output_path"].suffix == ".png"
     assert events[-1].payload["image_path"].startswith("/images/")
 
 
@@ -185,3 +195,96 @@ async def test_service_records_resolved_prompt_model(mock_service_config, tmp_pa
     assert experiment["prompt"]["source"] == "generated"
     assert experiment["prompt"]["model"] == "qwen3.5:9b"
     assert experiment["pipeline"]["prompt_model"] == "qwen3.5:9b"
+
+
+@pytest.mark.asyncio
+async def test_service_shares_locked_lora_and_snapshots_metadata_before_cleanup(
+    mock_service_config,
+    tmp_path,
+    monkeypatch,
+):
+    lora_path = tmp_path / "loras" / "locked-style" / "epoch-1.safetensors"
+    lora_path.parent.mkdir(parents=True)
+    lora_path.write_bytes(b"service locked lora")
+    selection = SelectedLora("locked-style", lora_path, "locked-trigger")
+    plan = GenerationPlan(
+        plugin_results=(PluginResult("lora", "locked-trigger", "locked adapter"),),
+        plugin_descriptions=("lora: locked adapter",),
+        enabled_plugins=("lora",),
+        temporal_descriptor="",
+        selected_lora=selection,
+    )
+
+    monkeypatch.setattr(
+        "src.services.image_generation.resolve_generation_plan",
+        lambda config, plugins_enabled=True: plan,
+    )
+
+    async def generate_locked_prompt(self, meta_prompt=None):
+        assert self.generation_plan is plan
+        assert meta_prompt == "draft with the locked style"
+        return "A moonlit local model lab filled with precise instruments"
+
+    monkeypatch.setattr(
+        "src.services.image_generation.PromptGenerator.generate_prompt",
+        generate_locked_prompt,
+    )
+
+    class CleanupClearingBackend:
+        def __init__(self):
+            self.plan = None
+            self.last_generation_metadata = {}
+            self.cleaned = False
+
+        def set_generation_plan(self, received_plan):
+            self.plan = received_plan
+
+        async def generate_image(self, prompt, output_path, force_reinit=False, seed=None):
+            assert self.plan is plan
+            assert "locked-trigger" in prompt
+            assert prompt.endswith(", locked-trigger")
+            assert "'locked-trigger'" not in prompt
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            Image.new("RGB", (8, 8), color=(40, 60, 80)).save(output_path)
+            self.last_generation_metadata = {
+                "selected_lora": "locked-style",
+                "selected_lora_path": str(lora_path.resolve()),
+                "selected_lora_keyword": "locked-trigger",
+                "lora_backend": "diffsynth",
+                "seed": seed,
+            }
+            return output_path, 0.5, "Z-Image-Turbo"
+
+        def cleanup(self):
+            self.cleaned = True
+            self.last_generation_metadata = {}
+
+    backend = CleanupClearingBackend()
+    service = ImageGenService(mock_service_config, output_dir=tmp_path)
+    result = await service.generate(
+        GenerationServiceRequest(
+            meta_prompt="draft with the locked style",
+            seed=17,
+            cleanup=True,
+        ),
+        backend=backend,
+        backend_name="z-image",
+    )
+
+    provenance = result.metadata["lora_provenance"]
+    assert backend.cleaned is True
+    assert result.metadata["selected_lora"] == "locked-style"
+    assert result.metadata["selected_lora_keyword"] == "locked-trigger"
+    assert result.metadata["selected_lora_kind"] == "style"
+    assert result.prompt.endswith(", locked-trigger")
+    assert result.metadata["lora_backend"] == "diffsynth"
+    assert provenance["path"] == str(lora_path.resolve())
+    assert provenance["sha256"]
+    assert result.metadata["generation_plan"]["resolution"] == "once_per_job"
+    assert result.metadata["experiment"]["enhancers"]["selected_lora"] == provenance
+
+    catalog = load_catalog(tmp_path)
+    relative_key = result.image_path.relative_to(tmp_path).as_posix()
+    catalog_metadata = catalog["assets"][relative_key]["metadata"]
+    assert catalog_metadata["selected_lora"] == "locked-style"
+    assert catalog_metadata["lora_provenance"] == provenance

--- a/tests/test_lora_metadata.py
+++ b/tests/test_lora_metadata.py
@@ -1,0 +1,119 @@
+"""LoRA prompt-role metadata and conditioning tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.generators.prompt_generator import PromptGenerator
+from src.plugins.lora import SelectedLora, condition_prompt_for_lora, get_lora_metadata
+from src.utils.generation_plan import GenerationPlan
+from src.utils.ollama import OllamaModelInfo
+from src.utils.plugin_manager import PluginResult
+
+
+def test_installed_lora_metadata_distinguishes_prompt_role():
+    pixel = get_lora_metadata("pxlstl")
+    assert pixel.kind == "style"
+    assert pixel.trigger == "pxlstl"
+    assert pixel.trigger_placement == "suffix"
+    assert pixel.trigger_required is True
+    assert pixel.base_model == "Tongyi-MAI/Z-Image-Turbo"
+    assert pixel.source == "https://huggingface.co/mks0813/z-image-turbo-pixel-art-lora"
+
+    drawings = get_lora_metadata("childrens drawings")
+    assert drawings.kind == "style"
+    assert drawings.trigger_required is False
+
+
+def test_style_and_object_loras_condition_prompts_differently(tmp_path):
+    weights = tmp_path / "adapter.safetensors"
+    style = SelectedLora("pixel", weights, "pxlstl", "style", "suffix", True)
+    object_lora = SelectedLora("robot", weights, "rb0tkn", "object", "subject", True)
+    no_trigger = SelectedLora("drawings", weights, "childrens drawings", "style", "suffix", False)
+
+    assert condition_prompt_for_lora("A fox beneath amber trees", style) == (
+        "A fox beneath amber trees, pxlstl"
+    )
+    assert condition_prompt_for_lora("A fox beneath amber trees.", style) == (
+        "A fox beneath amber trees, pxlstl"
+    )
+    assert condition_prompt_for_lora("A fox beneath amber trees, 'pxlstl'", style) == (
+        "A fox beneath amber trees, pxlstl"
+    )
+    repaired = condition_prompt_for_lora("A studio where 'pxlstl' paints stars", style)
+    assert repaired.endswith(", pxlstl")
+    assert repaired.lower().count("pxlstl") == 1
+    assert "'pxlstl'" not in repaired
+
+    assert condition_prompt_for_lora("A brass robot in a workshop", object_lora) == (
+        "rb0tkn, A brass robot in a workshop"
+    )
+    assert condition_prompt_for_lora("Portrait of 'rb0tkn' in a workshop", object_lora) == (
+        "Portrait of rb0tkn in a workshop"
+    )
+    assert condition_prompt_for_lora("Crayon animals on white paper", no_trigger) == (
+        "Crayon animals on white paper"
+    )
+
+
+@pytest.mark.asyncio
+async def test_style_trigger_is_hidden_from_ollama_and_appended_as_suffix(monkeypatch, tmp_path):
+    config = MagicMock()
+    config.model.ollama_model = "ornith:9b"
+    config.model.ollama_temperature = 0.7
+    weights = tmp_path / "pxlstl.safetensors"
+    selection = SelectedLora("pxlstl", weights, "pxlstl", "style", "suffix", True)
+    plan = GenerationPlan(
+        plugin_results=(
+            PluginResult("time_of_day", "afternoon", "time context"),
+            PluginResult("lora", "pxlstl", "pixel adapter"),
+        ),
+        plugin_descriptions=("time_of_day: time context", "lora: pixel adapter"),
+        enabled_plugins=("time_of_day", "lora"),
+        temporal_descriptor="afternoon",
+        selected_lora=selection,
+    )
+    captured_messages = []
+    fake_ollama = ModuleType("ollama")
+
+    def fake_chat(*, model, messages, options, keep_alive):
+        del model, options, keep_alive
+        captured_messages.extend(messages)
+        return SimpleNamespace(
+            message=SimpleNamespace(
+                content="Afternoon, a red fox watches fireflies above an amber forest"
+            )
+        )
+
+    fake_ollama.chat = fake_chat
+    monkeypatch.setitem(sys.modules, "ollama", fake_ollama)
+    monkeypatch.setattr(
+        "src.generators.prompt_generator.list_ollama_models",
+        lambda: [
+            OllamaModelInfo(
+                name="ornith:9b",
+                size=1,
+                modified="2026-07-16T00:00:00Z",
+                digest="digest",
+                format="gguf",
+                family="qwen",
+                capabilities=["completion"],
+                can_prompt=True,
+                can_vision=False,
+                can_image=False,
+            )
+        ],
+    )
+
+    prompt = await PromptGenerator(config, plan).generate_prompt()
+
+    messages_seen_by_ollama = "\n".join(message["content"] for message in captured_messages)
+    assert "pxlstl" not in messages_seen_by_ollama
+    assert "central subject" not in messages_seen_by_ollama
+    assert prompt == ("Afternoon, a red fox watches fireflies above an amber forest, pxlstl")
+    assert "'pxlstl'" not in prompt

--- a/tests/test_mageflow_generator.py
+++ b/tests/test_mageflow_generator.py
@@ -1,0 +1,125 @@
+"""Focused tests for the isolated Mage-Flow client and readiness contract."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+from types import SimpleNamespace
+
+from PIL import Image
+
+from src.generators.mageflow_image_generator import MageFlowImageGenerator
+from src.utils.mageflow_runtime import mageflow_runtime_ready, probe_mageflow_runtime
+
+
+class FakeResponse:
+    def __init__(self, body: bytes, headers: dict[str, str] | None = None):
+        self.body = body
+        self.headers = headers or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def config():
+    return SimpleNamespace(
+        model=SimpleNamespace(
+            mageflow_model="microsoft/Mage-Flow",
+            mageflow_revision="faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9",
+            mageflow_url="http://mageflow:8001",
+            mageflow_steps=20,
+            mageflow_cfg=5.0,
+            mageflow_timeout_seconds=30,
+        ),
+        image=SimpleNamespace(height=769, width=1361),
+    )
+
+
+def test_probe_requires_matching_ready_runtime(monkeypatch):
+    payload = json.dumps(
+        {
+            "status": "ready",
+            "model_id": "microsoft/Mage-Flow",
+            "model_revision": "faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9",
+            "loaded": False,
+        }
+    ).encode()
+    monkeypatch.setattr(
+        "src.utils.mageflow_runtime.request.urlopen",
+        lambda *_args, **_kwargs: FakeResponse(payload),
+    )
+
+    status = probe_mageflow_runtime("http://mageflow:8001")
+
+    assert status["ready"] is True
+    assert status["loaded"] is False
+    assert mageflow_runtime_ready("http://mageflow:8001", "microsoft/Mage-Flow") is True
+    assert (
+        mageflow_runtime_ready(
+            "http://mageflow:8001",
+            "microsoft/Mage-Flow",
+            "faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9",
+        )
+        is True
+    )
+    assert (
+        mageflow_runtime_ready(
+            "http://mageflow:8001",
+            "microsoft/Mage-Flow",
+            "different-revision",
+        )
+        is False
+    )
+    assert mageflow_runtime_ready("http://mageflow:8001", "microsoft/Mage-Flow-Turbo") is False
+
+
+def test_generator_sends_reproducible_request_and_saves_png(tmp_path, monkeypatch):
+    image_buffer = io.BytesIO()
+    Image.new("RGB", (16, 16), "navy").save(image_buffer, format="PNG")
+    observed = {}
+
+    def urlopen(http_request, timeout):
+        observed["url"] = http_request.full_url
+        observed["payload"] = json.loads(http_request.data)
+        observed["timeout"] = timeout
+        return FakeResponse(
+            image_buffer.getvalue(),
+            {
+                "X-DreamGen-Model-Revision": "faca09c18c1c",
+                "X-DreamGen-Source-SHA": "6cefeb40e4c8",
+            },
+        )
+
+    monkeypatch.setattr("src.generators.mageflow_image_generator.request.urlopen", urlopen)
+    generator = MageFlowImageGenerator(config())
+    output = tmp_path / "mage.png"
+
+    result = asyncio.run(generator.generate_image("A reproducible probe", output, seed=42))
+
+    assert result[0] == output
+    assert result[2] == "Mage-Flow"
+    assert Image.open(output).size == (16, 16)
+    assert observed["url"] == "http://mageflow:8001/generate"
+    assert observed["payload"] == {
+        "prompt": "A reproducible probe",
+        "model_id": "microsoft/Mage-Flow",
+        "height": 768,
+        "width": 1360,
+        "steps": 20,
+        "guidance_scale": 5.0,
+        "seed": 42,
+    }
+    assert generator.last_generation_metadata["isolated_runtime"] is True
+    assert generator.last_generation_metadata["model_revision"] == "faca09c18c1c"
+    assert (
+        generator.last_generation_metadata["verified_model_revision"]
+        == "faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9"
+    )
+    assert generator.last_generation_metadata["implementation_revision"] == "6cefeb40e4c8"

--- a/tests/test_mageflow_sidecar.py
+++ b/tests/test_mageflow_sidecar.py
@@ -1,0 +1,146 @@
+"""Contract tests for the isolated Mage-Flow HTTP adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import io
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from PIL import Image
+
+
+def load_sidecar_module():
+    module_path = Path(__file__).parents[1] / "mageflow-service" / "app.py"
+    spec = importlib.util.spec_from_file_location("dreamgen_mageflow_sidecar", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def sidecar():
+    return load_sidecar_module()
+
+
+def generation_request(sidecar, prompt: str = "A red apple on a wooden table"):
+    return sidecar.GenerateRequest(
+        prompt=prompt,
+        model_id=sidecar.MODEL_ID,
+        height=512,
+        width=512,
+        steps=20,
+        guidance_scale=5.0,
+        seed=42,
+    )
+
+
+def test_cached_snapshot_is_pinned_to_verified_revision(sidecar, monkeypatch):
+    observed = {}
+
+    def snapshot_download(**kwargs):
+        observed.update(kwargs)
+        return f"/models/snapshots/{sidecar.MODEL_REVISION}"
+
+    monkeypatch.setattr(sidecar, "snapshot_download", snapshot_download)
+
+    snapshot = sidecar._cached_snapshot()
+
+    assert snapshot == f"/models/snapshots/{sidecar.MODEL_REVISION}"
+    assert observed == {
+        "repo_id": "microsoft/Mage-Flow",
+        "revision": "faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9",
+        "local_files_only": True,
+    }
+
+
+def test_health_requires_checkpoint_cuda_vram_and_compiler(sidecar, monkeypatch):
+    snapshot = f"/models/snapshots/{sidecar.MODEL_REVISION}"
+    monkeypatch.setattr(sidecar, "_cached_snapshot", lambda: snapshot)
+    monkeypatch.setattr(
+        sidecar,
+        "_cuda_status",
+        lambda: {
+            "available": True,
+            "device": "Test GPU",
+            "total_gb": 24.0,
+            "sufficient": True,
+            "reason": None,
+        },
+    )
+    monkeypatch.setattr(sidecar.shutil, "which", lambda _name: "/usr/bin/cc")
+    sidecar._last_error = None
+    sidecar._downloading = False
+    sidecar._pipeline = None
+
+    payload = sidecar._health_payload()
+
+    assert payload["status"] == "ready"
+    assert payload["model_revision"] == sidecar.MODEL_REVISION
+    assert payload["verified_model_revision"] == sidecar.MODEL_REVISION
+    assert payload["compiler"] == "/usr/bin/cc"
+
+
+def test_policy_refusal_is_an_explicit_error_not_a_blank_png(sidecar, monkeypatch):
+    pipeline = SimpleNamespace(
+        model=SimpleNamespace(
+            txt_enc=SimpleNamespace(
+                screen_text=lambda _prompt: SimpleNamespace(
+                    violates=True,
+                    categories=["policy"],
+                    reason="blocked for test",
+                )
+            )
+        )
+    )
+    monkeypatch.setattr(sidecar, "_load_pipeline", lambda: pipeline)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(sidecar.generate(generation_request(sidecar)))
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail["reason"] == "blocked for test"
+
+
+def test_successful_generation_returns_png_and_pinned_provenance(sidecar, monkeypatch):
+    pipeline = SimpleNamespace(
+        model=SimpleNamespace(
+            txt_enc=SimpleNamespace(
+                screen_text=lambda _prompt: SimpleNamespace(
+                    violates=False,
+                    categories=[],
+                    reason="allowed",
+                )
+            )
+        ),
+        generate=lambda *_args, **_kwargs: [Image.new("RGB", (512, 512), "red")],
+    )
+    monkeypatch.setattr(sidecar, "_load_pipeline", lambda: pipeline)
+    monkeypatch.setattr(
+        sidecar,
+        "_cached_snapshot",
+        lambda: f"/models/snapshots/{sidecar.MODEL_REVISION}",
+    )
+
+    response = asyncio.run(sidecar.generate(generation_request(sidecar)))
+
+    assert response.media_type == "image/png"
+    assert response.headers["x-dreamgen-model-revision"] == sidecar.MODEL_REVISION
+    assert response.headers["x-dreamgen-source-sha"] == sidecar.SOURCE_SHA
+    assert Image.open(io.BytesIO(response.body)).size == (512, 512)
+
+
+def test_unload_releases_sidecar_pipeline(sidecar, monkeypatch):
+    sidecar._pipeline = object()
+    monkeypatch.setattr(sidecar.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(sidecar.torch.cuda, "is_initialized", lambda: False)
+    monkeypatch.setattr(sidecar.torch.cuda, "empty_cache", lambda: None)
+
+    payload = sidecar.unload()
+
+    assert payload == {"status": "ready", "unloaded": True, "was_loaded": True}
+    assert sidecar._pipeline is None

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -29,7 +29,13 @@ def test_runtime_status_resolves_auto_and_reports_all_required_backends(tmp_path
     assert payload["configured_backend"] == "auto"
     assert payload["resolved_backend"] == "small"
     assert {item["backend"] for item in payload["backends"]} >= {
-        "flux", "small", "turbo", "zimage", "ollama", "smoke", "mock"
+        "flux",
+        "small",
+        "turbo",
+        "zimage",
+        "ollama",
+        "smoke",
+        "mock",
     }
     assert "system" in payload["memory"]
     assert payload["recommended"]["backend"] in {"zimage", "flux", "small"}

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -12,6 +12,9 @@ def runtime_config(tmp_path):
             small_sd_model="vendor/small",
             turbo_model="vendor/turbo",
             smoke_test_model="vendor/smoke",
+            mageflow_model="microsoft/Mage-Flow",
+            mageflow_revision="faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9",
+            mageflow_url="http://mageflow.invalid",
             zimage_model_path=tmp_path / "zimage",
             ollama_model="prompt:latest",
             ollama_image_model="",
@@ -22,7 +25,18 @@ def runtime_config(tmp_path):
 
 def test_runtime_status_resolves_auto_and_reports_all_required_backends(tmp_path, monkeypatch):
     config = runtime_config(tmp_path)
-    monkeypatch.setattr("src.services.model_runtime.resolve_image_backend", lambda _config: "small")
+    monkeypatch.setattr(
+        "src.services.model_runtime.resolve_image_backend",
+        lambda _config, **_kwargs: "small",
+    )
+    monkeypatch.setattr(
+        "src.services.model_runtime.probe_mageflow_runtime",
+        lambda _url: {
+            "ready": False,
+            "status": "runtime_unavailable",
+            "reason": "test runtime absent",
+        },
+    )
     manager = ModelRuntimeManager(config, tmp_path / "selection.json")
 
     payload = manager.status()
@@ -30,6 +44,7 @@ def test_runtime_status_resolves_auto_and_reports_all_required_backends(tmp_path
     assert payload["configured_backend"] == "auto"
     assert payload["resolved_backend"] == "small"
     assert {item["backend"] for item in payload["backends"]} >= {
+        "mageflow",
         "flux",
         "small",
         "turbo",
@@ -39,7 +54,64 @@ def test_runtime_status_resolves_auto_and_reports_all_required_backends(tmp_path
         "mock",
     }
     assert "system" in payload["memory"]
-    assert payload["recommended"]["backend"] in {"zimage", "flux", "small"}
+    assert payload["recommended"]["backend"] in {"mageflow", "zimage", "flux", "small"}
+
+
+def test_runtime_requires_both_mageflow_checkpoint_and_sidecar(tmp_path, monkeypatch):
+    config = runtime_config(tmp_path)
+    manager = ModelRuntimeManager(config, tmp_path / "selection.json")
+    monkeypatch.setattr(
+        manager,
+        "_hf_model",
+        lambda _model_id: {
+            "status": "ready",
+            "size": 17_507_371_519,
+            "incomplete_files": 0,
+            "path": "cached",
+        },
+    )
+    monkeypatch.setattr(
+        "src.services.model_runtime.probe_mageflow_runtime",
+        lambda _url: {
+            "ready": False,
+            "status": "runtime_unavailable",
+            "reason": "sidecar unavailable",
+        },
+    )
+
+    status = manager._mageflow()
+
+    assert status["status"] == "runtime_unavailable"
+    assert status["reason"] == "sidecar unavailable"
+
+
+def test_runtime_rejects_unverified_mageflow_revision(tmp_path, monkeypatch):
+    config = runtime_config(tmp_path)
+    manager = ModelRuntimeManager(config, tmp_path / "selection.json")
+    monkeypatch.setattr(
+        manager,
+        "_hf_model",
+        lambda _model_id: {
+            "status": "ready",
+            "size": 17_507_371_519,
+            "incomplete_files": 0,
+            "path": "cached",
+        },
+    )
+    monkeypatch.setattr(
+        "src.services.model_runtime.probe_mageflow_runtime",
+        lambda _url: {
+            "ready": True,
+            "status": "ready",
+            "model_id": "microsoft/Mage-Flow",
+            "model_revision": "unverified",
+        },
+    )
+
+    status = manager._mageflow()
+
+    assert status["status"] == "revision_mismatch"
+    assert config.model.mageflow_revision in status["reason"]
 
 
 def test_runtime_detects_complete_local_zimage(tmp_path):
@@ -87,18 +159,29 @@ def test_unavailable_zimage_resolves_to_small_fallback(tmp_path, monkeypatch):
     assert resolve_image_backend(config) == "small"
 
 
-def test_runtime_status_explains_zimage_fallback(tmp_path, monkeypatch):
+def test_runtime_status_explains_mageflow_fallback(tmp_path, monkeypatch):
     config = runtime_config(tmp_path)
-    monkeypatch.setattr("src.services.model_runtime.resolve_image_backend", lambda _config: "small")
+    monkeypatch.setattr(
+        "src.services.model_runtime.resolve_image_backend",
+        lambda _config, **_kwargs: "small",
+    )
+    monkeypatch.setattr(
+        "src.services.model_runtime.probe_mageflow_runtime",
+        lambda _url: {
+            "ready": False,
+            "status": "runtime_unavailable",
+            "reason": "test runtime absent",
+        },
+    )
     manager = ModelRuntimeManager(config, tmp_path / "selection.json")
 
     payload = manager.status()
 
     assert payload["active_model"] == "Small Stable Diffusion"
     assert payload["active_model_id"] == "vendor/small"
-    assert payload["preferred_model"] == "Z-Image-Turbo"
+    assert payload["preferred_model"] == "Microsoft Mage-Flow"
     assert payload["preferred_model_status"] == "not_downloaded"
-    assert "Z-Image-Turbo unavailable" in payload["fallback_reason"]
+    assert "Mage-Flow unavailable" in payload["fallback_reason"]
 
 
 def test_runtime_selection_survives_restart(tmp_path):

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from src.generators.factory import resolve_image_backend
 from src.services.model_runtime import ModelRuntimeManager
 
 
@@ -58,6 +59,46 @@ def test_runtime_detects_complete_local_zimage(tmp_path):
     status = ModelRuntimeManager(config)._local_zimage()
     assert status["status"] == "ready"
     assert status["size"] > 0
+
+
+def test_auto_prefers_ready_local_zimage(tmp_path, monkeypatch):
+    config = runtime_config(tmp_path)
+    root = config.model.zimage_model_path
+    for relative in (
+        "model_index.json",
+        "tokenizer/tokenizer.json",
+        "vae/diffusion_pytorch_model.safetensors",
+        "transformer/model.safetensors",
+        "text_encoder/model.safetensors",
+    ):
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"ready")
+
+    monkeypatch.setattr("src.generators.factory.is_model_cached", lambda _model_id: False)
+    assert resolve_image_backend(config) == "zimage"
+
+
+def test_unavailable_zimage_resolves_to_small_fallback(tmp_path, monkeypatch):
+    config = runtime_config(tmp_path)
+    config.model.image_backend = "zimage"
+    monkeypatch.setattr("src.generators.factory.is_model_cached", lambda _model_id: False)
+
+    assert resolve_image_backend(config) == "small"
+
+
+def test_runtime_status_explains_zimage_fallback(tmp_path, monkeypatch):
+    config = runtime_config(tmp_path)
+    monkeypatch.setattr("src.services.model_runtime.resolve_image_backend", lambda _config: "small")
+    manager = ModelRuntimeManager(config, tmp_path / "selection.json")
+
+    payload = manager.status()
+
+    assert payload["active_model"] == "Small Stable Diffusion"
+    assert payload["active_model_id"] == "vendor/small"
+    assert payload["preferred_model"] == "Z-Image-Turbo"
+    assert payload["preferred_model_status"] == "not_downloaded"
+    assert "Z-Image-Turbo unavailable" in payload["fallback_reason"]
 
 
 def test_runtime_selection_survives_restart(tmp_path):

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,13 @@
+from src.utils.observability import read_lifecycle_events, write_lifecycle_event
+
+
+def test_lifecycle_events_are_written_and_read_in_reverse_chronological_order(tmp_path):
+    metrics_dir = tmp_path / "metrics"
+    write_lifecycle_event(metrics_dir, {"name": "generation_started", "id": "one"})
+    write_lifecycle_event(metrics_dir, {"name": "generation_completed", "id": "one"})
+
+    events = read_lifecycle_events(metrics_dir)
+    assert [event["name"] for event in events] == [
+        "generation_completed",
+        "generation_started",
+    ]

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from src.generators.ollama_image_generator import OllamaImageGenerator
 from src.generators.prompt_generator import PromptGenerator
+from src.utils.generation_plan import GenerationPlan
 from src.utils.ollama import OllamaModelInfo
 
 
@@ -67,16 +68,7 @@ async def test_prompt_generator_falls_back_to_available_completion_model(monkeyp
         "src.generators.prompt_generator.list_ollama_models",
         lambda: [_image_model("x/z-image-turbo:latest"), _completion_model("qwen3.6:27b")],
     )
-    monkeypatch.setattr(
-        "src.generators.prompt_generator.get_context_with_descriptions",
-        lambda: {"results": [], "descriptions": []},
-    )
-    monkeypatch.setattr(
-        "src.generators.prompt_generator.get_temporal_descriptor",
-        lambda: "afternoon",
-    )
-
-    generator = PromptGenerator(config)
+    generator = PromptGenerator(config, GenerationPlan((), (), (), "", None))
     prompt = await generator.generate_prompt()
 
     assert prompt == "sunlit alley, cinematic framing"

--- a/tests/test_provenance_guard.py
+++ b/tests/test_provenance_guard.py
@@ -1,0 +1,65 @@
+"""Tests for operational provenance checks."""
+
+from pathlib import Path
+
+from src.plugins.provenance_guard import provenance_guard_post, provenance_guard_pre
+from src.utils.plugin_manager import PluginManager
+
+
+def _plan():
+    return {
+        "resolution": "once_per_job",
+        "plugin_contributions": [
+            {"name": "dream_source_mixer", "category": "entropy", "provenance": {"seed": 4}}
+        ],
+    }
+
+
+def test_provenance_guard_pre_passes_structured_plan():
+    result = provenance_guard_pre({"generation_plan": _plan()})
+
+    assert result["status"] == "passed"
+    assert "plugin_contribution_provenance" in result["checks"]
+
+
+def test_provenance_guard_pre_fails_without_plan_provenance():
+    result = provenance_guard_pre(
+        {
+            "generation_plan": {
+                "resolution": "once_per_job",
+                "plugin_contributions": [{"name": "legacy", "category": "context"}],
+            }
+        }
+    )
+
+    assert result["status"] == "failed"
+    assert "plugin_contribution_provenance" in result["missing"]
+
+
+def test_provenance_guard_post_marks_missing_output_metadata(tmp_path):
+    result = provenance_guard_post(
+        {
+            "image_path": Path(tmp_path) / "missing.png",
+            "final_prompt": "a prompt",
+            "backend": "mock",
+            "model_name": "mock",
+            "generation_plan": _plan(),
+        }
+    )
+
+    assert result["status"] == "warning"
+    assert result["quality_flags"] == ["provenance_incomplete"]
+
+
+def test_operational_guards_are_not_prompt_contributions():
+    manager = PluginManager()
+    manager.register("context", "context", lambda: "context", category="context")
+    manager.register_guard(
+        "provenance_guard",
+        "guard",
+        pre_hook=lambda context: {"status": "passed"},
+    )
+
+    assert [result.name for result in manager.execute_plugins()] == ["context"]
+    assert manager.execute_guards("pre", {})[0]["category"] == "operational"
+    assert manager.registry_entries()[-1].kind == "guard"

--- a/tests/test_publish_gallery.py
+++ b/tests/test_publish_gallery.py
@@ -3,8 +3,13 @@ import json
 import pytest
 
 from scripts.publish_gallery import discover_assets
-from src.utils.gallery_publisher import build_publish_plan
-from src.utils.publication_catalog import backfill_catalog, set_publication_state
+from src.utils.gallery_publisher import build_publish_plan, build_release_manifest
+from src.utils.publication_catalog import (
+    backfill_catalog,
+    load_catalog,
+    save_catalog,
+    set_publication_state,
+)
 
 
 def test_discover_assets_skips_mock_placeholders_and_includes_prompt(tmp_path):
@@ -90,7 +95,13 @@ def test_build_publish_plan_reports_reasons_and_metadata_sidecar(tmp_path):
     image.write_bytes(b"png")
     image.with_suffix(".txt").write_text("prompt", encoding="utf-8")
     image.with_suffix(".meta.json").write_text(
-        json.dumps({"backend": "small-sd", "is_placeholder": False}),
+        json.dumps(
+            {
+                "backend": "small-sd",
+                "is_placeholder": False,
+                "quality_flags": ["nightly"],
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -114,3 +125,88 @@ def test_build_publish_plan_reports_reasons_and_metadata_sidecar(tmp_path):
         skipped.key.endswith("hidden.png") and skipped.reason == "state=hidden"
         for skipped in plan.skipped
     )
+
+
+def test_release_manifest_is_approved_ordered_versioned_and_rollback_safe(tmp_path):
+    output_dir = tmp_path / "output"
+    week_dir = output_dir / "2026" / "week_31"
+    week_dir.mkdir(parents=True)
+
+    older = week_dir / "image_20260731_120000_older.png"
+    newer = week_dir / "image_20260731_130000_newer.png"
+    draft = week_dir / "image_20260731_140000_draft.png"
+    older.write_bytes(b"older approved image")
+    newer.write_bytes(b"newer approved image")
+    draft.write_bytes(b"unapproved image")
+    for image in (older, newer, draft):
+        image.with_suffix(".txt").write_text(image.stem, encoding="utf-8")
+
+    backfill_catalog(output_dir, default_state="published")
+    set_publication_state(output_dir, draft.relative_to(output_dir).as_posix(), "draft")
+    catalog = load_catalog(output_dir)
+    catalog["assets"][older.relative_to(output_dir).as_posix()][
+        "created_at"
+    ] = "2026-07-31T12:00:00Z"
+    catalog["assets"][newer.relative_to(output_dir).as_posix()][
+        "created_at"
+    ] = "2026-07-31T13:00:00Z"
+    save_catalog(output_dir, catalog)
+
+    plan = build_publish_plan(output_dir, since=None, limit=None)
+    release = build_release_manifest(
+        output_dir,
+        plan,
+        published_at="2026-07-31T22:00:00Z",
+        previous_release={
+            "release_id": "previous-release",
+            "release_key": "_dreamgen/releases/previous-release.json",
+        },
+    )
+
+    assert [item["key"] for item in release.manifest["items"]] == [
+        "2026/week_31/image_20260731_130000_newer.png",
+        "2026/week_31/image_20260731_120000_older.png",
+    ]
+    assert release.manifest["leading_key"].endswith("newer.png")
+    assert release.manifest["image_count"] == 2
+    assert (
+        release.manifest["items"][0]["asset_version"]
+        != release.manifest["items"][1]["asset_version"]
+    )
+    assert release.manifest["items"][0]["caption_version"]
+    assert release.manifest["rollback"] == {
+        "previous_release_id": "previous-release",
+        "previous_release_key": "_dreamgen/releases/previous-release.json",
+    }
+    assert all("draft" not in item["key"] for item in release.manifest["items"])
+    assert release.release_key.startswith("_dreamgen/releases/20260731-")
+
+    repeated = build_release_manifest(
+        output_dir,
+        plan,
+        published_at="2026-07-31T22:00:00Z",
+        previous_release={"release_id": "previous-release"},
+    )
+    assert repeated.release_id == release.release_id
+
+
+def test_publication_state_records_approval_and_rollback_history(tmp_path):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    image = output_dir / "candidate.png"
+    image.write_bytes(b"creative candidate")
+    image.with_suffix(".meta.json").write_text(
+        json.dumps({"quality_flags": ["draft", "provisional", "nightly"]}),
+        encoding="utf-8",
+    )
+    backfill_catalog(output_dir, default_state="draft")
+
+    published = set_publication_state(output_dir, "candidate.png", "published")
+    hidden = set_publication_state(output_dir, "candidate.png", "hidden")
+
+    assert published["published_at"]
+    assert published["quality_flags"] == ["nightly"]
+    assert hidden["published_at"] == published["published_at"]
+    assert hidden["unpublished_at"]
+    assert hidden["publication_history"][-2]["to"] == "published"
+    assert hidden["publication_history"][-1]["to"] == "hidden"

--- a/tests/test_publish_gallery.py
+++ b/tests/test_publish_gallery.py
@@ -3,7 +3,13 @@ import json
 import pytest
 
 from scripts.publish_gallery import discover_assets
-from src.utils.gallery_publisher import build_publish_plan, build_release_manifest
+from src.utils import gallery_publisher
+from src.utils.gallery_publisher import (
+    PublishAsset,
+    PublishPlan,
+    build_publish_plan,
+    build_release_manifest,
+)
 from src.utils.publication_catalog import (
     backfill_catalog,
     load_catalog,
@@ -210,3 +216,66 @@ def test_publication_state_records_approval_and_rollback_history(tmp_path):
     assert hidden["unpublished_at"]
     assert hidden["publication_history"][-2]["to"] == "published"
     assert hidden["publication_history"][-1]["to"] == "hidden"
+
+
+def test_auto_transport_falls_back_to_wrangler_without_moving_pointer(tmp_path, monkeypatch):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    image = output_dir / "approved.png"
+    image.write_bytes(b"approved")
+    plan = PublishPlan(
+        assets=[PublishAsset(image, "approved.png", "state=published")],
+        skipped=[],
+        image_count=1,
+    )
+    events = []
+
+    monkeypatch.setattr(gallery_publisher, "build_publish_plan", lambda *args, **kwargs: plan)
+    monkeypatch.setattr(gallery_publisher, "print_plan", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gallery_publisher, "resolve_transport", lambda *args, **kwargs: "rclone")
+    monkeypatch.setattr(gallery_publisher, "validate_remote_environment", lambda *args: None)
+    monkeypatch.setattr(
+        gallery_publisher,
+        "load_previous_release",
+        lambda **kwargs: events.append(("load", kwargs["transport"])),
+    )
+    monkeypatch.setattr(
+        gallery_publisher,
+        "rclone_copy_assets",
+        lambda *args, **kwargs: (_ for _ in ()).throw(SystemExit("403")),
+    )
+    monkeypatch.setattr(
+        gallery_publisher,
+        "wrangler_put_assets",
+        lambda *args, **kwargs: events.append(("upload", kwargs["transfers"])),
+    )
+    release = gallery_publisher.PublishRelease(
+        {
+            "release_id": "release",
+            "release_key": "_dreamgen/releases/release.json",
+            "leading_key": "approved.png",
+            "rollback": {"previous_release_id": None},
+        }
+    )
+    monkeypatch.setattr(
+        gallery_publisher, "build_release_manifest", lambda *args, **kwargs: release
+    )
+    monkeypatch.setattr(
+        gallery_publisher,
+        "publish_release_manifests",
+        lambda *args, **kwargs: events.append(("manifest", kwargs["transport"])),
+    )
+
+    gallery_publisher.publish_gallery(
+        output_dir=output_dir,
+        execute=True,
+        transport="auto",
+        transfers=4,
+    )
+
+    assert events == [
+        ("load", "rclone"),
+        ("load", "wrangler"),
+        ("upload", 4),
+        ("manifest", "wrangler"),
+    ]

--- a/tests/test_zimage_generator.py
+++ b/tests/test_zimage_generator.py
@@ -9,6 +9,9 @@ import torch
 
 from src.generators.base_generator import GenerationResult
 from src.generators.zimage_generator import ZImageGenerator
+from src.plugins.lora import SelectedLora
+from src.utils.generation_plan import GenerationPlan
+from src.utils.plugin_manager import PluginResult
 
 
 @pytest.fixture
@@ -132,6 +135,32 @@ class TestZImageGeneratorWithMockZImage:
 
         mock_diffsynth.assert_called_once_with(None)
         mock_native.assert_not_called()
+
+    def test_load_model_uses_job_locked_lora_after_cleanup(self, mock_config, tmp_path):
+        lora_path = tmp_path / "locked-style" / "epoch-1.safetensors"
+        lora_path.parent.mkdir(parents=True)
+        lora_path.write_bytes(b"locked zimage lora")
+        plan = GenerationPlan(
+            plugin_results=(PluginResult("lora", "locked-trigger", "locked adapter"),),
+            plugin_descriptions=("lora: locked adapter",),
+            enabled_plugins=("lora",),
+            temporal_descriptor="locked-trigger",
+            selected_lora=SelectedLora("locked-style", lora_path, "locked-trigger"),
+        )
+
+        with patch("torch.cuda.is_available", return_value=False):
+            gen = ZImageGenerator(mock_config)
+        gen.set_generation_plan(plan)
+
+        with patch.object(gen, "_load_diffsynth_pipe") as mock_diffsynth:
+            with patch("src.generators.zimage_generator.plugin_manager.execute_plugins") as execute:
+                gen.load_model()
+
+        execute.assert_not_called()
+        mock_diffsynth.assert_called_once_with(lora_path.resolve())
+        assert gen.selected_lora_name == "locked-style"
+        assert gen.selected_lora_path == lora_path.resolve()
+        assert gen.selected_lora_keyword == "locked-trigger"
 
     def test_build_diffsynth_model_configs_expands_local_shards(self, mock_config, tmp_path):
         model_path = tmp_path / "Z-Image-Turbo"

--- a/tests/test_zimage_plugin_integration.py
+++ b/tests/test_zimage_plugin_integration.py
@@ -17,13 +17,23 @@ from src.plugins import (
 
 
 @pytest.fixture
-def mock_config():
+def mock_config(tmp_path):
     """Create a mock configuration for testing."""
     config = MagicMock()
     config.model.image_backend = "zimage"
     config.model.flux_model = "black-forest-labs/FLUX.1-schnell"
     config.model.small_sd_model = "segmind/tiny-sd"
-    config.model.zimage_model_path = Path("/tmp/fake_zimage_model")
+    config.model.zimage_model_path = tmp_path / "fake_zimage_model"
+    for relative in (
+        "model_index.json",
+        "tokenizer/tokenizer.json",
+        "vae/diffusion_pytorch_model.safetensors",
+        "transformer/model.safetensors",
+        "text_encoder/model.safetensors",
+    ):
+        checkpoint_file = config.model.zimage_model_path / relative
+        checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
+        checkpoint_file.write_bytes(b"ready")
     config.model.zimage_attention = "_sdpa"
     config.model.zimage_compile = False
     config.image.height = 1024
@@ -131,7 +141,7 @@ class TestZImagePromptEnhancement:
         with patch("torch.cuda.is_available", return_value=False):
             gen = ZImageGenerator(mock_config)
             # Verify generator can be created with bilingual prompt support
-            assert gen.model_path == Path("/tmp/fake_zimage_model")
+            assert gen.model_path == mock_config.model.zimage_model_path
 
             # These should all be valid prompts for Z-Image
             for prompt in prompts:
@@ -150,7 +160,7 @@ class TestZImageModelInfo:
 
             # Check required fields
             assert info["model_name"] == "Z-Image-Turbo"
-            assert info["model_path"] == str(Path("/tmp/fake_zimage_model"))
+            assert info["model_path"] == str(mock_config.model.zimage_model_path)
             assert info["parameters"] == "6B"
             assert info["architecture"] == "Single-Stream DiT (S3-DiT)"
             assert info["inference_steps"] == 8

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -854,7 +854,7 @@ export default function Home() {
               GPU {status?.gpu_available ? "online" : "offline"}
             </span>
             <span className="status-pill hidden md:inline-flex capitalize">
-              {status?.backend ?? "unknown"}
+              {status?.active_model ?? status?.backend ?? "unknown"}
             </span>
           </div>
         </div>

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -28,6 +28,7 @@ import QueueHistory from "@/components/QueueHistory";
 import Settings from "@/components/Settings";
 import AdvancedControls from "@/components/AdvancedControls";
 import MetaPromptModal from "@/components/MetaPromptModal";
+import ImageEditPanel, { type ImageEditTarget } from "@/components/ImageEditPanel";
 import TaskProgress from "@/components/TaskProgress";
 import {
   API_BASE,
@@ -36,6 +37,7 @@ import {
   GenerationJob,
   GenerateResponse,
   GenerationConfig,
+  GenerationMetricsResponse,
   PluginInfo,
   SystemStatus,
 } from "@/lib/api";
@@ -169,6 +171,7 @@ export default function Home() {
   const [experimentLabel, setExperimentLabel] = useState("");
   const [promptFamily, setPromptFamily] = useState("");
   const [qualityFlags, setQualityFlags] = useState("");
+  const [recipeId, setRecipeId] = useState<string | null>(null);
   const [promptError, setPromptError] = useState<string | null>(null);
   const [isGeneratingPrompt, setIsGeneratingPrompt] = useState(false);
   const [promptProgress, setPromptProgress] = useState<ProgressSnapshot | null>(null);
@@ -181,12 +184,14 @@ export default function Home() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [generationProgress, setGenerationProgress] = useState<ProgressSnapshot | null>(null);
   const [currentImage, setCurrentImage] = useState<GenerateResponse | null>(null);
+  const [editTarget, setEditTarget] = useState<ImageEditTarget | null>(null);
   const [recentImages, setRecentImages] = useState<RecentImage[]>([]);
   const [status, setStatus] = useState<SystemStatus | null>(null);
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
   const [generationConfig, setGenerationConfig] = useState<GenerationConfig | null>(null);
   const [generationEvents, setGenerationEvents] = useState<GenerationEvent[]>([]);
   const [generationJobs, setGenerationJobs] = useState<GenerationJob[]>([]);
+  const [generationMetrics, setGenerationMetrics] = useState<GenerationMetricsResponse | null>(null);
   const [isJobsLoading, setIsJobsLoading] = useState(false);
   const [nextRunAt, setNextRunAt] = useState<Date | null>(null);
   const [, setClockTick] = useState(Date.now());
@@ -377,6 +382,14 @@ export default function Home() {
     }
   }, []);
 
+  const loadGenerationMetrics = useCallback(async () => {
+    try {
+      setGenerationMetrics(await api.getGenerationMetrics());
+    } catch (error) {
+      console.error("Failed to load generation metrics:", error);
+    }
+  }, []);
+
   runGenerationRef.current = async (source: "manual" | "loop") => {
     if (isGeneratingRef.current) return;
 
@@ -411,6 +424,7 @@ export default function Home() {
         experiment_label: experimentLabelRef.current.trim() || undefined,
         prompt_family: promptFamilyRef.current.trim() || undefined,
         quality_flags: splitQualityFlags(qualityFlagsRef.current),
+        recipe_id: recipeId || undefined,
         client_request_id: clientRequestId,
       });
 
@@ -437,6 +451,7 @@ export default function Home() {
         loadDashboardControls(),
         loadGenerationEvents(),
         loadGenerationJobs(),
+        loadGenerationMetrics(),
         api.getStatus().then(setStatus),
       ]);
     } catch (error) {
@@ -528,6 +543,7 @@ export default function Home() {
     loadDashboardControls();
     loadGenerationEvents();
     loadGenerationJobs();
+    loadGenerationMetrics();
 
     const unsubscribe = api.subscribeWebSocket((data) => {
       const nextPromptProgress = getTaskProgressUpdate(
@@ -563,10 +579,12 @@ export default function Home() {
         addLog(`Saved ${String(msg.image_path ?? "image")}.`);
         void loadGenerationEvents();
         void loadGenerationJobs();
+        void loadGenerationMetrics();
       } else if (msg.type === "generation_error") {
         addLog(`Backend error: ${String(msg.error ?? "unknown")}`, "error");
         void loadGenerationEvents();
         void loadGenerationJobs();
+        void loadGenerationMetrics();
       }
     });
 
@@ -576,7 +594,7 @@ export default function Home() {
         clearTimeout(generationResetTimeoutRef.current);
       }
     };
-  }, [loadDashboardControls, loadGenerationEvents, loadGenerationJobs, loadRecentImages, refreshDashboardState]);
+  }, [loadDashboardControls, loadGenerationEvents, loadGenerationJobs, loadGenerationMetrics, loadRecentImages, refreshDashboardState]);
 
   useEffect(() => {
     const hasActiveJobs = generationJobs.some(
@@ -716,6 +734,54 @@ export default function Home() {
     addLog("Copied job prompt into the generator.");
   };
 
+  const branchJob = async (job: GenerationJob) => {
+    const request = job.request;
+    const metadata = job.metadata ?? {};
+    const experiment = (metadata.experiment ?? {}) as Record<string, unknown>;
+    const parameters = (experiment.parameters ?? {}) as Record<string, unknown>;
+    const enhancers = (experiment.enhancers ?? {}) as Record<string, unknown>;
+    const pipeline = (experiment.pipeline ?? {}) as Record<string, unknown>;
+    const prompt = job.prompt || request.prompt || "";
+    setPromptSeed(prompt);
+    promptSeedRef.current = prompt;
+    setMetaPrompt(request.meta_prompt ?? "");
+    setSeed(request.seed ?? (typeof parameters.seed === "number" ? parameters.seed : null));
+    setRecipeId(request.recipe_id ?? null);
+    setExperimentLabel(typeof metadata.experiment_label === "string" ? metadata.experiment_label : "");
+    setPromptFamily(typeof metadata.prompt_family === "string" ? metadata.prompt_family : "");
+    setQualityFlags(
+      Array.isArray(metadata.quality_flags) ? metadata.quality_flags.map(String).join(", ") : ""
+    );
+
+    const overrides = request.config_overrides ?? {};
+    const model = (overrides.model ?? {}) as Record<string, unknown>;
+    const image = (overrides.image ?? {}) as Record<string, unknown>;
+    const lora = (overrides.lora ?? {}) as Record<string, unknown>;
+    const configUpdates: Partial<GenerationConfig> = {
+      image_backend: typeof model.image_backend === "string"
+        ? model.image_backend
+        : typeof pipeline.configured_backend === "string" ? pipeline.configured_backend : undefined,
+      width: typeof image.width === "number" ? image.width : undefined,
+      height: typeof image.height === "number" ? image.height : undefined,
+      num_inference_steps: typeof image.num_inference_steps === "number" ? image.num_inference_steps : undefined,
+      guidance_scale: typeof image.guidance_scale === "number" ? image.guidance_scale : undefined,
+      true_cfg_scale: typeof image.true_cfg_scale === "number" ? image.true_cfg_scale : undefined,
+      enabled_loras: Array.isArray(lora.enabled_loras)
+        ? lora.enabled_loras.map(String)
+        : Array.isArray(enhancers.loras) ? enhancers.loras.map(String) : undefined,
+    };
+    const cleanUpdates = Object.fromEntries(Object.entries(configUpdates).filter(([, value]) => value !== undefined));
+    if (Object.keys(cleanUpdates).length > 0) {
+      try {
+        const response = await api.setGenerationConfig(cleanUpdates);
+        setGenerationConfig(response.config);
+      } catch (error) {
+        addLog(`Could not restore runtime settings: ${error instanceof Error ? error.message : "unknown error"}`, "error");
+      }
+    }
+    addLog(`Restored full settings from job ${job.id.slice(0, 8)}${request.recipe_id ? ` (${request.recipe_id})` : ""}.`);
+  };
+
   const copyProbeRecipe = async () => {
     try {
       await navigator.clipboard.writeText(JSON.stringify(probeRecipe, null, 2));
@@ -744,11 +810,12 @@ export default function Home() {
         quality_flags: Array.isArray(job.metadata.quality_flags)
           ? job.metadata.quality_flags.map(String)
           : undefined,
-        metadata: {
-          ...(job.request.metadata ?? {}),
-          rerun_of_job_id: job.id,
-        },
-      });
+          metadata: {
+            ...(job.request.metadata ?? {}),
+            rerun_of_job_id: job.id,
+          },
+          config_overrides: job.request.config_overrides ?? {},
+        });
       addLog(`Queued rerun ${queued.id.slice(0, 8)}.`);
       await loadGenerationJobs();
     } catch (error) {
@@ -1338,6 +1405,14 @@ export default function Home() {
                                   {currentImage.prompt}
                                 </p>
                               </div>
+                              <button
+                                type="button"
+                                onClick={() => setEditTarget({ imageUrl: `${API_BASE}${currentImage.image_path}`, sourcePath: currentImage.image_path, prompt: currentImage.prompt })}
+                                className="mt-3 inline-flex min-h-10 items-center justify-center gap-2 rounded-xl bg-violet-500 px-4 py-2 text-sm text-white transition hover:bg-violet-600"
+                              >
+                                <Wand2 className="h-4 w-4" />
+                                Edit / branch from this image
+                              </button>
                             </motion.div>
                           ) : (
                             <div className="flex h-full min-h-[320px] flex-col items-center justify-center text-center">
@@ -1471,15 +1546,41 @@ export default function Home() {
                             </div>
                           )}
                         </div>
+
+                        <div className="rounded-lg border border-border/60 bg-background/78 px-3 py-2">
+                          <div className="flex items-center justify-between gap-2">
+                            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Timing metrics</div>
+                            <span className="text-[11px] text-muted-foreground">
+                              {generationMetrics?.otel_enabled ? "OTel on" : "JSONL local"}
+                            </span>
+                          </div>
+                          {generationMetrics && generationMetrics.completed_generations > 0 ? (
+                            <div className="mt-2 space-y-2">
+                              {Object.entries(generationMetrics.phase_averages_ms).slice(0, 2).map(([backend, values]) => (
+                                <div key={backend} className="text-xs">
+                                  <div className="truncate font-medium text-foreground" title={backend}>{backend}</div>
+                                  <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-muted-foreground">
+                                    {Object.entries(values).filter(([key]) => key !== "runs").map(([phase, value]) => (
+                                      <span key={phase}>{phase} {value.toFixed(0)}ms</span>
+                                    ))}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          ) : (
+                            <div className="mt-2 text-xs leading-5 text-muted-foreground">No completed timing samples yet.</div>
+                          )}
+                        </div>
                       </div>
                     </div>
 
-                    <QueueHistory
+          <QueueHistory
                       jobs={generationJobs}
                       isLoading={isJobsLoading}
                       onRefresh={() => void loadGenerationJobs()}
-                      onCopyPrompt={copyJobPrompt}
-                      onRerun={(job) => void rerunJob(job)}
+            onCopyPrompt={copyJobPrompt}
+            onBranch={(job) => void branchJob(job)}
+            onRerun={(job) => void rerunJob(job)}
                     />
 
                     <div className="ambient-panel rounded-[1.75rem] border border-border/80 p-5">
@@ -1577,7 +1678,7 @@ export default function Home() {
               exit={{ opacity: 0, y: -8 }}
               className="h-full"
             >
-              <Gallery />
+              <Gallery onRequestEdit={setEditTarget} />
             </motion.div>
           )}
 
@@ -1608,6 +1709,28 @@ export default function Home() {
           </span>
         </div>
       </footer>
+      {editTarget && (
+        <ImageEditPanel
+          target={editTarget}
+          onClose={() => setEditTarget(null)}
+          onCompleted={(response) => {
+            setCurrentImage((current) => current ? {
+              ...current,
+              id: response.id,
+              prompt: response.prompt,
+              image_path: response.edited_path,
+              metadata: {
+                ...current.metadata,
+                ...response.metadata,
+                backend: String(response.metadata.backend ?? "edit"),
+                plugins_used: current.metadata.plugins_used ?? [],
+              },
+              created_at: response.created_at,
+            } : current);
+            void loadRecentImages();
+          }}
+        />
+      )}
       </div>
       </div>
       </div>

--- a/web-ui/components/Gallery.tsx
+++ b/web-ui/components/Gallery.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Trash2, Download, X, Loader2, Clock, FileText, Copy, Check,
   Calendar, Grid, ChevronLeft, ChevronRight, Folder, Star, Eye, EyeOff, Archive,
-  UploadCloud, ExternalLink, Info
+  UploadCloud, ExternalLink, Info, Search, Square, CheckSquare, Layers3, WandSparkles
 } from "lucide-react";
 import {
   api,
@@ -18,6 +18,7 @@ import {
 import { cn } from "@/lib/utils";
 import { motion, AnimatePresence } from "framer-motion";
 import galleryCache from "@/lib/cache";
+import type { ImageEditTarget } from "@/components/ImageEditPanel";
 
 interface GalleryImage {
   path: string;
@@ -81,6 +82,36 @@ const isPublicGalleryState = (state: PublicationState) => (
   state === "featured" || state === "published"
 );
 
+const getCloudSyncState = (image: GalleryImage) => {
+  const blocked = image.publication.quality_flags.length > 0;
+  const publicState = isPublicGalleryState(image.publication.state);
+
+  if (blocked) {
+    return {
+      label: "cloud blocked",
+      title: `Excluded from R2 sync: ${image.publication.quality_flags.join(", ")}`,
+      tone: "bg-rose-600 text-white",
+      icon: Archive,
+    };
+  }
+
+  if (publicState) {
+    return {
+      label: image.publication.state === "featured" ? "R2 featured" : "R2 published",
+      title: "Eligible for cloud sync and public gallery display",
+      tone: "bg-emerald-600 text-white",
+      icon: UploadCloud,
+    };
+  }
+
+  return {
+    label: "local only",
+    title: "Not published to R2",
+    tone: "bg-zinc-700 text-white",
+    icon: EyeOff,
+  };
+};
+
 const toGalleryImage = (entry: GalleryCatalogEntry): GalleryImage => ({
   path: entry.image_url || `/images/${entry.path}`,
   catalog_path: entry.path,
@@ -125,7 +156,11 @@ const withTimeout = async <T,>(
   })
 );
 
-export default function Gallery() {
+interface GalleryProps {
+  onRequestEdit?: (target: ImageEditTarget) => void;
+}
+
+export default function Gallery({ onRequestEdit }: GalleryProps) {
   const [images, setImages] = useState<GalleryImage[]>([]);
   const [weekGroups, setWeekGroups] = useState<WeekGroup[]>([]);
   const [loading, setLoading] = useState(true);
@@ -144,6 +179,10 @@ export default function Gallery() {
   const [modelFilter, setModelFilter] = useState("all");
   const [promptFamilyFilter, setPromptFamilyFilter] = useState("all");
   const [qualityFlagFilter, setQualityFlagFilter] = useState("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
+  const [bulkState, setBulkState] = useState<PublicationState>("published");
+  const [bulkUpdating, setBulkUpdating] = useState(false);
   const [facets, setFacets] = useState<GalleryFacets | null>(null);
   const [syncStatus, setSyncStatus] = useState<GallerySyncStatus | null>(null);
   const [copiedPromptPath, setCopiedPromptPath] = useState<string | null>(null);
@@ -215,6 +254,7 @@ export default function Gallery() {
       modelFilter,
       promptFamilyFilter,
       qualityFlagFilter,
+      searchQuery,
       page,
       limit,
     ].join("_");
@@ -230,6 +270,7 @@ export default function Gallery() {
           model: modelFilter === "all" ? undefined : modelFilter,
           prompt_family: promptFamilyFilter === "all" ? undefined : promptFamilyFilter,
           quality_flag: qualityFlagFilter === "all" ? undefined : qualityFlagFilter,
+          search: searchQuery.trim() || undefined,
         }),
         api.getGallerySyncStatus(10),
         api.getGalleryFacets(),
@@ -295,8 +336,13 @@ export default function Gallery() {
     page,
     promptFamilyFilter,
     qualityFlagFilter,
+    searchQuery,
     viewMode,
   ]);
+
+  useEffect(() => {
+    setSelectedPaths((current) => new Set([...current].filter((path) => images.some((image) => image.catalog_path === path))));
+  }, [images]);
 
   const getWeekNumber = (date: Date): number => {
     const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
@@ -441,6 +487,45 @@ export default function Gallery() {
       showActionMessage({ type: "error", text: message });
     } finally {
       setPublicationUpdating(null);
+    }
+  };
+
+  const toggleSelected = (imagePath: string, event: React.MouseEvent) => {
+    event.stopPropagation();
+    setSelectedPaths((current) => {
+      const next = new Set(current);
+      if (next.has(imagePath)) next.delete(imagePath);
+      else next.add(imagePath);
+      return next;
+    });
+  };
+
+  const toggleSelectAllVisible = () => {
+    setSelectedPaths((current) => {
+      const next = new Set(current);
+      const allSelected = images.length > 0 && images.every((image) => next.has(image.catalog_path));
+      images.forEach((image) => (allSelected ? next.delete(image.catalog_path) : next.add(image.catalog_path)));
+      return next;
+    });
+  };
+
+  const handleBulkPublicationChange = async () => {
+    const paths = [...selectedPaths];
+    if (paths.length === 0) return;
+    setBulkUpdating(true);
+    try {
+      const result = await api.bulkUpdatePublicationState(paths, bulkState);
+      setSelectedPaths(new Set());
+      await withTimeout(galleryCache.clear(), CACHE_TIMEOUT_MS, undefined);
+      await loadImages();
+      showActionMessage({
+        type: result.failures.length > 0 ? "error" : "success",
+        text: `${result.updated.length} image${result.updated.length === 1 ? "" : "s"} set to ${bulkState}${result.failures.length ? `; ${result.failures.length} blocked` : ""}.`,
+      });
+    } catch (err) {
+      showActionMessage({ type: "error", text: err instanceof Error ? err.message : "Bulk update failed" });
+    } finally {
+      setBulkUpdating(false);
     }
   };
 
@@ -600,6 +685,7 @@ export default function Gallery() {
 
   const selectedMetadataRows = selectedImage ? getMetadataRows(selectedImage) : [];
   const selectedExperimentRows = selectedImage ? getExperimentRows(selectedImage) : [];
+  const selectedCloudSyncState = selectedImage ? getCloudSyncState(selectedImage) : null;
 
   const renderStateBadge = (state: PublicationState, className?: string) => (
     <span
@@ -617,6 +703,8 @@ export default function Gallery() {
     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2 sm:gap-3 lg:gap-4">
       {images.map((image) => {
         const featuredBlocked = !image.publication.publishable;
+        const cloudSyncState = getCloudSyncState(image);
+        const CloudStateIcon = cloudSyncState.icon;
         return (
           <motion.div
             key={image.path}
@@ -633,16 +721,36 @@ export default function Gallery() {
             />
             <div className="absolute left-2 top-2 flex flex-col items-start gap-1">
               {renderStateBadge(image.publication.state, "shadow-sm")}
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 rounded px-2 py-0.5 text-[10px] shadow-sm",
+                  cloudSyncState.tone
+                )}
+                title={cloudSyncState.title}
+              >
+                <CloudStateIcon className="h-3 w-3" />
+                {cloudSyncState.label}
+              </span>
               {featuredBlocked && (
                 <span
                   className="inline-flex items-center gap-1 rounded bg-black/70 px-2 py-0.5 text-[10px] text-white shadow-sm"
                   title="Diagnostic placeholder images cannot be published or featured"
                 >
                   <Info className="h-3 w-3" />
-                  local only
+                  blocked
                 </span>
               )}
             </div>
+
+            <button
+              type="button"
+              onClick={(event) => toggleSelected(image.catalog_path, event)}
+              className="absolute right-2 top-2 z-10 rounded bg-black/65 p-1 text-white shadow-sm transition hover:bg-black/85"
+              aria-label={`${selectedPaths.has(image.catalog_path) ? "Deselect" : "Select"} ${image.catalog_path}`}
+              title={selectedPaths.has(image.catalog_path) ? "Deselect image" : "Select image"}
+            >
+              {selectedPaths.has(image.catalog_path) ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+            </button>
 
             <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
               <div className="absolute bottom-0 left-0 right-0 p-3">
@@ -661,8 +769,19 @@ export default function Gallery() {
                       <Trash2 className="w-3.5 h-3.5" />
                     )}
                   </button>
-                  <button
-                    onClick={(e) => handleDownload(image.path, image.prompt, e)}
+                    <button
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onRequestEdit?.({ imageUrl: image.path, sourcePath: image.catalog_path, prompt: image.prompt });
+                      }}
+                      className="p-1.5 rounded bg-violet-500/90 hover:bg-violet-500 text-white disabled:opacity-50"
+                      title="Edit image"
+                      aria-label={`Edit ${image.catalog_path}`}
+                    >
+                      <WandSparkles className="w-3.5 h-3.5" />
+                    </button>
+                    <button
+                      onClick={(e) => handleDownload(image.path, image.prompt, e)}
                     className="p-1.5 bg-primary/80 hover:bg-primary rounded text-primary-foreground"
                     title="Download image"
                     aria-label={`Download ${image.catalog_path}`}
@@ -761,6 +880,46 @@ export default function Gallery() {
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-2">
+              <div className="flex h-8 min-w-[220px] items-center gap-2 rounded-md border border-border bg-background px-2">
+                <Search className="h-3.5 w-3.5 text-muted-foreground" />
+                <input
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="Search prompt, LoRA, plugin..."
+                  className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                  aria-label="Search gallery metadata"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={toggleSelectAllVisible}
+                className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2 text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                title="Select all visible images"
+              >
+                <Layers3 className="h-3.5 w-3.5" />
+                {selectedPaths.size > 0 ? `${selectedPaths.size} selected` : "Select visible"}
+              </button>
+              {selectedPaths.size > 0 && (
+                <div className="flex h-8 items-center gap-1 rounded-md border border-primary/40 bg-primary/10 px-1">
+                  <select
+                    value={bulkState}
+                    onChange={(event) => setBulkState(event.target.value as PublicationState)}
+                    className="h-6 bg-transparent px-1 text-xs text-foreground outline-none"
+                    aria-label="Bulk publication state"
+                  >
+                    {PUBLICATION_OPTIONS.map((option) => <option key={option.state} value={option.state}>{option.label}</option>)}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() => void handleBulkPublicationChange()}
+                    disabled={bulkUpdating}
+                    className="inline-flex h-6 items-center gap-1 rounded bg-primary px-2 text-xs text-primary-foreground disabled:opacity-60"
+                  >
+                    {bulkUpdating && <Loader2 className="h-3 w-3 animate-spin" />}
+                    Apply
+                  </button>
+                </div>
+              )}
               <select
                 value={catalogFilter}
                 onChange={(event) => setCatalogFilter(event.target.value as CatalogFilter)}
@@ -1035,6 +1194,21 @@ export default function Gallery() {
               <div className="relative flex min-h-[45vh] items-center justify-center bg-black">
                 <div className="absolute left-3 top-3 z-10 flex items-center gap-2">
                   {renderStateBadge(selectedImage.publication.state, "shadow-sm")}
+                  {selectedCloudSyncState && (() => {
+                    const CloudStateIcon = selectedCloudSyncState.icon;
+                    return (
+                      <span
+                        className={cn(
+                          "inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] shadow-sm",
+                          selectedCloudSyncState.tone
+                        )}
+                        title={selectedCloudSyncState.title}
+                      >
+                        <CloudStateIcon className="h-3.5 w-3.5" />
+                        {selectedCloudSyncState.label}
+                      </span>
+                    );
+                  })()}
                   {selectedImageIndex >= 0 && (
                     <span className="rounded bg-black/65 px-2 py-1 text-xs text-white">
                       {selectedImageIndex + 1} / {images.length}
@@ -1132,6 +1306,10 @@ export default function Gallery() {
                           Diagnostic placeholder images are kept local and cannot be published or featured.
                         </p>
                       )}
+                      <div className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
+                        <UploadCloud className="h-3.5 w-3.5" />
+                        <span>{selectedCloudSyncState?.title || "Cloud sync status unavailable"}</span>
+                      </div>
                       <div className="flex flex-wrap gap-2">
                         {PUBLICATION_OPTIONS.map((option) => {
                           const Icon = option.icon;
@@ -1225,6 +1403,16 @@ export default function Gallery() {
                     >
                       <ExternalLink className="h-4 w-4" />
                       Open
+                    </button>
+                    <button
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onRequestEdit?.({ imageUrl: selectedImage.path, sourcePath: selectedImage.catalog_path, prompt: selectedImage.prompt });
+                      }}
+                      className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-violet-500 text-sm text-white transition hover:bg-violet-600"
+                    >
+                      <WandSparkles className="h-4 w-4" />
+                      Edit / branch
                     </button>
                     <button
                       onClick={(event) => handleDownload(selectedImage.path, selectedImage.prompt, event)}

--- a/web-ui/components/ImageEditPanel.tsx
+++ b/web-ui/components/ImageEditPanel.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { CheckCircle2, FileImage, Loader2, WandSparkles, X } from "lucide-react";
+
+import { API_BASE, api, type EditResponse } from "@/lib/api";
+
+export interface ImageEditTarget {
+  imageUrl: string;
+  sourcePath?: string;
+  prompt?: string;
+}
+
+interface ImageEditPanelProps {
+  target?: ImageEditTarget | null;
+  onClose: () => void;
+  onCompleted?: (response: EditResponse) => void;
+}
+
+export default function ImageEditPanel({ target, onClose, onCompleted }: ImageEditPanelProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [prompt, setPrompt] = useState(target?.prompt ? `Edit this image: ${target.prompt}` : "");
+  const [strength, setStrength] = useState(0.8);
+  const [backend, setBackend] = useState<"mock" | "auto">("mock");
+  const [previewUrl, setPreviewUrl] = useState(target?.imageUrl || "");
+  const [result, setResult] = useState<EditResponse | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPreviewUrl(target?.imageUrl || "");
+    setPrompt(target?.prompt ? `Edit this image: ${target.prompt}` : "");
+    setFile(null);
+    setResult(null);
+  }, [target]);
+
+  const sourceUrl = useMemo(() => {
+    if (file) return URL.createObjectURL(file);
+    if (!previewUrl) return "";
+    return previewUrl.startsWith("http") ? previewUrl : `${API_BASE}${previewUrl}`;
+  }, [file, previewUrl]);
+
+  useEffect(() => () => {
+    if (file && sourceUrl.startsWith("blob:")) URL.revokeObjectURL(sourceUrl);
+  }, [file, sourceUrl]);
+
+  const submit = async () => {
+    if (!prompt.trim()) {
+      setError("Add an instruction for the edit.");
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      let sourceFile = file;
+      if (!sourceFile && sourceUrl) {
+        const response = await fetch(sourceUrl);
+        if (!response.ok) throw new Error("Could not load the source image");
+        const blob = await response.blob();
+        sourceFile = new File([blob], "dreamgen-source.png", { type: blob.type || "image/png" });
+      }
+      if (!sourceFile) throw new Error("Choose an image or open an existing output first");
+      const editResponse = await api.editImage(sourceFile, {
+        prompt: prompt.trim(),
+        strength,
+        backend,
+        source_path: target?.sourcePath,
+      });
+      setResult(editResponse);
+      onCompleted?.(editResponse);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Image editing failed");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/75 p-4 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label="Edit image">
+      <div className="max-h-[92vh] w-full max-w-4xl overflow-y-auto rounded-2xl border border-border bg-background shadow-2xl">
+        <div className="flex items-start justify-between gap-4 border-b border-border p-5">
+          <div>
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-primary"><WandSparkles className="h-4 w-4" /> Creative edit</div>
+            <h2 className="mt-1 text-xl font-semibold text-foreground">Branch from an image</h2>
+            <p className="mt-1 text-sm text-muted-foreground">The source, instruction, backend, and result stay linked in a durable edit job.</p>
+          </div>
+          <button type="button" onClick={onClose} className="rounded-lg border border-border p-2 text-muted-foreground hover:bg-muted" aria-label="Close edit panel"><X className="h-4 w-4" /></button>
+        </div>
+
+        <div className="grid gap-5 p-5 lg:grid-cols-[1fr_1.1fr]">
+          <div className="space-y-4">
+            <div className="overflow-hidden rounded-xl border border-border bg-black/70">
+              {sourceUrl ? <img src={sourceUrl} alt="Edit source" className="max-h-[360px] w-full object-contain" /> : <div className="flex h-64 items-center justify-center text-muted-foreground"><FileImage className="h-10 w-10" /></div>}
+            </div>
+            <label className="block rounded-xl border border-dashed border-border p-4 text-sm text-muted-foreground hover:border-primary/50">
+              <span className="font-medium text-foreground">Upload another source</span>
+              <input type="file" accept="image/*" className="mt-2 block w-full text-xs" onChange={(event) => setFile(event.target.files?.[0] ?? null)} />
+            </label>
+          </div>
+
+          <div className="space-y-4">
+            <label className="block text-sm font-medium text-foreground">Instruction
+              <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} rows={5} placeholder="Add a warm neon sign and preserve the composition" className="mt-2 w-full rounded-xl border border-input bg-background px-3 py-3 text-sm leading-6 outline-none focus:border-primary" />
+            </label>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="text-sm text-foreground">Backend
+                <select value={backend} onChange={(event) => setBackend(event.target.value as "mock" | "auto")} className="mt-2 h-10 w-full rounded-lg border border-input bg-background px-3 text-sm">
+                  <option value="mock">Mock / deterministic</option>
+                  <option value="auto">Configured local editor</option>
+                </select>
+              </label>
+              <label className="text-sm text-foreground">Strength <span className="text-muted-foreground">{strength.toFixed(2)}</span>
+                <input type="range" min="0" max="1" step="0.05" value={strength} onChange={(event) => setStrength(Number(event.target.value))} className="mt-4 w-full" />
+              </label>
+            </div>
+            {error && <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive" role="alert">{error}</div>}
+            <button type="button" onClick={() => void submit()} disabled={isSubmitting} className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl bg-primary px-4 py-3 text-sm font-medium text-primary-foreground disabled:opacity-60">
+              {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />}
+              {isSubmitting ? "Editing..." : "Create linked edit"}
+            </button>
+
+            {result && (
+              <div className="rounded-xl border border-emerald-400/35 bg-emerald-400/10 p-4" role="status">
+                <div className="flex items-center gap-2 text-sm font-medium text-emerald-200"><CheckCircle2 className="h-4 w-4" /> Edit completed</div>
+                <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                  <span>Job {result.metadata.job_id ? String(result.metadata.job_id).slice(0, 12) : result.id.slice(0, 12)}</span>
+                  <span>{String(result.metadata.backend ?? "editor")}</span>
+                </div>
+                <img src={`${API_BASE}${result.edited_path}`} alt="Edited result" className="mt-3 max-h-56 w-full rounded-lg object-contain" />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/components/QueueHistory.tsx
+++ b/web-ui/components/QueueHistory.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Clock3, Copy, Play, RefreshCcw, RotateCcw, XCircle } from "lucide-react";
+import { Clock3, Copy, Play, RefreshCcw, RotateCcw, Settings2, XCircle } from "lucide-react";
 
 import { API_BASE, type GenerationJob } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -10,6 +10,7 @@ interface QueueHistoryProps {
   isLoading?: boolean;
   onRefresh: () => void;
   onCopyPrompt: (prompt: string) => void;
+  onBranch: (job: GenerationJob) => void;
   onRerun: (job: GenerationJob) => void;
 }
 
@@ -33,11 +34,17 @@ const jobPrompt = (job: GenerationJob) => job.prompt || job.request.prompt || ""
 const truncate = (value: string, max = 86) =>
   value.length > max ? `${value.slice(0, max).trim()}...` : value;
 
+const formatDuration = (seconds?: number | null) => {
+  if (seconds === null || seconds === undefined) return "timing pending";
+  return seconds < 60 ? `${seconds.toFixed(2)}s` : `${Math.floor(seconds / 60)}m ${(seconds % 60).toFixed(0)}s`;
+};
+
 export default function QueueHistory({
   jobs,
   isLoading = false,
   onRefresh,
   onCopyPrompt,
+  onBranch,
   onRerun,
 }: QueueHistoryProps) {
   const activeJobs = jobs.filter(isActiveJob);
@@ -146,6 +153,8 @@ export default function QueueHistory({
                       </p>
                       <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
                         <span>{job.backend ?? "backend pending"}</span>
+                        <span>{job.model_name ?? "model pending"}</span>
+                        <span>{formatDuration(job.generation_time)}</span>
                         {job.request.seed !== null && job.request.seed !== undefined ? (
                           <span>seed {job.request.seed}</span>
                         ) : null}
@@ -154,7 +163,14 @@ export default function QueueHistory({
                     </div>
                   </div>
 
-                  <div className="mt-3 grid grid-cols-2 gap-2">
+                  <div className="mt-3 grid grid-cols-3 gap-2">
+                    <button
+                      onClick={() => onBranch(job)}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl border border-border/70 px-3 py-2 text-xs text-muted-foreground transition hover:border-primary/40 hover:text-foreground"
+                    >
+                      <Settings2 className="h-3.5 w-3.5" />
+                      Branch settings
+                    </button>
                     <button
                       onClick={() => onCopyPrompt(prompt)}
                       disabled={!prompt}

--- a/web-ui/components/Settings.tsx
+++ b/web-ui/components/Settings.tsx
@@ -75,6 +75,11 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
   }, [onRuntimeChange]);
 
   useEffect(() => {
+    // Older builds briefly mirrored the HF token into browser storage. Remove
+    // that stale copy and keep the browser out of credential persistence.
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem("hf_token");
+    }
     loadModelStatus();
     loadGenerationConfig();
     loadHFTokenStatus();
@@ -264,10 +269,7 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
     setIsSubmitting(true);
     try {
       await api.setHFToken(hfToken.trim());
-      setMessage({ type: 'success', text: 'HuggingFace token saved successfully!' });
-
-      // Store in localStorage as well (like agenticinsights.com pattern)
-      localStorage.setItem('hf_token', hfToken.trim());
+      setMessage({ type: 'success', text: 'Hugging Face token saved to the local backend.' });
 
       setHFToken("");
       await loadHFTokenStatus();
@@ -1185,8 +1187,9 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                     </div>
 
                     <p className="text-sm text-muted-foreground mb-4">
-                      Optional for the tiny public fallback model. Still useful for gated or private
-                      model downloads and for avoiding rate limits.
+                      Optional for public fallback models. Useful for gated or private model downloads
+                      and for avoiding rate limits. The token is sent to this local backend, stored in
+                      its configured Hugging Face cache, and is never persisted in the browser.
                       Get your token from{" "}
                       <a
                         href="https://huggingface.co/settings/tokens"
@@ -1233,6 +1236,27 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                         )}
                       </button>
                     </form>
+                  </div>
+
+                  <div className="border border-border rounded-lg p-4 bg-muted/20">
+                    <div className="flex items-center gap-2 mb-3">
+                      <AlertCircle className="w-5 h-5 text-primary" />
+                      <h4 className="text-lg font-medium">Cloudflare deployment</h4>
+                      <span className="text-xs rounded-full bg-muted px-2 py-0.5 text-muted-foreground">
+                        Explicit setup only
+                      </span>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      DreamGen does not implement Cloudflare OAuth, account linking, or automatic
+                      Worker provisioning from this page. Nothing is deployed or authorized here.
+                      Deploy your own Workers or Pages project explicitly with Wrangler or the
+                      repository workflow after reviewing the requested account and R2 scopes.
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-3">
+                      Keep Cloudflare credentials in your deployment environment; do not enter them
+                      into DreamGen or commit them to the repository. This local API is an operator
+                      surface, not a customer-account login gateway.
+                    </p>
                   </div>
                 </div>
               </div>

--- a/web-ui/components/Settings.tsx
+++ b/web-ui/components/Settings.tsx
@@ -236,13 +236,14 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
   };
 
   const movePlugin = async (pluginName: string, direction: 'up' | 'down') => {
-    const currentIndex = plugins.findIndex((plugin) => plugin.name === pluginName);
+    const orderedPlugins = plugins.filter((plugin) => plugin.kind !== 'guard');
+    const currentIndex = orderedPlugins.findIndex((plugin) => plugin.name === pluginName);
     if (currentIndex === -1) return;
 
     const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
-    if (targetIndex < 0 || targetIndex >= plugins.length) return;
+    if (targetIndex < 0 || targetIndex >= orderedPlugins.length) return;
 
-    const nextPlugins = [...plugins];
+    const nextPlugins = [...orderedPlugins];
     const [movedPlugin] = nextPlugins.splice(currentIndex, 1);
     nextPlugins.splice(targetIndex, 0, movedPlugin);
 
@@ -366,6 +367,7 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
   };
 
   const loraPluginEnabled = plugins.some((plugin) => plugin.name === "lora" && plugin.enabled);
+  const entropyLevel = generationConfig?.entropy_level ?? "strange";
   const selectedBackend = generationConfig?.image_backend ?? "auto";
   const availableLoras = generationConfig?.available_loras ?? [];
   const enabledLoras = generationConfig?.enabled_loras ?? [];
@@ -1124,6 +1126,14 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                           <div className="flex items-center gap-2">
                             <h4 className="font-medium">{plugin.name}</h4>
                             <span className="text-xs px-2 py-0.5 bg-muted text-muted-foreground rounded-full">
+                              {plugin.category ?? "context"}
+                            </span>
+                            {plugin.kind === "guard" && (
+                              <span className="text-xs px-2 py-0.5 bg-amber-500/10 text-amber-600 rounded-full">
+                                hook
+                              </span>
+                            )}
+                            <span className="text-xs px-2 py-0.5 bg-muted text-muted-foreground rounded-full">
                               #{plugin.order}
                             </span>
                           </div>
@@ -1133,6 +1143,23 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                         </div>
 
                         <div className="flex flex-col gap-2 shrink-0">
+                          {plugin.name === "dream_source_mixer" && (
+                            <select
+                              value={entropyLevel}
+                              onChange={(event) =>
+                                updateGenerationConfig({
+                                  entropy_level: event.target.value as "calm" | "strange" | "wild",
+                                })
+                              }
+                              className="rounded border border-border bg-background px-2 py-1 text-xs"
+                              aria-label="Dream Source Mixer entropy level"
+                            >
+                              <option value="calm">calm</option>
+                              <option value="strange">strange</option>
+                              <option value="wild">wild</option>
+                            </select>
+                          )}
+                          {plugin.kind !== "guard" && <>
                           <button
                             type="button"
                             onClick={() => movePlugin(plugin.name, 'up')}
@@ -1151,6 +1178,7 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                           >
                             <ArrowDown className="w-4 h-4" />
                           </button>
+                          </>}
                         </div>
                       </div>
                     ))}

--- a/web-ui/components/Settings.tsx
+++ b/web-ui/components/Settings.tsx
@@ -57,6 +57,7 @@ const IMAGE_BACKEND_OPTIONS = [
 export default function Settings({ systemStatus, onRuntimeChange }: SettingsProps) {
   const [activeSection, setActiveSection] = useState("models");
   const [modelStatus, setModelStatus] = useState<ModelStatus | null>(null);
+  const [modelStatusError, setModelStatusError] = useState(false);
   const [generationConfig, setGenerationConfig] = useState<GenerationConfig | null>(null);
   const [loadingGenerationConfig, setLoadingGenerationConfig] = useState(false);
   const [hfTokenStatus, setHFTokenStatus] = useState<HFTokenStatus | null>(null);
@@ -69,6 +70,7 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
   const [loadingOllama, setLoadingOllama] = useState(false);
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
   const [loadingPlugins, setLoadingPlugins] = useState(false);
+  const [pluginsError, setPluginsError] = useState(false);
 
   const notifyRuntimeChange = useCallback(async () => {
     await onRuntimeChange?.();
@@ -114,11 +116,13 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
   }, []);
 
   const loadModelStatus = async () => {
+    setModelStatusError(false);
     try {
       const status = await api.getModelStatus();
       setModelStatus(status);
     } catch (error) {
       console.error('Failed to load model status:', error);
+      setModelStatusError(true);
     }
   };
 
@@ -159,11 +163,13 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
 
   const loadPlugins = async () => {
     setLoadingPlugins(true);
+    setPluginsError(false);
     try {
       const pluginList = await api.getPlugins();
       setPlugins(pluginList);
     } catch (error) {
       console.error('Failed to load plugins:', error);
+      setPluginsError(true);
       setMessage({ type: 'error', text: 'Failed to load plugins' });
     } finally {
       setLoadingPlugins(false);
@@ -367,6 +373,11 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
   };
 
   const loraPluginEnabled = plugins.some((plugin) => plugin.name === "lora" && plugin.enabled);
+  const enabledPromptPlugins = plugins.filter((plugin) => plugin.enabled && plugin.kind !== "guard");
+  const enabledGuardPlugins = plugins.filter((plugin) => plugin.enabled && plugin.kind === "guard");
+  const activeRuntimeModel = modelStatus?.models.find(
+    (model) => model.backend === modelStatus.resolved_backend && model.status === "ready"
+  );
   const entropyLevel = generationConfig?.entropy_level ?? "strange";
   const selectedBackend = generationConfig?.image_backend ?? "auto";
   const availableLoras = generationConfig?.available_loras ?? [];
@@ -1300,76 +1311,97 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
               exit={{ opacity: 0, y: -10 }}
               className="p-4 sm:p-6 lg:p-8"
             >
-              <div className="max-w-2xl">
-                <h3 className="text-xl font-semibold mb-6">System Information</h3>
+              <div className="max-w-3xl">
+                <h3 className="text-xl font-semibold">System Information</h3>
+                <p className="text-sm text-muted-foreground mt-1 mb-6">
+                  Live readiness, runtime, resource, and plugin guard state from the backend.
+                </p>
 
-                {systemStatus && (
-                  <div className="space-y-4">
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                      <div className="border border-border rounded-lg p-4">
-                        <div className="flex items-center gap-2 mb-2">
-                          <Server className="w-4 h-4 text-muted-foreground" />
-                          <span className="text-sm font-medium">API Status</span>
-                        </div>
-                        <div className={cn(
-                          "text-lg font-semibold",
-                          systemStatus.status === 'ready' ? 'text-green-500' : 'text-orange-500'
-                        )}>
-                          {systemStatus.status === 'ready' ? 'Ready' : 'Not Ready'}
-                        </div>
-                      </div>
-
-                      <div className="border border-border rounded-lg p-4">
-                        <div className="flex items-center gap-2 mb-2">
-                          <Cpu className="w-4 h-4 text-muted-foreground" />
-                          <span className="text-sm font-medium">GPU</span>
-                        </div>
-                        <div className={cn(
-                          "text-lg font-semibold",
-                          systemStatus.gpu_available ? 'text-green-500' : 'text-orange-500'
-                        )}>
-                          {systemStatus.gpu_available ? 'Available' : 'Not Available'}
-                        </div>
-                      </div>
-
-                      <div className="border border-border rounded-lg p-4">
-                        <div className="flex items-center gap-2 mb-2">
-                          <Database className="w-4 h-4 text-muted-foreground" />
-                          <span className="text-sm font-medium">Backend</span>
-                        </div>
-                        <div className="text-lg font-semibold text-foreground capitalize">
-                          {systemStatus.backend}
-                        </div>
-                      </div>
-
-                      <div className="border border-border rounded-lg p-4">
-                        <div className="flex items-center gap-2 mb-2">
-                          <SettingsIcon className="w-4 h-4 text-muted-foreground" />
-                          <span className="text-sm font-medium">Plugins</span>
-                        </div>
-                        <div className="text-lg font-semibold text-foreground">
-                          {systemStatus.active_plugins.length} Active
-                        </div>
-                      </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className="border border-border rounded-lg p-4">
+                    <div className="flex items-center gap-2 mb-2">
+                      <Server className="w-4 h-4 text-muted-foreground" />
+                      <span className="text-sm font-medium">Backend readiness</span>
                     </div>
-
-                    {systemStatus.active_plugins.length > 0 && (
-                      <div className="border border-border rounded-lg p-4">
-                        <h4 className="text-sm font-medium mb-3">Active Plugins</h4>
-                        <div className="flex flex-wrap gap-2">
-                          {systemStatus.active_plugins.map((plugin) => (
-                            <span
-                              key={plugin}
-                              className="px-2 py-1 bg-primary/10 text-primary text-xs rounded-md"
-                            >
-                              {plugin}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
+                    <div className={cn(
+                      "text-lg font-semibold",
+                      systemStatus?.status === "ready" ? "text-green-500" : "text-orange-500"
+                    )}>
+                      {systemStatus ? (systemStatus.status === "ready" ? "Ready" : systemStatus.status) : "Unavailable"}
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-2">
+                      {systemStatus
+                        ? `Image backend: ${systemStatus.backend}. Prompt service: ${systemStatus.ollama_available ? "online" : "unavailable"}.`
+                        : "The /api/status response has not loaded."}
+                    </p>
                   </div>
-                )}
+
+                  <div className="border border-border rounded-lg p-4">
+                    <div className="flex items-center gap-2 mb-2">
+                      <Database className="w-4 h-4 text-muted-foreground" />
+                      <span className="text-sm font-medium">Active runtime</span>
+                    </div>
+                    <div className="text-lg font-semibold text-foreground capitalize">
+                      {modelStatus?.resolved_backend ?? (modelStatusError ? "Unavailable" : "Loading…")}
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-2">
+                      {modelStatus
+                        ? `${modelStatus.configured_backend} configured → ${activeRuntimeModel?.name ?? "runtime model not identified"}.`
+                        : modelStatusError
+                          ? "The /api/models/status response is unavailable."
+                          : "Loading /api/models/status…"}
+                    </p>
+                  </div>
+
+                  <div className="border border-border rounded-lg p-4">
+                    <div className="flex items-center gap-2 mb-2">
+                      <Cpu className="w-4 h-4 text-muted-foreground" />
+                      <span className="text-sm font-medium">Device & resources</span>
+                    </div>
+                    <div className={cn(
+                      "text-lg font-semibold",
+                      modelStatus?.memory.cuda.available || systemStatus?.gpu_available
+                        ? "text-green-500"
+                        : "text-orange-500"
+                    )}>
+                      {modelStatus
+                        ? (modelStatus.memory.cuda.available
+                          ? modelStatus.memory.cuda.device ?? "CUDA available"
+                          : "CPU only")
+                        : systemStatus
+                          ? (systemStatus.gpu_available ? "GPU available" : "CPU only")
+                          : "Unavailable"}
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-2">
+                      {modelStatus
+                        ? (modelStatus.memory.cuda.available && modelStatus.memory.cuda.free_gb !== undefined
+                          ? `${modelStatus.memory.cuda.free_gb.toFixed(1)} / ${modelStatus.memory.cuda.total_gb?.toFixed(1) ?? "?"} GB VRAM free.`
+                          : `${modelStatus.memory.system.available_gb.toFixed(1)} / ${modelStatus.memory.system.total_gb.toFixed(1)} GB RAM free.`)
+                        : "Resource details are unavailable until the model status loads."}
+                    </p>
+                  </div>
+
+                  <div className="border border-border rounded-lg p-4">
+                    <div className="flex items-center gap-2 mb-2">
+                      <SettingsIcon className="w-4 h-4 text-muted-foreground" />
+                      <span className="text-sm font-medium">Plugins & guards</span>
+                    </div>
+                    <div className="text-lg font-semibold text-foreground">
+                      {pluginsError
+                        ? "Unavailable"
+                        : loadingPlugins
+                          ? "Loading…"
+                          : `${enabledPromptPlugins.length} prompt · ${enabledGuardPlugins.length} guard`}
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-2">
+                      {pluginsError
+                        ? "The /api/plugins response is unavailable."
+                        : loadingPlugins
+                          ? "Loading plugin state…"
+                          : `Prompt: ${enabledPromptPlugins.map((plugin) => plugin.name.replaceAll("_", " ")).join(", ") || "none"}. Guard: ${enabledGuardPlugins.map((plugin) => plugin.name.replaceAll("_", " ")).join(", ") || "none"}.`}
+                    </p>
+                  </div>
+                </div>
               </div>
             </motion.div>
           )}

--- a/web-ui/components/Settings.tsx
+++ b/web-ui/components/Settings.tsx
@@ -380,6 +380,8 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
   );
   const entropyLevel = generationConfig?.entropy_level ?? "strange";
   const selectedBackend = generationConfig?.image_backend ?? "auto";
+  const resolvedBackend =
+    modelStatus?.resolved_backend ?? generationConfig?.resolved_image_backend ?? selectedBackend;
   const availableLoras = generationConfig?.available_loras ?? [];
   const enabledLoras = generationConfig?.enabled_loras ?? [];
   const loraProbability = generationConfig?.lora_application_probability ?? 0;
@@ -392,7 +394,12 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
   const activeImageModelLabel =
     selectedBackend === "ollama"
       ? (activeImageModel ?? configuredImageModel) || "No Ollama image model"
-      : generationConfig?.image_model ?? selectedBackend;
+      : modelStatus?.models.find(
+          (model) => model.backend === resolvedBackend && model.status === "ready"
+        )?.name
+        ?? generationConfig?.active_image_model
+        ?? generationConfig?.image_model
+        ?? resolvedBackend;
   const selectedBackendLabel =
     IMAGE_BACKEND_OPTIONS.find((backend) => backend.id === selectedBackend)?.label ?? selectedBackend;
   const promptModelFallback = generationConfig?.prompt_model ?? configuredPromptModel;
@@ -570,6 +577,11 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                             Configured {configuredImageModel}; using {activeImageModel}.
                           </div>
                         )}
+                        {selectedBackend !== resolvedBackend && selectedBackend !== "ollama" && (
+                          <div className="mt-2 text-xs text-amber-700 dark:text-amber-300">
+                            Configured {selectedBackend}; using the {resolvedBackend} fallback until the preferred model is ready.
+                          </div>
+                        )}
                         <div className="mt-3 text-xs text-muted-foreground">
                           Use the backend choices below for local Diffusers, Qwen, Z-Image, or Ollama image rendering.
                         </div>
@@ -621,7 +633,8 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                     ) : (
                       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
                         {IMAGE_BACKEND_OPTIONS.map((backend) => {
-                          const isActive = selectedBackend === backend.id;
+                          const isConfigured = selectedBackend === backend.id;
+                          const isActive = resolvedBackend === backend.id;
                           return (
                             <button
                               key={backend.id}
@@ -634,16 +647,21 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                               }
                               className={cn(
                                 "rounded-lg border p-3 text-left transition-colors",
-                                isActive
+                                isConfigured || isActive
                                   ? "border-primary bg-primary/5"
                                   : "border-border hover:bg-muted/40"
                               )}
                             >
                               <div className="flex items-center justify-between gap-2">
                                 <span className="font-medium">{backend.label}</span>
-                                {isActive && (
+                                {isConfigured && (
                                   <span className="text-[11px] px-2 py-0.5 rounded-full bg-primary/15 text-primary">
-                                    Active
+                                    {isActive ? "Active" : "Configured"}
+                                  </span>
+                                )}
+                                {!isConfigured && isActive && (
+                                  <span className="text-[11px] px-2 py-0.5 rounded-full bg-green-500/15 text-green-600 dark:text-green-400">
+                                    Active fallback
                                   </span>
                                 )}
                               </div>
@@ -1339,18 +1357,27 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                   <div className="border border-border rounded-lg p-4">
                     <div className="flex items-center gap-2 mb-2">
                       <Database className="w-4 h-4 text-muted-foreground" />
-                      <span className="text-sm font-medium">Active runtime</span>
+                      <span className="text-sm font-medium">Active model & runtime</span>
                     </div>
                     <div className="text-lg font-semibold text-foreground capitalize">
-                      {modelStatus?.resolved_backend ?? (modelStatusError ? "Unavailable" : "Loading…")}
+                      {systemStatus?.active_model
+                        ?? modelStatus?.models.find((model) => model.backend === modelStatus.resolved_backend && model.status === "ready")?.name
+                        ?? (modelStatusError ? "Unavailable" : "Loading…")}
                     </div>
                     <p className="text-xs text-muted-foreground mt-2">
-                      {modelStatus
-                        ? `${modelStatus.configured_backend} configured → ${activeRuntimeModel?.name ?? "runtime model not identified"}.`
+                      {systemStatus
+                        ? `${systemStatus.active_model_id} · backend ${systemStatus.active_backend_label} · ${systemStatus.active_model_status}.`
+                        : modelStatus
+                          ? `${modelStatus.configured_backend} configured → ${activeRuntimeModel?.name ?? "runtime model not identified"}.`
                         : modelStatusError
                           ? "The /api/models/status response is unavailable."
                           : "Loading /api/models/status…"}
                     </p>
+                    {systemStatus?.fallback_reason && (
+                      <p className="text-xs text-amber-700 dark:text-amber-300 mt-2">
+                        {systemStatus.fallback_reason}
+                      </p>
+                    )}
                   </div>
 
                   <div className="border border-border rounded-lg p-4">

--- a/web-ui/components/Settings.tsx
+++ b/web-ui/components/Settings.tsx
@@ -43,6 +43,7 @@ interface SettingsProps {
 
 const IMAGE_BACKEND_OPTIONS = [
   { id: "auto", label: "Auto", description: "Use the best ready local backend." },
+  { id: "mageflow", label: "Mage-Flow", description: "Use Microsoft's public 4B research image model in its isolated local CUDA runtime." },
   { id: "zimage", label: "Z-Image", description: "Use the Z-Image stack and local LoRAs." },
   { id: "qwen", label: "Qwen-Image", description: "Use Qwen-Image for text-rich posters, signs, and bilingual typography." },
   { id: "ernie", label: "ERNIE-Image", description: "Use ERNIE-Image-Turbo for 8-step prompt-enhanced multilingual text rendering." },
@@ -351,6 +352,11 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
       case 'ready': return 'text-green-500';
       case 'downloading': return 'text-yellow-500';
       case 'partial': return 'text-orange-500';
+      case 'runtime_unavailable':
+      case 'incompatible_runtime':
+      case 'runtime_error':
+      case 'revision_mismatch':
+        return 'text-red-500';
       case 'not_downloaded': return 'text-gray-400';
       default: return 'text-gray-400';
     }
@@ -367,6 +373,11 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
       case 'ready': return <CheckCircle className="w-4 h-4 text-green-500" />;
       case 'downloading': return <Loader2 className="w-4 h-4 text-yellow-500 animate-spin" />;
       case 'partial': return <AlertCircle className="w-4 h-4 text-orange-500" />;
+      case 'runtime_unavailable':
+      case 'incompatible_runtime':
+      case 'runtime_error':
+      case 'revision_mismatch':
+        return <AlertCircle className="w-4 h-4 text-red-500" />;
       case 'not_downloaded': return <Download className="w-4 h-4 text-gray-400" />;
       default: return <AlertCircle className="w-4 h-4 text-gray-400" />;
     }
@@ -577,11 +588,13 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                             Configured {configuredImageModel}; using {activeImageModel}.
                           </div>
                         )}
-                        {selectedBackend !== resolvedBackend && selectedBackend !== "ollama" && (
+                        {selectedBackend !== "auto" &&
+                          selectedBackend !== resolvedBackend &&
+                          selectedBackend !== "ollama" && (
                           <div className="mt-2 text-xs text-amber-700 dark:text-amber-300">
                             Configured {selectedBackend}; using the {resolvedBackend} fallback until the preferred model is ready.
                           </div>
-                        )}
+                          )}
                         <div className="mt-3 text-xs text-muted-foreground">
                           Use the backend choices below for local Diffusers, Qwen, Z-Image, or Ollama image rendering.
                         </div>
@@ -654,16 +667,23 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                             >
                               <div className="flex items-center justify-between gap-2">
                                 <span className="font-medium">{backend.label}</span>
-                                {isConfigured && (
-                                  <span className="text-[11px] px-2 py-0.5 rounded-full bg-primary/15 text-primary">
-                                    {isActive ? "Active" : "Configured"}
-                                  </span>
-                                )}
-                                {!isConfigured && isActive && (
-                                  <span className="text-[11px] px-2 py-0.5 rounded-full bg-green-500/15 text-green-600 dark:text-green-400">
-                                    Active fallback
-                                  </span>
-                                )}
+                                <div className="flex items-center gap-1">
+                                  {backend.id === "mageflow" && (
+                                    <span className="text-[11px] px-2 py-0.5 rounded-full bg-violet-500/15 text-violet-600 dark:text-violet-300">
+                                      Featured
+                                    </span>
+                                  )}
+                                  {isConfigured && (
+                                    <span className="text-[11px] px-2 py-0.5 rounded-full bg-primary/15 text-primary">
+                                      {isActive ? "Active" : "Configured"}
+                                    </span>
+                                  )}
+                                  {!isConfigured && isActive && (
+                                    <span className="text-[11px] px-2 py-0.5 rounded-full bg-green-500/15 text-green-600 dark:text-green-400">
+                                      {selectedBackend === "auto" ? "Active" : "Active fallback"}
+                                    </span>
+                                  )}
+                                </div>
                               </div>
                               <p className="mt-2 text-xs text-muted-foreground">
                                 {backend.description}
@@ -686,6 +706,26 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                             No image-capable Ollama model is currently available.
                           </span>
                         )}
+                      </div>
+                    )}
+
+                    {selectedBackend === "mageflow" && (
+                      <div className="mt-4 grid gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm">
+                        <div className="font-medium text-foreground">Microsoft Mage-Flow research runtime</div>
+                        <div className="text-muted-foreground">
+                          Public MIT checkpoint, isolated from DreamGen&apos;s existing model stack.
+                          Microsoft describes the family as research-only and not intended for product/service deployment.
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {generationConfig?.mageflow_model ?? "microsoft/Mage-Flow"} ·{" "}
+                          {generationConfig?.mageflow_steps ?? 20} steps · CFG{" "}
+                          {generationConfig?.mageflow_cfg ?? 5}
+                        </div>
+                        <div className="break-all text-xs text-muted-foreground">
+                          Verified checkpoint:{" "}
+                          {generationConfig?.mageflow_revision ??
+                            "faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9"}
+                        </div>
                       </div>
                     )}
 
@@ -841,7 +881,14 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                           <div className="flex items-center gap-3">
                             {getModelStatusIcon(model)}
                             <div>
-                              <h4 className="font-medium">{model.name}</h4>
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h4 className="font-medium">{model.name}</h4>
+                                {model.backend === "mageflow" && (
+                                  <span className="rounded-full bg-violet-500/15 px-2 py-0.5 text-[11px] text-violet-600 dark:text-violet-300">
+                                    Featured RL checkpoint
+                                  </span>
+                                )}
+                              </div>
                               <div className="flex items-center gap-2 text-xs text-muted-foreground">
                                 <span className="capitalize">{model.type.replace('-', ' ')}</span>
                                 <span>•</span>
@@ -863,6 +910,39 @@ export default function Settings({ systemStatus, onRuntimeChange }: SettingsProp
                               {model.path && model.id === "local:zimage" && (
                                 <div className="text-xs text-muted-foreground mt-1 break-all">
                                   {model.path}
+                                </div>
+                              )}
+                              {model.reason && (
+                                <div className="mt-1 max-w-2xl text-xs text-muted-foreground">
+                                  {model.reason}
+                                </div>
+                              )}
+                              {model.runtime && (
+                                <div className="mt-1 text-xs text-muted-foreground">
+                                  Runtime: {model.runtime.loaded ? "loaded" : "not loaded"}
+                                  {model.runtime.attention ? ` · ${model.runtime.attention}` : ""}
+                                  {model.runtime.source_sha ? ` · ${model.runtime.source_sha.slice(0, 12)}` : ""}
+                                </div>
+                              )}
+                              {model.verified_revision && (
+                                <div className="mt-1 break-all text-xs text-muted-foreground">
+                                  Verified checkpoint: {model.verified_revision}
+                                </div>
+                              )}
+                              {(model.source_url || model.license || model.research_only) && (
+                                <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                  {model.source_url && (
+                                    <a
+                                      href={model.source_url}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                      className="text-primary hover:underline"
+                                    >
+                                      Official model
+                                    </a>
+                                  )}
+                                  {model.license && <span>{model.license}</span>}
+                                  {model.research_only && <span>Research-only guidance</span>}
                                 </div>
                               )}
                             </div>

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -98,6 +98,20 @@ export interface SystemStatus {
   active_plugins: string[];
   gpu_available: boolean;
   ollama_available: boolean;
+  configured_backend: string;
+  resolved_backend: string;
+  active_backend_label: string;
+  active_model: string;
+  active_model_id: string;
+  active_model_status: string;
+  preferred_backend: string;
+  preferred_model: string;
+  preferred_model_id: string;
+  preferred_model_status: string;
+  fallback_backend: string;
+  fallback_model: string;
+  fallback_model_id: string;
+  fallback_reason?: string | null;
 }
 
 export interface ModelInfo {
@@ -117,6 +131,19 @@ export interface ModelStatus {
   cache_dir: string;
   configured_backend: string;
   resolved_backend: string;
+  active_backend?: string;
+  active_backend_label?: string;
+  active_model?: string;
+  active_model_id?: string;
+  active_model_status?: string;
+  preferred_backend?: string;
+  preferred_model?: string;
+  preferred_model_id?: string;
+  preferred_model_status?: string;
+  fallback_backend?: string;
+  fallback_model?: string;
+  fallback_model_id?: string;
+  fallback_reason?: string | null;
   memory: {
     system: { total_gb: number; available_gb: number; percent_used: number };
     cuda: { available: boolean; device?: string; total_gb?: number; free_gb?: number; allocated_gb?: number; reserved_gb?: number };
@@ -187,6 +214,12 @@ export interface GenerationConfig {
   configured_prompt_model?: string;
   image_backend?: string;
   image_model?: string;
+  resolved_image_backend?: string;
+  active_image_model?: string;
+  active_image_model_id?: string;
+  preferred_image_model?: string;
+  preferred_image_model_status?: string;
+  fallback_reason?: string | null;
   ollama_image_model?: string;
   pipeline?: {
     prompt: {

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -86,6 +86,9 @@ export interface PluginInfo {
   enabled: boolean;
   description: string;
   order: number;
+  category?: 'entropy' | 'context' | 'style' | 'operational' | string;
+  kind?: 'prompt' | 'guard' | string;
+  phase?: string;
 }
 
 export interface SystemStatus {
@@ -199,6 +202,7 @@ export interface GenerationConfig {
   enabled_loras?: string[];
   available_loras?: string[];
   lora_application_probability?: number;
+  entropy_level?: 'calm' | 'strange' | 'wild';
   lora_dir?: string;
   zimage_model_path?: string;
   zimage_native_available?: boolean;

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -130,6 +130,8 @@ export interface HFTokenStatus {
 export interface EditRequest {
   prompt: string;
   strength?: number;
+  backend?: 'auto' | 'mock' | 'qwen';
+  source_path?: string;
 }
 
 export interface EditResponse {
@@ -137,10 +139,7 @@ export interface EditResponse {
   prompt: string;
   original_path: string;
   edited_path: string;
-  metadata: {
-    model: string;
-    strength: number;
-  };
+  metadata: Record<string, unknown>;
   created_at: string;
 }
 
@@ -231,6 +230,14 @@ export interface GenerationEventsResponse {
   limit: number;
 }
 
+export interface GenerationMetricsResponse {
+  events: number;
+  completed_generations: number;
+  phase_averages_ms: Record<string, Record<string, number>>;
+  otel_enabled: boolean;
+  jsonl_path: string;
+}
+
 export type GenerationJobStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 
 export interface GenerationJobRequest {
@@ -282,6 +289,7 @@ export interface CreateGenerationJobRequest {
   quality_flags?: string[];
   client_request_id?: string;
   metadata?: Record<string, unknown>;
+  config_overrides?: Record<string, unknown>;
 }
 
 export type PublicationState = 'draft' | 'published' | 'hidden' | 'featured' | 'rejected';
@@ -344,6 +352,7 @@ export interface GalleryCatalogFilters {
   model?: string;
   prompt_family?: string;
   quality_flag?: string;
+  search?: string;
 }
 
 const extractErrorMessage = async (response: Response, fallback: string) => {
@@ -491,6 +500,7 @@ export class ImageGenAPI {
     if (filters.model) params.set('model', filters.model);
     if (filters.prompt_family) params.set('prompt_family', filters.prompt_family);
     if (filters.quality_flag) params.set('quality_flag', filters.quality_flag);
+    if (filters.search) params.set('search', filters.search);
 
     try {
       const response = await fetch(`${this.baseUrl}/api/gallery/catalog?${params.toString()}`, {
@@ -670,6 +680,25 @@ export class ImageGenAPI {
     return response.json();
   }
 
+  async getGenerationMetrics(limit: number = 500): Promise<GenerationMetricsResponse> {
+    const response = await fetch(`${this.baseUrl}/api/generation/metrics?limit=${limit}`);
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get generation metrics'));
+    return response.json();
+  }
+
+  async bulkUpdatePublicationState(
+    imagePaths: string[],
+    state: PublicationState
+  ): Promise<{ updated: GalleryCatalogEntry[]; failures: Array<{ path: string; error: string }>; state: string }> {
+    const response = await fetch(`${this.baseUrl}/api/gallery/publication/bulk`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ image_paths: imagePaths, state }),
+    });
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to update publication states'));
+    return response.json();
+  }
+
   async setHFToken(token: string): Promise<{ message: string }> {
     const response = await fetch(`${this.baseUrl}/api/config/hf-token`, {
       method: 'POST',
@@ -695,12 +724,20 @@ export class ImageGenAPI {
     if (request.strength !== undefined) {
       formData.append('strength', request.strength.toString());
     }
+    if (request.backend) formData.append('backend', request.backend);
+    if (request.source_path) formData.append('source_path', request.source_path);
 
     const response = await fetch(`${this.baseUrl}/api/edit`, {
       method: 'POST',
       body: formData,
     });
     if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to edit image'));
+    return response.json();
+  }
+
+  async getEditJob(jobId: string): Promise<Record<string, unknown>> {
+    const response = await fetch(`${this.baseUrl}/api/edit/jobs/${encodeURIComponent(jobId)}`);
+    if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to get edit job'));
     return response.json();
   }
 

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -119,11 +119,38 @@ export interface ModelInfo {
   id: string;
   name: string;
   type: string;
-  status: 'not_downloaded' | 'not_configured' | 'configured' | 'downloading' | 'ready' | 'partial';
+  status:
+    | 'not_downloaded'
+    | 'not_configured'
+    | 'configured'
+    | 'downloading'
+    | 'ready'
+    | 'partial'
+    | 'runtime_unavailable'
+    | 'incompatible_runtime'
+    | 'runtime_error'
+    | 'revision_mismatch';
   size: number;
   incomplete_files: number;
   path?: string;
   downloadable?: boolean;
+  reason?: string;
+  source_url?: string;
+  implementation_url?: string;
+  license?: string;
+  research_only?: boolean;
+  verified_revision?: string;
+  runtime?: {
+    reachable?: boolean;
+    ready?: boolean;
+    loaded?: boolean;
+    status?: string;
+    reason?: string;
+    source_sha?: string;
+    model_revision?: string;
+    verified_model_revision?: string;
+    attention?: string;
+  };
 }
 
 export interface ModelStatus {
@@ -239,6 +266,11 @@ export interface GenerationConfig {
   lora_dir?: string;
   zimage_model_path?: string;
   zimage_native_available?: boolean;
+  mageflow_model?: string;
+  mageflow_revision?: string;
+  mageflow_url?: string;
+  mageflow_steps?: number;
+  mageflow_cfg?: number;
   qwen_image_model?: string;
   qwen_prompt_magic?: boolean;
   qwen_device_map?: string;
@@ -711,7 +743,11 @@ export class ImageGenAPI {
     return response.json();
   }
 
-  async unloadModels(): Promise<{ message: string; memory: ModelStatus['memory'] }> {
+  async unloadModels(): Promise<{
+    message: string;
+    memory: ModelStatus['memory'];
+    mageflow?: { status: string; unloaded: boolean; was_loaded?: boolean; reason?: string };
+  }> {
     const response = await fetch(`${this.baseUrl}/api/models/unload`, { method: 'POST' });
     if (!response.ok) throw new Error(await extractErrorMessage(response, 'Failed to unload models'));
     return response.json();

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -12,7 +12,7 @@
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.540.0",
-        "next": "15.4.7",
+        "next": "15.5.21",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "tailwind-merge": "^3.3.1",
@@ -767,9 +767,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.7.tgz",
-      "integrity": "sha512-PrBIpO8oljZGTOe9HH0miix1w5MUiGJ/q83Jge03mHEE0E3pyqzAy2+l5G6aJDbXoobmxPJTVhbCuwlLtjSHwg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.21.tgz",
+      "integrity": "sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -783,9 +783,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.7.tgz",
-      "integrity": "sha512-2Dkb+VUTp9kHHkSqtws4fDl2Oxms29HcZBwFIda1X7Ztudzy7M6XF9HDS2dq85TmdN47VpuhjE+i6wgnIboVzQ==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.21.tgz",
+      "integrity": "sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ==",
       "cpu": [
         "arm64"
       ],
@@ -799,9 +799,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.7.tgz",
-      "integrity": "sha512-qaMnEozKdWezlmh1OGDVFueFv2z9lWTcLvt7e39QA3YOvZHNpN2rLs/IQLwZaUiw2jSvxW07LxMCWtOqsWFNQg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.21.tgz",
+      "integrity": "sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww==",
       "cpu": [
         "x64"
       ],
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.7.tgz",
-      "integrity": "sha512-ny7lODPE7a15Qms8LZiN9wjNWIeI+iAZOFDOnv2pcHStncUr7cr9lD5XF81mdhrBXLUP9yT9RzlmSWKIazWoDw==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.21.tgz",
+      "integrity": "sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A==",
       "cpu": [
         "arm64"
       ],
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.7.tgz",
-      "integrity": "sha512-4SaCjlFR/2hGJqZLLWycccy1t+wBrE/vyJWnYaZJhUVHccpGLG5q0C+Xkw4iRzUIkE+/dr90MJRUym3s1+vO8A==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.21.tgz",
+      "integrity": "sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw==",
       "cpu": [
         "arm64"
       ],
@@ -847,9 +847,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.7.tgz",
-      "integrity": "sha512-2uNXjxvONyRidg00VwvlTYDwC9EgCGNzPAPYbttIATZRxmOZ3hllk/YYESzHZb65eyZfBR5g9xgCZjRAl9YYGg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.21.tgz",
+      "integrity": "sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg==",
       "cpu": [
         "x64"
       ],
@@ -863,9 +863,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.7.tgz",
-      "integrity": "sha512-ceNbPjsFgLscYNGKSu4I6LYaadq2B8tcK116nVuInpHHdAWLWSwVK6CHNvCi0wVS9+TTArIFKJGsEyVD1H+4Kg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.21.tgz",
+      "integrity": "sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ==",
       "cpu": [
         "x64"
       ],
@@ -879,9 +879,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.7.tgz",
-      "integrity": "sha512-pZyxmY1iHlZJ04LUL7Css8bNvsYAMYOY9JRwFA3HZgpaNKsJSowD09Vg2R9734GxAcLJc2KDQHSCR91uD6/AAw==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.21.tgz",
+      "integrity": "sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA==",
       "cpu": [
         "arm64"
       ],
@@ -895,9 +895,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.7.tgz",
-      "integrity": "sha512-HjuwPJ7BeRzgl3KrjKqD2iDng0eQIpIReyhpF5r4yeAHFwWRuAhfW92rWv/r3qeQHEwHsLRzFDvMqRjyM5DI6A==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.21.tgz",
+      "integrity": "sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ==",
       "cpu": [
         "x64"
       ],
@@ -4495,12 +4495,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.7.tgz",
-      "integrity": "sha512-OcqRugwF7n7mC8OSYjvsZhhG1AYSvulor1EIUsIkbbEbf1qoE5EbH36Swj8WhF4cHqmDgkiam3z1c1W0J1Wifg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.21.tgz",
+      "integrity": "sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.7",
+        "@next/env": "15.5.21",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -4513,14 +4513,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.4.7",
-        "@next/swc-darwin-x64": "15.4.7",
-        "@next/swc-linux-arm64-gnu": "15.4.7",
-        "@next/swc-linux-arm64-musl": "15.4.7",
-        "@next/swc-linux-x64-gnu": "15.4.7",
-        "@next/swc-linux-x64-musl": "15.4.7",
-        "@next/swc-win32-arm64-msvc": "15.4.7",
-        "@next/swc-win32-x64-msvc": "15.4.7",
+        "@next/swc-darwin-arm64": "15.5.21",
+        "@next/swc-darwin-x64": "15.5.21",
+        "@next/swc-linux-arm64-gnu": "15.5.21",
+        "@next/swc-linux-arm64-musl": "15.5.21",
+        "@next/swc-linux-x64-gnu": "15.5.21",
+        "@next/swc-linux-x64-musl": "15.5.21",
+        "@next/swc-win32-arm64-msvc": "15.5.21",
+        "@next/swc-win32-x64-msvc": "15.5.21",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -13,7 +13,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.540.0",
-    "next": "15.4.7",
+    "next": "15.5.21",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "tailwind-merge": "^3.3.1",


### PR DESCRIPTION
## Summary

Release candidate for DreamGen's verified Microsoft Mage-Flow integration and approval-gated public gallery path.

- pins the official Mage implementation and RL-aligned `microsoft/Mage-Flow` checkpoint
- runs Mage-Flow in an isolated CUDA sidecar with truthful readiness and revision provenance
- prefers Mage-Flow in `auto` only when the exact runtime/checkpoint is ready
- preserves operator-controlled local generation and draft-by-default publication
- publishes the public Cloudflare gallery from an exact approval-filtered release manifest instead of raw bucket contents
- versions image/caption URLs for cache invalidation and links each release to its previous immutable manifest for rollback

## Verified upstream

- Implementation: https://github.com/microsoft/Mage/tree/6cefeb40e4c8ecc404ecb73732a91878939f27e0
- Checkpoint: https://huggingface.co/microsoft/Mage-Flow/tree/faca09c18c1c19458e7fbc3f7bce6f7a7d4d01a9
- Paper: https://arxiv.org/abs/2607.19064
- License: MIT
- Intended-use guidance: Microsoft describes the family as research-only and not intended for product/service deployment.

DreamGen is independently operated as a local research and artistic hobby project about machine "dreaming," not a hosted production image service. The operator has accepted Mage's published research-only guidance for that use. This integration does not imply Microsoft sponsorship, endorsement, or affiliation.

## Cloudflare gallery release contract

`dreamgen publish --execute` now:

1. reads `output/.gallery_catalog.json`
2. includes only `published` or `featured`, publishable, non-blocked assets
3. copies only those files without deleting source or remote image objects
4. writes `_dreamgen/releases/<release-id>.json`
5. moves `_dreamgen/current.json` last

The Pages API follows the manifest order, exposes content-versioned URLs, and falls back to full filename timestamps only before the first manifest publish. The manifest retains catalog SHA, per-asset SHA/version, approval timestamp, and previous-release pointer.

Real-catalog release evidence:

- release ID: `20260731-96377d84c54dbd25`
- 336 approved images
- 97 draft/blocked entries skipped
- leading key: `2026/week_29/image_20260714_020519_474a9bca.png`
- no deletions
- transport: Wrangler OAuth fallback after the configured rclone key returned 403

## Validation

- `uv run pytest tests/ --cov=src --cov-report=xml --cov-report=term`: 144 passed, 1 skipped, 61% coverage
- affected release/Mage tests: 20 passed
- Black, isort, pylint errors-only, and mypy: passed
- web UI lint/build: passed (two existing `<img>` warnings)
- host-image/gallery worker: TypeScript passed; 9 tests passed; npm audit found 0 vulnerabilities
- PR pre-commit suite: passed
- fresh local Mage-Flow evidence: 512×512, 20 steps, CFG 5.0, pinned checkpoint revision, ~4.0 seconds on the configured workstation
- experiment provenance records resolved Mage-Flow dimensions/steps/guidance and model/source revisions instead of the originally requested fallback parameters
- live gallery API/browser verification confirmed the approved release at item 1 of 336 with immutable content-versioned URLs

## Release decision

The previous responsible-use gate is resolved. DreamGen's operator explicitly accepts Microsoft's research-only guidance for this independent local research/artistic hobby project. The PR is ready for normal CI-gated merge and Semantic Release; no unapproved creative asset is included or published by the merge.